### PR TITLE
Let the human choose a creature type from a dropdown

### DIFF
--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -8,6 +8,14 @@ Security as H3s, each of them a bullet list.
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-08-16
+
+### Added
+
+- Choose a creature type: when a card asks you for one (a tribal land entering, a
+  lord naming a type), pick it from a dropdown pre-selected with the AI's
+  suggestion, with the same "AI decides" escape as the other manual decisions.
+
 ## [0.1.1] - 2026-08-16
 
 ### Added

--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -13,8 +13,9 @@ Security as H3s, each of them a bullet list.
 ### Added
 
 - Choose a creature type: when a card asks you for one (a tribal land entering, a
-  lord naming a type), pick it from a dropdown pre-selected with the AI's
-  suggestion, with the same "AI decides" escape as the other manual decisions.
+  lord naming a type), pick it from a compact searchable dropdown — type to filter
+  the 300+ types live — pre-selected with the AI's suggestion, with the same
+  "AI decides" escape as the other manual decisions.
 
 ## [0.1.1] - 2026-08-16
 

--- a/domainbook/domains/simulation/features/step-through-a-turn.md
+++ b/domainbook/domains/simulation/features/step-through-a-turn.md
@@ -52,6 +52,12 @@ Example: Paying with a specific source
   When the engine asks how to pay
   Then you choose which land or color to tap
   And unspent mana is held as a reserve shown beside your life
+
+Example: Naming a creature type
+  Given a card you play asks you to name a creature type
+  When the engine asks for the type
+  Then you pick one from the valid types, pre-selected with the AI's suggestion
+  And you may instead let the AI choose for you
 ```
 
 ## Rule: Pass turn advances your own turn and stops when an opponent acts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",

--- a/src/App.css
+++ b/src/App.css
@@ -802,3 +802,43 @@ th {
   font-weight: 700;
   margin-top: 0.35rem;
 }
+
+/* ── Searchable select (combobox) ──────────────────────────────── */
+.combobox {
+  position: relative;
+  width: 100%;
+  max-width: 280px;
+}
+.combobox__list {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  z-index: 20;
+  margin: 0;
+  padding: 4px;
+  list-style: none;
+  max-height: 240px;
+  overflow-y: auto;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.45);
+}
+.combobox__option {
+  padding: 0.4rem 0.6rem;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.combobox__option--active {
+  background: color-mix(in srgb, var(--accent) 18%, var(--panel-2));
+}
+.combobox__empty {
+  padding: 0.4rem 0.6rem;
+  color: var(--muted);
+  font-size: 0.85rem;
+}

--- a/src/components/SearchableSelect.tsx
+++ b/src/components/SearchableSelect.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+
+interface SearchableSelectProps {
+  options: string[];
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  emptyLabel?: string;
+  id?: string;
+}
+
+/** A compact combobox: shows the selected value, filters options as you type. */
+export function SearchableSelect({
+  options,
+  value,
+  onChange,
+  placeholder,
+  emptyLabel,
+  id,
+}: SearchableSelectProps) {
+  const listId = useId();
+  const rootRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [active, setActive] = useState(0);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return q ? options.filter((o) => o.toLowerCase().includes(q)) : options;
+  }, [options, query]);
+
+  useEffect(() => {
+    if (!open) return;
+    function onDown(e: MouseEvent) {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+        setQuery("");
+      }
+    }
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const el = listRef.current?.children[active] as HTMLElement | undefined;
+    el?.scrollIntoView({ block: "nearest" });
+  }, [active, open]);
+
+  function openList() {
+    setOpen(true);
+    setQuery("");
+    setActive(Math.max(0, options.indexOf(value)));
+  }
+
+  function select(option: string) {
+    onChange(option);
+    setOpen(false);
+    setQuery("");
+  }
+
+  function onKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (!open && (e.key === "ArrowDown" || e.key === "Enter")) {
+      openList();
+      e.preventDefault();
+      return;
+    }
+    if (e.key === "ArrowDown") {
+      setActive((a) => Math.min(a + 1, filtered.length - 1));
+      e.preventDefault();
+    } else if (e.key === "ArrowUp") {
+      setActive((a) => Math.max(a - 1, 0));
+      e.preventDefault();
+    } else if (e.key === "Enter") {
+      if (filtered[active]) select(filtered[active]);
+      e.preventDefault();
+    } else if (e.key === "Escape") {
+      setOpen(false);
+      setQuery("");
+    }
+  }
+
+  return (
+    <div className="combobox" ref={rootRef}>
+      <input
+        id={id}
+        className="input"
+        type="text"
+        role="combobox"
+        aria-expanded={open}
+        aria-controls={listId}
+        autoComplete="off"
+        placeholder={placeholder}
+        value={open ? query : value}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setOpen(true);
+          setActive(0);
+        }}
+        onFocus={openList}
+        onKeyDown={onKeyDown}
+      />
+      {open && (
+        <ul className="combobox__list" id={listId} role="listbox" ref={listRef}>
+          {filtered.length === 0 ? (
+            <li className="combobox__empty">{emptyLabel}</li>
+          ) : (
+            filtered.map((opt, i) => (
+              <li
+                key={opt}
+                role="option"
+                aria-selected={opt === value}
+                className={`combobox__option ${i === active ? "combobox__option--active" : ""}`}
+                onMouseEnter={() => setActive(i)}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  select(opt);
+                }}
+              >
+                {opt}
+              </li>
+            ))
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/engine/EngineClient.ts
+++ b/src/engine/EngineClient.ts
@@ -91,6 +91,14 @@ export class EngineClient {
     return this.req("humanAction", { actor, action });
   }
 
+  /** The action the AI would take for `player` right now, without applying it. */
+  aiProposal(
+    difficulty: AiDifficulty,
+    player: number,
+  ): Promise<{ action: any }> {
+    return this.req("aiProposal", { difficulty, player });
+  }
+
   terminate(): void {
     this.worker.terminate();
     this.pending.clear();

--- a/src/engine/engine.worker.ts
+++ b/src/engine/engine.worker.ts
@@ -77,6 +77,11 @@ async function handle(cmd: string, args: any): Promise<any> {
         state: wantState ? get_game_state() : null,
       };
     }
+    case "aiProposal": {
+      const { difficulty, player } = args;
+      const proposal = get_ai_action_proposal(difficulty, player ?? 0);
+      return { action: proposal?.action ?? null };
+    }
     case "legalActions": {
       return get_legal_actions_js();
     }

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -186,6 +186,18 @@ export const messages = {
   "mana.color.Green": { pt: "Verde", en: "Green" },
   "mana.color.Colorless": { pt: "Incolor", en: "Colorless" },
 
+  "creatureType.title": {
+    pt: "Escolher tipo de criatura",
+    en: "Choose a creature type",
+  },
+  "creatureType.source": {
+    pt: "{name} pede um tipo de criatura.",
+    en: "{name} asks for a creature type.",
+  },
+  "creatureType.aiHint": { pt: "Sugestão da IA: {choice}", en: "AI suggestion: {choice}" },
+  "creatureType.confirm": { pt: "Confirmar", en: "Confirm" },
+  "creatureType.letAi": { pt: "IA decide", en: "Let the AI decide" },
+
   "report.title": { pt: "Resultado da série", en: "Series result" },
   "report.newSetup": { pt: "Nova configuração", en: "New setup" },
   "report.winRateDeck": { pt: "Win rate (seu deck)", en: "Win rate (your deck)" },

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -195,8 +195,11 @@ export const messages = {
     en: "{name} asks for a creature type.",
   },
   "creatureType.aiHint": { pt: "Sugestão da IA: {choice}", en: "AI suggestion: {choice}" },
+  "creatureType.search": { pt: "Buscar tipo de criatura…", en: "Search creature type…" },
   "creatureType.confirm": { pt: "Confirmar", en: "Confirm" },
   "creatureType.letAi": { pt: "IA decide", en: "Let the AI decide" },
+
+  "select.noResults": { pt: "Nenhum resultado", en: "No matches" },
 
   "report.title": { pt: "Resultado da série", en: "Series result" },
   "report.newSetup": { pt: "Nova configuração", en: "New setup" },

--- a/src/match/RunView.tsx
+++ b/src/match/RunView.tsx
@@ -44,6 +44,7 @@ import { toBoardView, type BoardView, type SeatMeta } from "../board/boardView";
 import { abilitiesBySource } from "../sim/decisions/abilities";
 import { aggregate } from "../analysis/matchStats";
 import { fetchCardsCached } from "../lib/scryfallCache";
+import { SearchableSelect } from "../components/SearchableSelect";
 import { useI18n } from "../i18n/I18nContext";
 import { phaseLabel, type Lang } from "../i18n/messages";
 
@@ -1000,17 +1001,13 @@ export function RunView({
                 </p>
               )}
               <div className="import__row">
-                <select
-                  className="input"
+                <SearchableSelect
+                  options={creatureTypeTurn.prompt.options}
                   value={creatureTypePick}
-                  onChange={(e) => setCreatureTypePick(e.target.value)}
-                >
-                  {creatureTypeTurn.prompt.options.map((ct) => (
-                    <option key={ct} value={ct}>
-                      {ct}
-                    </option>
-                  ))}
-                </select>
+                  onChange={setCreatureTypePick}
+                  placeholder={t("creatureType.search")}
+                  emptyLabel={t("select.noResults")}
+                />
               </div>
               {creatureTypeTurn.prompt.aiChoice && (
                 <p className="hint">

--- a/src/match/RunView.tsx
+++ b/src/match/RunView.tsx
@@ -36,6 +36,10 @@ import {
   tapManaSourceAction,
   type ManaPrompt,
 } from "../sim/decisions/mana";
+import {
+  chooseOptionAction,
+  type CreatureTypePrompt,
+} from "../sim/decisions/creatureType";
 import { toBoardView, type BoardView, type SeatMeta } from "../board/boardView";
 import { abilitiesBySource } from "../sim/decisions/abilities";
 import { aggregate } from "../analysis/matchStats";
@@ -122,6 +126,11 @@ interface ManaTurn {
   resolve: (choice: HumanChoice) => void;
 }
 
+interface CreatureTypeTurn {
+  prompt: CreatureTypePrompt & { aiChoice: string | null };
+  resolve: (choice: HumanChoice) => void;
+}
+
 /** Runs a configured series of matches and renders the live board + results. */
 export function RunView({
   config,
@@ -155,6 +164,9 @@ export function RunView({
   const [blockAssign, setBlockAssign] = useState<Map<number, number>>(new Map());
   const [selectedBlocker, setSelectedBlocker] = useState<number | null>(null);
   const [manaTurn, setManaTurn] = useState<ManaTurn | null>(null);
+  const [creatureTypeTurn, setCreatureTypeTurn] =
+    useState<CreatureTypeTurn | null>(null);
+  const [creatureTypePick, setCreatureTypePick] = useState("");
   const [passingTurn, setPassingTurn] = useState(false);
   const runnerRef = useRef<MatchRunner | null>(null);
 
@@ -293,6 +305,21 @@ export function RunView({
                   },
                 });
               }),
+            requestHumanCreatureType: (_env, prompt) =>
+              new Promise<HumanChoice>((resolve) => {
+                if (cancelled) {
+                  resolve({ ai: true });
+                  return;
+                }
+                setCreatureTypePick(prompt.aiChoice ?? prompt.options[0] ?? "");
+                setCreatureTypeTurn({
+                  prompt,
+                  resolve: (choice) => {
+                    setCreatureTypeTurn(null);
+                    resolve(choice);
+                  },
+                });
+              }),
           },
         );
         runnerRef.current = runner;
@@ -417,10 +444,10 @@ export function RunView({
 
   // Any other decision that needs the human pauses the pass-turn flow.
   useEffect(() => {
-    if (passingTurn && (targeting || manaTurn || blockingTurn)) {
+    if (passingTurn && (targeting || manaTurn || blockingTurn || creatureTypeTurn)) {
       setPassingTurn(false);
     }
-  }, [passingTurn, targeting, manaTurn, blockingTurn]);
+  }, [passingTurn, targeting, manaTurn, blockingTurn, creatureTypeTurn]);
 
   // Map draggable hand cards to their play actions for the current window.
   const play: PlayInteraction | undefined = useMemo(() => {
@@ -955,6 +982,60 @@ export function RunView({
                   onClick={() => manaTurn.resolve({ ai: true })}
                 >
                   {t("mana.letAi")}
+                </button>
+              </div>
+            </>
+          )}
+
+          {creatureTypeTurn && (
+            <>
+              <div className="control-title">
+                <strong>{t("creatureType.title")}</strong>
+              </div>
+              {creatureTypeTurn.prompt.sourceName && (
+                <p className="hint">
+                  {t("creatureType.source", {
+                    name: creatureTypeTurn.prompt.sourceName,
+                  })}
+                </p>
+              )}
+              <div className="import__row">
+                <select
+                  className="input"
+                  value={creatureTypePick}
+                  onChange={(e) => setCreatureTypePick(e.target.value)}
+                >
+                  {creatureTypeTurn.prompt.options.map((ct) => (
+                    <option key={ct} value={ct}>
+                      {ct}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              {creatureTypeTurn.prompt.aiChoice && (
+                <p className="hint">
+                  {t("creatureType.aiHint", {
+                    choice: creatureTypeTurn.prompt.aiChoice,
+                  })}
+                </p>
+              )}
+              <div className="import__row">
+                <button
+                  className="btn"
+                  disabled={!creatureTypePick}
+                  onClick={() =>
+                    creatureTypeTurn.resolve({
+                      action: chooseOptionAction(creatureTypePick),
+                    })
+                  }
+                >
+                  {t("creatureType.confirm")}
+                </button>
+                <button
+                  className="btn btn--ghost"
+                  onClick={() => creatureTypeTurn.resolve({ ai: true })}
+                >
+                  {t("creatureType.letAi")}
                 </button>
               </div>
             </>

--- a/src/sim/decisions/creatureType.test.ts
+++ b/src/sim/decisions/creatureType.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { parseCreatureTypePrompt, chooseOptionAction } from "./creatureType";
+import type { WaitingFor } from "../../engine/types";
+
+// Real NamedChoice (CreatureType) captured from the phase-rs WASM build (trimmed).
+const REAL_CREATURE_TYPE: WaitingFor = {
+  type: "NamedChoice",
+  data: {
+    choice_type: "CreatureType",
+    options: ["Advisor", "Aetherborn", "Elf", "Goblin", "Zombie"],
+    player: 1,
+    source: {
+      prompt: { display_name: "Secluded Courtyard" },
+    },
+  },
+};
+
+// Real NamedChoice used for a color choice — same waiting_for, different choice_type.
+const REAL_COLOR: WaitingFor = {
+  type: "NamedChoice",
+  data: {
+    choice_type: { Color: { excluded: ["Red"] } },
+    options: ["White", "Blue", "Black", "Green"],
+    player: 1,
+    source: { prompt: { display_name: "Thriving Bluff" } },
+  },
+};
+
+describe("parseCreatureTypePrompt", () => {
+  it("parses a creature-type NamedChoice into its options and source", () => {
+    const p = parseCreatureTypePrompt(REAL_CREATURE_TYPE)!;
+    expect(p).not.toBeNull();
+    expect(p.player).toBe(1);
+    expect(p.sourceName).toBe("Secluded Courtyard");
+    expect(p.options).toContain("Elf");
+    expect(p.options.length).toBe(5);
+  });
+
+  it("also matches a constrained (object) CreatureType choice_type", () => {
+    const wf: WaitingFor = {
+      type: "NamedChoice",
+      data: {
+        choice_type: { CreatureType: { excluded: ["Wall"] } },
+        options: ["Elf", "Goblin"],
+        player: 0,
+      },
+    };
+    expect(parseCreatureTypePrompt(wf)?.options).toEqual(["Elf", "Goblin"]);
+  });
+
+  it("ignores color and other NamedChoice kinds", () => {
+    expect(parseCreatureTypePrompt(REAL_COLOR)).toBeNull();
+  });
+
+  it("returns null for unrelated or empty waiting_for", () => {
+    expect(parseCreatureTypePrompt(undefined)).toBeNull();
+    expect(parseCreatureTypePrompt({ type: "Priority", data: {} })).toBeNull();
+    expect(
+      parseCreatureTypePrompt({
+        type: "NamedChoice",
+        data: { choice_type: "CreatureType", options: [], player: 0 },
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("chooseOptionAction", () => {
+  it("builds the ChooseOption action the engine expects", () => {
+    expect(chooseOptionAction("Elf")).toEqual({
+      type: "ChooseOption",
+      data: { choice: "Elf" },
+    });
+  });
+});

--- a/src/sim/decisions/creatureType.ts
+++ b/src/sim/decisions/creatureType.ts
@@ -1,0 +1,49 @@
+// "Choose a creature type" (Cavern of Souls, Metallic Mimic, Unclaimed Territory…)
+// arrives as a generic NamedChoice whose choice_type marks it a CreatureType — the
+// same waiting_for also carries Color and other named choices, which stay AI-driven.
+// data.options is the engine-filtered list of valid types; data.source names the
+// permanent asking. Submit the pick as a ChooseOption action, echoing its string.
+
+import type { WaitingFor } from "../../engine/types";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export interface CreatureTypePrompt {
+  player: number;
+  options: string[];
+  /** The permanent asking for the choice, for the prompt (may be empty). */
+  sourceName: string;
+}
+
+function isCreatureTypeChoice(choiceType: any): boolean {
+  return (
+    choiceType === "CreatureType" ||
+    (choiceType && typeof choiceType === "object" && "CreatureType" in choiceType)
+  );
+}
+
+/** Read a "choose a creature type" decision aimed at the human, or null. */
+export function parseCreatureTypePrompt(
+  wf: WaitingFor | undefined,
+): CreatureTypePrompt | null {
+  if (!wf || wf.type !== "NamedChoice") return null;
+  const d: any = wf.data;
+  if (!isCreatureTypeChoice(d?.choice_type)) return null;
+  const options: string[] = Array.isArray(d?.options)
+    ? d.options.filter((o: unknown): o is string => typeof o === "string")
+    : [];
+  if (options.length === 0) return null;
+  return {
+    player: d?.player ?? 0,
+    options,
+    sourceName: d?.source?.prompt?.display_name ?? "",
+  };
+}
+
+/** Submit a named choice (creature type) back to the engine. */
+export function chooseOptionAction(choice: string): {
+  type: string;
+  data: { choice: string };
+} {
+  return { type: "ChooseOption", data: { choice } };
+}

--- a/src/sim/driver.ts
+++ b/src/sim/driver.ts
@@ -15,6 +15,10 @@ import {
   type BlockersPrompt,
 } from "./decisions/blockers";
 import { parseManaPrompt, type ManaPrompt } from "./decisions/mana";
+import {
+  parseCreatureTypePrompt,
+  type CreatureTypePrompt,
+} from "./decisions/creatureType";
 
 export interface MatchResult {
   matchIndex: number;
@@ -176,6 +180,11 @@ export interface DriverCallbacks {
   requestHumanMana?: (
     env: GameStateEnvelope,
     prompt: ManaPrompt,
+  ) => Promise<HumanChoice>;
+  /** Called when the human must choose a creature type; `aiChoice` is the AI's pick. */
+  requestHumanCreatureType?: (
+    env: GameStateEnvelope,
+    prompt: CreatureTypePrompt & { aiChoice: string | null },
   ) => Promise<HumanChoice>;
 }
 
@@ -371,6 +380,10 @@ export class MatchRunner {
           : null;
       const humanMana =
         humanNonPriority && cb.requestHumanMana ? parseManaPrompt(wf) : null;
+      const humanCreatureType =
+        humanNonPriority && cb.requestHumanCreatureType
+          ? parseCreatureTypePrompt(wf)
+          : null;
 
       // Run the human's choice: play their action, or hand this decision to the AI.
       const applyChoice = async (choice: HumanChoice): Promise<void> => {
@@ -409,6 +422,18 @@ export class MatchRunner {
         await applyChoice(choice);
       } else if (humanMana) {
         const choice = await cb.requestHumanMana!(env, humanMana);
+        if (this.aborted) {
+          stopped = true;
+          break;
+        }
+        await applyChoice(choice);
+      } else if (humanCreatureType) {
+        const hint = await engine.aiProposal(opts.difficulty, humanSeat);
+        const suggested = hint?.action?.data?.choice;
+        const choice = await cb.requestHumanCreatureType!(env, {
+          ...humanCreatureType,
+          aiChoice: typeof suggested === "string" ? suggested : null,
+        });
         if (this.aborted) {
           stopped = true;
           break;


### PR DESCRIPTION
## What

When a card asks for a **creature type** (a tribal land entering, a lord naming a type), manual play now lets the human pick it from a dropdown instead of silently letting the AI decide — closing the last "decided for you" gap alongside the existing target / mana / attacker / blocker decisions.

- The dropdown is **pre-selected with the AI's own suggestion**, peeked via a new `aiProposal` engine command that mints a proposal *without* applying it.
- An **"AI decides"** button hands the choice back, matching every other manual decision.
- Only fires on the human's own `CreatureType` `NamedChoice`; the co-located `Color` choice stays AI-driven, as before.

## How

- `src/sim/decisions/creatureType.ts` — parses the `CreatureType` `NamedChoice` (both the unconstrained string form and the constrained object form) into a typed prompt, with a real captured fixture in `creatureType.test.ts` (5 tests).
- `src/engine/engine.worker.ts` + `EngineClient.ts` — new `aiProposal(difficulty, player)` command peeks the AI's action without submitting it.
- `src/sim/driver.ts` — new `requestHumanCreatureType` callback, routed in `playLoop` next to the other human decisions.
- `src/match/RunView.tsx` — dropdown control panel (pre-selected hint + confirm + "AI decides"), folded into the pass-turn pause guard.
- `src/i18n/messages.ts` — pt/en strings.

## Verification

- `npm run typecheck` · `npm run lint` · `npm test` (61 passed, incl. 5 new) · `npm run build` — all green.
- The novel engine mechanism was verified live in watch mode: peeked `get_ai_action_proposal` then submitted a human `ChooseOption` for a real `CreatureType` prompt (Secluded Courtyard) and confirmed the game advanced past it.
- `domainbook check --range main..HEAD` — 2 domains checked, nothing stale (changelog `[0.1.2]` + `step-through-a-turn` feature example).

🤖 Generated with [Claude Code](https://claude.com/claude-code)