### PR TITLE
Add a stack & game-log sidebar

### DIFF
--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -8,6 +8,19 @@ Security as H3s, each of them a bullet list.
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-08-16
+
+### Added
+
+- Stack & game-log sidebar: a right-hand panel showing the current stack (top
+  first) and a running log of the game's events, read from the engine's own log
+  stream. Each log line names its cards and player, colours by outcome, groups
+  under turn headings, and expands to show the referenced card. A "Detailed"
+  toggle reveals the low-level lines (priority passes, phase markers) hidden by
+  the default curated view. The panel is docked open on desktop and a collapsible
+  overlay on mobile, and remembers its state. Opponents' hidden-information lines
+  are withheld unless hands are revealed.
+
 ## [0.1.2] - 2026-08-16
 
 ### Added

--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,22 +12,13 @@ Security as H3s, each of them a bullet list.
 
 ### Added
 
-- Stack & game-log sidebar: a right-hand drawer showing the current stack (top
-  first) and a running log of the game's events, read from the engine's own log
-  stream. Each log line names its cards and player, colours by outcome, groups
-  under turn headings, and expands to show the referenced card. A "Detailed"
-  toggle reveals the low-level lines the curated default hides — priority passes,
-  phase markers, tapping and untapping, mana added and spent, and card draws. The
-  drawer is glued to the right edge and slides open and closed from an arrow tab;
-  it reserves board space on desktop and covers the full screen on mobile, and
-  remembers its state. Opponents' hidden-information lines are withheld unless
-  hands are revealed.
+- Stack & game-log sidebar: a collapsible drawer showing the current stack and a
+  running, engine-sourced log of the game's events (`follow-the-game`).
 
 ### Changed
 
-- Every UI icon is now drawn from the lucide-react set instead of emoji, so they
-  render consistently across platforms: the board's mana pips, zone counts, life
-  and drop-zone slots, the language switcher, and each log-category icon.
+- Every UI icon is now drawn from lucide-react instead of emoji, for consistent
+  rendering across platforms (`board/ADR-0001`).
 
 ## [0.1.2] - 2026-08-16
 

--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,14 +12,22 @@ Security as H3s, each of them a bullet list.
 
 ### Added
 
-- Stack & game-log sidebar: a right-hand panel showing the current stack (top
+- Stack & game-log sidebar: a right-hand drawer showing the current stack (top
   first) and a running log of the game's events, read from the engine's own log
   stream. Each log line names its cards and player, colours by outcome, groups
   under turn headings, and expands to show the referenced card. A "Detailed"
-  toggle reveals the low-level lines (priority passes, phase markers) hidden by
-  the default curated view. The panel is docked open on desktop and a collapsible
-  overlay on mobile, and remembers its state. Opponents' hidden-information lines
-  are withheld unless hands are revealed.
+  toggle reveals the low-level lines the curated default hides — priority passes,
+  phase markers, tapping and untapping, mana added and spent, and card draws. The
+  drawer is glued to the right edge and slides open and closed from an arrow tab;
+  it reserves board space on desktop and covers the full screen on mobile, and
+  remembers its state. Opponents' hidden-information lines are withheld unless
+  hands are revealed.
+
+### Changed
+
+- Every UI icon is now drawn from the lucide-react set instead of emoji, so they
+  render consistently across platforms: the board's mana pips, zone counts, life
+  and drop-zone slots, the language switcher, and each log-category icon.
 
 ## [0.1.2] - 2026-08-16
 

--- a/domainbook/domains/board/decisions/0001-draw-icons-from-lucide-react-instead-of-emoji.md
+++ b/domainbook/domains/board/decisions/0001-draw-icons-from-lucide-react-instead-of-emoji.md
@@ -1,0 +1,34 @@
+---
+status: accepted
+date: 2026-08-16
+decision-makers: [RafaelAugustScherer]
+authored-by: agent
+---
+
+# Draw icons from lucide-react instead of emoji
+
+## Context and Problem Statement
+
+The board used emoji as its icons — mana pips, zone counts, life and drop-zone
+slots, and so on. Emoji render differently on every platform (and some not at all),
+so the board looked inconsistent across machines. The game-log sidebar was about to
+add a per-category icon, widening the surface. How should board icons be drawn?
+
+## Considered Options
+
+- Keep emoji.
+- Draw every icon from a vector icon set (`lucide-react`).
+
+## Decision Outcome
+
+Chosen: **draw every UI icon from `lucide-react`.** A single vector set renders
+identically across platforms and scales cleanly. The switch covers the board's mana
+pips, zone counts, life and drop-zone slots, the language switcher, and each
+log-category icon.
+
+### Consequences
+
+- Good: consistent, platform-independent icons; one shared source for new icons
+  such as the log's category glyphs.
+- Bad: a runtime dependency where there was none, and colour/glyph choices now have
+  to be made deliberately rather than borrowed from an emoji.

--- a/domainbook/domains/board/features/follow-the-game.md
+++ b/domainbook/domains/board/features/follow-the-game.md
@@ -27,6 +27,7 @@ Example: A play is logged with its card
   Given a player plays or casts a card
   When the log updates
   Then the entry names the card and the acting player
+  And the entry is coloured by its outcome
   And I can expand the entry to see the card
 
 Example: Turns and phases group the history

--- a/domainbook/domains/board/features/follow-the-game.md
+++ b/domainbook/domains/board/features/follow-the-game.md
@@ -1,0 +1,73 @@
+---
+id: follow-the-game
+name: Follow the game
+status: draft
+---
+
+## Story
+
+As a player
+I want a side panel showing the stack and a running log of what happened
+So that I can see what is resolving and pause to back-check the game's history
+
+## Rule: The sidebar shows the current stack, top first
+
+```gherkin
+Example: A spell waiting to resolve
+  Given a spell or ability is on the stack
+  When I look at the sidebar
+  Then it lists the stack top-first, with the top item marked
+  And an empty stack says so
+```
+
+## Rule: The game log is the engine's own event stream
+
+```gherkin
+Example: A play is logged with its card
+  Given a player plays or casts a card
+  When the log updates
+  Then the entry names the card and the acting player
+  And I can expand the entry to see the card
+
+Example: Turns and phases group the history
+  Given several turns have passed
+  When I scan the log
+  Then each turn is separated by a heading
+```
+
+## Rule: The log is readable by default, complete on demand
+
+```gherkin
+Example: Curated by default
+  Given the default log view
+  Then routine priority passes and phase markers are hidden
+  When I turn on the detailed view
+  Then every engine line is shown
+```
+
+## Rule: The sidebar starts open on desktop and collapsed on mobile
+
+```gherkin
+Example: Small screens keep the board visible
+  Given a narrow, mobile-width screen
+  Then the sidebar starts collapsed and opens as an overlay
+  And on a desktop screen it starts docked open
+  And the choice is remembered
+```
+
+## Rule: Hidden information stays hidden
+
+```gherkin
+Example: An opponent's private lines are withheld
+  Given hands are not revealed
+  When the log would show an opponent's hidden-information line
+  Then it is withheld unless the line is strictly the human's own
+```
+
+## Open Questions
+
+- Whether the log text, which the engine emits in English, should be localized to
+  the interface language.
+- Whether the retained history (currently the most recent lines) should be
+  bounded differently for long watch-mode games.
+

--- a/domainbook/domains/board/features/follow-the-game.md
+++ b/domainbook/domains/board/features/follow-the-game.md
@@ -41,17 +41,24 @@ Example: Turns and phases group the history
 Example: Curated by default
   Given the default log view
   Then routine priority passes and phase markers are hidden
+  And tapping and untapping, mana added and spent, and card draws are hidden
   When I turn on the detailed view
   Then every engine line is shown
 ```
 
-## Rule: The sidebar starts open on desktop and collapsed on mobile
+## Rule: The sidebar is a drawer glued to the right edge
 
 ```gherkin
-Example: Small screens keep the board visible
-  Given a narrow, mobile-width screen
-  Then the sidebar starts collapsed and opens as an overlay
-  And on a desktop screen it starts docked open
+Example: Sliding the drawer open and closed
+  Given the sidebar
+  Then it is glued to the right edge and slides in and out from an arrow tab
+  And on desktop it reserves board space while open
+  And on a narrow, mobile-width screen it covers the full screen while open
+
+Example: Its state is remembered
+  Given a desktop screen
+  Then the drawer starts open
+  And on a mobile-width screen it starts collapsed
   And the choice is remembered
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,14 @@
 {
   "name": "commander-playtester",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commander-playtester",
-      "version": "0.1.1",
+      "version": "0.1.3",
       "dependencies": {
+        "lucide-react": "^1.31.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -2918,6 +2919,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.31.0.tgz",
+      "integrity": "sha512-G8u2eEtoHUnUa9f8lbvqDhCiORMnYLdUEo06EEG9MQvHQrInKcX3Pa2TH39MM5qyzRcWETxB0+aOwAPI1g1kEg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "fetch-engine": "bash scripts/fetch-engine.sh"
   },
   "dependencies": {
+    "lucide-react": "^1.31.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/src/App.css
+++ b/src/App.css
@@ -842,3 +842,267 @@ th {
   color: var(--muted);
   font-size: 0.85rem;
 }
+
+/* ── Stack & game-log sidebar ──────────────────────────────────── */
+.run-layout {
+  display: flex;
+  gap: 1.25rem;
+  align-items: flex-start;
+}
+.run-main {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.game-sidebar {
+  flex: 0 0 330px;
+  position: sticky;
+  top: 1rem;
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 2rem);
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+.game-sidebar__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border);
+}
+.sidebar-backdrop {
+  display: none;
+}
+.sidebar-section {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border);
+}
+.sidebar-section--log {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  border-bottom: none;
+  padding-bottom: 0;
+}
+.sidebar-section__title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+.sidebar-count {
+  background: var(--panel-2);
+  border-radius: 999px;
+  padding: 0 0.45rem;
+  color: var(--text);
+}
+.log-toggle {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  text-transform: none;
+  letter-spacing: 0;
+  font-weight: 600;
+  color: var(--muted);
+  cursor: pointer;
+}
+.sidebar-empty {
+  margin: 0.25rem 0 0.5rem;
+}
+
+/* Stack */
+.stack-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  max-height: 220px;
+  overflow-y: auto;
+}
+.stack-card {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+.stack-card__img {
+  width: 40px;
+  height: 56px;
+  object-fit: cover;
+  object-position: top;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+.stack-card__img--none {
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+}
+.stack-card__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+.stack-card__name {
+  font-size: 0.85rem;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.stack-card__tag {
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--accent);
+}
+
+/* Log */
+.log-scroll {
+  flex: 1 1 auto;
+  min-height: 160px;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+  padding-bottom: 0.75rem;
+}
+.log-turn {
+  position: sticky;
+  top: 0;
+  background: var(--panel);
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text);
+  padding: 0.4rem 0 0.3rem;
+  margin-top: 0.25rem;
+  border-bottom: 1px solid var(--border);
+  z-index: 1;
+}
+.log-row {
+  border-left: 2px solid transparent;
+  padding-left: 0.4rem;
+  margin: 0.05rem 0;
+}
+.log-row--positive {
+  border-left-color: var(--good);
+}
+.log-row--negative {
+  border-left-color: var(--bad);
+}
+.log-row--informational {
+  border-left-color: var(--accent);
+}
+.log-row__head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  width: 100%;
+  background: transparent;
+  border: none;
+  padding: 0.2rem 0;
+  text-align: left;
+  color: var(--text);
+  font-size: 0.82rem;
+  line-height: 1.35;
+}
+.log-row__head:disabled {
+  cursor: default;
+  opacity: 1;
+}
+.log-row__chevron {
+  width: 0.8rem;
+  flex-shrink: 0;
+  color: var(--muted);
+  font-size: 0.7rem;
+}
+.log-row__icon {
+  flex-shrink: 0;
+  color: var(--muted);
+}
+.log-row__msg {
+  min-width: 0;
+}
+.log-row__cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  padding: 0.35rem 0 0.5rem 1.15rem;
+}
+.log-card__img {
+  width: 118px;
+  height: auto;
+  border-radius: 6px;
+}
+.log-card__none {
+  font-size: 0.8rem;
+  color: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.3rem 0.5rem;
+}
+
+/* Log segment chips */
+.seg-card {
+  color: var(--text);
+  font-weight: 700;
+}
+.seg-player {
+  color: var(--muted);
+  font-weight: 600;
+}
+.seg-player--you {
+  color: var(--accent);
+}
+.seg-zone {
+  font-style: italic;
+  color: var(--muted);
+}
+.seg-num {
+  font-weight: 700;
+}
+.seg-mana {
+  display: inline-block;
+  min-width: 1.05em;
+  text-align: center;
+  border-radius: 999px;
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  font-size: 0.72em;
+  font-weight: 700;
+  padding: 0 0.25em;
+}
+.seg-kw {
+  font-weight: 700;
+  color: var(--warn);
+}
+
+@media (max-width: 899px) {
+  .sidebar-backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 59;
+  }
+  .game-sidebar {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: min(90vw, 360px);
+    max-height: 100vh;
+    border-radius: 0;
+    z-index: 60;
+  }
+}

--- a/src/App.css
+++ b/src/App.css
@@ -465,6 +465,8 @@ th {
   text-overflow: ellipsis;
 }
 .seat__life {
+  display: inline-flex;
+  align-items: center;
   font-size: 1.6rem;
   font-weight: 800;
   line-height: 1;
@@ -472,10 +474,16 @@ th {
 }
 .seat__zones {
   display: flex;
+  align-items: center;
   gap: 0.6rem;
   font-size: 0.75rem;
   color: var(--muted);
   margin: 0.35rem 0;
+}
+.seat__zones span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
 }
 .seat__cmd {
   display: flex;
@@ -581,7 +589,9 @@ th {
   padding: 0.2rem 0.35rem;
 }
 .lang__globe {
-  font-size: 0.85rem;
+  display: inline-flex;
+  align-items: center;
+  color: var(--muted);
   margin: 0 0.15rem;
 }
 .lang__btn {
@@ -721,10 +731,10 @@ th {
 }
 .seat__mana {
   display: inline-flex;
-  gap: 0.05rem;
+  align-items: center;
+  gap: 0.1rem;
   font-size: 0.8rem;
   line-height: 1;
-  letter-spacing: -0.05em;
 }
 
 /* ── Drag-to-play drop slots ───────────────────────────────────── */
@@ -755,7 +765,9 @@ th {
   color: var(--muted);
 }
 .slot__icon {
-  font-size: 1.3rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   line-height: 1;
 }
 .slot__label {
@@ -844,26 +856,38 @@ th {
 }
 
 /* ── Stack & game-log sidebar ──────────────────────────────────── */
+:root {
+  --sidebar-w: 340px;
+}
 .run-layout {
-  display: flex;
-  gap: 1.25rem;
-  align-items: flex-start;
+  position: relative;
 }
 .run-main {
-  flex: 1 1 auto;
   min-width: 0;
 }
+/* Drawer glued to the right edge; slides in and out. */
 .game-sidebar {
-  flex: 0 0 330px;
-  position: sticky;
-  top: 1rem;
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: var(--sidebar-w);
+  z-index: 60;
   display: flex;
   flex-direction: column;
-  max-height: calc(100vh - 2rem);
   background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  overflow: hidden;
+  border-left: 1px solid var(--border);
+  transform: translateX(100%);
+  transition: transform 0.25s ease;
+}
+.game-sidebar--open {
+  transform: translateX(0);
+}
+/* Reserve room on desktop so the board isn't hidden behind the open drawer. */
+@media (min-width: 900px) {
+  .app:has(.game-sidebar--open) {
+    padding-right: calc(1.25rem + var(--sidebar-w));
+  }
 }
 .game-sidebar__head {
   display: flex;
@@ -872,8 +896,41 @@ th {
   padding: 0.75rem 1rem;
   border-bottom: 1px solid var(--border);
 }
-.sidebar-backdrop {
-  display: none;
+.game-sidebar__toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 0.25rem;
+  border-radius: 6px;
+}
+.game-sidebar__toggle:hover {
+  color: var(--text);
+  background: var(--panel-2);
+}
+/* Reopen handle that peeks in from the right edge when the drawer is closed. */
+.sidebar-tab {
+  position: fixed;
+  top: 96px;
+  right: 0;
+  z-index: 55;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-right: none;
+  border-radius: 8px 0 0 8px;
+  padding: 0.5rem 0.35rem;
+  color: var(--text);
+  cursor: pointer;
+  box-shadow: -2px 0 8px rgba(0, 0, 0, 0.15);
+}
+.sidebar-tab:hover {
+  color: var(--accent);
 }
 .sidebar-section {
   padding: 0.75rem 1rem;
@@ -929,6 +986,10 @@ th {
   gap: 0.4rem;
   max-height: 220px;
   overflow-y: auto;
+  scrollbar-width: none;
+}
+.stack-list::-webkit-scrollbar {
+  display: none;
 }
 .stack-card {
   display: flex;
@@ -974,6 +1035,10 @@ th {
   overflow-y: auto;
   padding-right: 0.25rem;
   padding-bottom: 0.75rem;
+  scrollbar-width: none;
+}
+.log-scroll::-webkit-scrollbar {
+  display: none;
 }
 .log-turn {
   position: sticky;
@@ -1005,7 +1070,7 @@ th {
 }
 .log-row__head {
   display: flex;
-  align-items: baseline;
+  align-items: flex-start;
   gap: 0.35rem;
   width: 100%;
   background: transparent;
@@ -1021,12 +1086,18 @@ th {
   opacity: 1;
 }
 .log-row__chevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   width: 0.8rem;
+  height: 1.15rem;
   flex-shrink: 0;
   color: var(--muted);
-  font-size: 0.7rem;
 }
 .log-row__icon {
+  display: inline-flex;
+  align-items: center;
+  height: 1.15rem;
   flex-shrink: 0;
   color: var(--muted);
 }
@@ -1088,21 +1159,9 @@ th {
 }
 
 @media (max-width: 899px) {
-  .sidebar-backdrop {
-    display: block;
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.5);
-    z-index: 59;
-  }
   .game-sidebar {
-    position: fixed;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    width: min(90vw, 360px);
-    max-height: 100vh;
-    border-radius: 0;
-    z-index: 60;
+    left: 0;
+    width: auto;
+    border-left: none;
   }
 }

--- a/src/board/Board.tsx
+++ b/src/board/Board.tsx
@@ -1,5 +1,21 @@
 import { useState } from "react";
 import type { MouseEvent as ReactMouseEvent } from "react";
+import {
+  Biohazard,
+  Circle,
+  Cog,
+  Hand,
+  Layers,
+  PawPrint,
+  Skull,
+  Sparkles,
+  Square,
+  Swords,
+  Trees,
+  Wand2,
+  Zap,
+  type LucideIcon,
+} from "lucide-react";
 import type { GameObject } from "../engine/types";
 import type { BoardView, SeatView } from "./boardView";
 import { useI18n } from "../i18n/I18nContext";
@@ -151,13 +167,13 @@ function manaProps(
   return { manaSource: true, onTapSource: () => mana.onTapSource(o.id) };
 }
 
-const MANA_PIP: Record<string, string> = {
-  White: "⚪",
-  Blue: "🔵",
-  Black: "⚫",
-  Red: "🔴",
-  Green: "🟢",
-  Colorless: "◇",
+const MANA_COLOR: Record<string, string> = {
+  White: "#efe9c8",
+  Blue: "#4a90e2",
+  Black: "#6b7280",
+  Red: "#ef4444",
+  Green: "#38a169",
+  Colorless: "#9aa2b1",
 };
 
 const PERMANENT_TYPES = [
@@ -168,14 +184,14 @@ const PERMANENT_TYPES = [
   "Planeswalker",
   "Battle",
 ];
-const SLOT_ICON: Record<string, string> = {
-  Land: "🌄",
-  Creature: "🐾",
-  Artifact: "⚙️",
-  Enchantment: "✨",
-  Planeswalker: "🔮",
-  Battle: "⚔️",
-  Spell: "🎇",
+const SLOT_ICON: Record<string, LucideIcon> = {
+  Land: Trees,
+  Creature: PawPrint,
+  Artifact: Cog,
+  Enchantment: Sparkles,
+  Planeswalker: Wand2,
+  Battle: Swords,
+  Spell: Zap,
 };
 
 function coreTypes(o: GameObject): string[] {
@@ -350,24 +366,40 @@ function Seat({
         <div className="seat__life-wrap">
           {seat.manaPool.length > 0 && (
             <span className="seat__mana" title="Mana disponível">
-              {seat.manaPool.map((pip) => (
-                <span key={pip.color} className="seat__mana-pip">
-                  {(MANA_PIP[pip.color] ?? "◇").repeat(pip.count)}
-                </span>
-              ))}
+              {seat.manaPool.map((pip) => {
+                const color = MANA_COLOR[pip.color] ?? MANA_COLOR.Colorless;
+                return Array.from({ length: pip.count }, (_, i) => (
+                  <Circle
+                    key={`${pip.color}-${i}`}
+                    size={11}
+                    color={color}
+                    fill={color}
+                  />
+                ));
+              })}
             </span>
           )}
           <span className="seat__life">
-            {seat.isEliminated ? "💀" : seat.life}
+            {seat.isEliminated ? <Skull size={22} /> : seat.life}
           </span>
         </div>
       </div>
 
       <div className="seat__zones">
-        <span>🂠 {seat.handCount}</span>
-        <span>📚 {seat.librarySize}</span>
-        <span>⚰️ {seat.graveyardSize}</span>
-        {seat.poison > 0 && <span>☠️ {seat.poison}</span>}
+        <span>
+          <Hand size={13} /> {seat.handCount}
+        </span>
+        <span>
+          <Layers size={13} /> {seat.librarySize}
+        </span>
+        <span>
+          <Skull size={13} /> {seat.graveyardSize}
+        </span>
+        {seat.poison > 0 && (
+          <span>
+            <Biohazard size={13} /> {seat.poison}
+          </span>
+        )}
       </div>
 
       <div className="seat__field">
@@ -409,6 +441,7 @@ function DropLane({ card, play }: { card: GameObject; play: PlayInteraction }) {
     <div className="droplane">
       {slotsFor(card).map((cat) => {
         const ok = slotAccepts(cat, card);
+        const SlotIcon = SLOT_ICON[cat] ?? Square;
         return (
           <div
             key={cat}
@@ -424,7 +457,7 @@ function DropLane({ card, play }: { card: GameObject; play: PlayInteraction }) {
             }}
           >
             <span className="slot__icon" aria-hidden>
-              {SLOT_ICON[cat] ?? "▢"}
+              <SlotIcon size={22} />
             </span>
             <span className="slot__label">{categoryLabel(lang, cat)}</span>
           </div>

--- a/src/board/GameSidebar.tsx
+++ b/src/board/GameSidebar.tsx
@@ -1,8 +1,24 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  ArrowRightLeft,
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  Copy,
+  Flag,
+  Gem,
+  Heart,
+  Layers,
+  RotateCw,
+  Skull,
+  Star,
+  Swords,
+  Zap,
+  type LucideIcon,
+} from "lucide-react";
 import type { GameObject, LogEntry, LogSegment } from "../engine/types";
 import { useI18n } from "../i18n/I18nContext";
 import {
-  categoryIcon,
   entryCards,
   entryText,
   isCurated,
@@ -25,6 +41,20 @@ interface GameSidebarProps {
   open: boolean;
   onToggle: () => void;
 }
+
+const CATEGORY_ICON: Record<string, LucideIcon> = {
+  Turn: Flag,
+  Zone: ArrowRightLeft,
+  Combat: Swords,
+  Mana: Gem,
+  Life: Heart,
+  Stack: Layers,
+  Trigger: Zap,
+  Destroy: Skull,
+  Token: Copy,
+  Special: Star,
+  State: RotateCw,
+};
 
 const MANA_ABBR: Record<string, string> = {
   White: "W",
@@ -65,8 +95,6 @@ export function GameSidebar({
     if (el && atBottom.current) el.scrollTop = el.scrollHeight;
   }, [visible.length, open]);
 
-  if (!open) return null;
-
   const stackTopFirst = [...stack].reverse();
 
   function toggle(id: number) {
@@ -80,16 +108,28 @@ export function GameSidebar({
 
   return (
     <>
-      <div className="sidebar-backdrop" onClick={onToggle} />
-      <aside className="game-sidebar" aria-label={t("sidebar.title")}>
+      {!open && (
+        <button
+          className="sidebar-tab"
+          onClick={onToggle}
+          aria-label={t("sidebar.show")}
+        >
+          <ChevronLeft size={20} />
+        </button>
+      )}
+      <aside
+        className={`game-sidebar ${open ? "game-sidebar--open" : ""}`}
+        aria-label={t("sidebar.title")}
+        aria-hidden={!open}
+      >
         <div className="game-sidebar__head">
           <strong>{t("sidebar.title")}</strong>
           <button
-            className="chip chip--btn"
+            className="game-sidebar__toggle"
             onClick={onToggle}
             aria-label={t("sidebar.hide")}
           >
-            ✕
+            <ChevronRight size={18} />
           </button>
         </div>
 
@@ -108,19 +148,21 @@ export function GameSidebar({
                 const name = o.name ?? "";
                 const img = name ? images?.[name.toLowerCase()] : undefined;
                 return (
-                <li key={o.id} className="stack-card">
-                  {img ? (
-                    <img className="stack-card__img" src={img} alt={name} />
-                  ) : (
-                    <div className="stack-card__img stack-card__img--none" />
-                  )}
-                  <div className="stack-card__meta">
-                    <span className="stack-card__name">{name}</span>
-                    {i === 0 && stackTopFirst.length > 1 && (
-                      <span className="stack-card__tag">{t("sidebar.stackTop")}</span>
+                  <li key={o.id} className="stack-card">
+                    {img ? (
+                      <img className="stack-card__img" src={img} alt={name} />
+                    ) : (
+                      <div className="stack-card__img stack-card__img--none" />
                     )}
-                  </div>
-                </li>
+                    <div className="stack-card__meta">
+                      <span className="stack-card__name">{name}</span>
+                      {i === 0 && stackTopFirst.length > 1 && (
+                        <span className="stack-card__tag">
+                          {t("sidebar.stackTop")}
+                        </span>
+                      )}
+                    </div>
+                  </li>
                 );
               })}
             </ul>
@@ -191,6 +233,7 @@ function LogRow({
   const cards = entryCards(entry);
   const hasCard = cards.length > 0;
   const tone = entry.presentation.tone.toLowerCase();
+  const Icon = CATEGORY_ICON[entry.category] ?? Star;
   return (
     <div className={`log-row log-row--${tone}`}>
       <button
@@ -201,10 +244,11 @@ function LogRow({
         title={entryText(entry)}
       >
         <span className="log-row__chevron">
-          {hasCard ? (expanded ? "▾" : "▸") : ""}
+          {hasCard &&
+            (expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />)}
         </span>
         <span className="log-row__icon" aria-hidden>
-          {categoryIcon(entry.category)}
+          <Icon size={13} />
         </span>
         <span className="log-row__msg">
           {entry.segments.map((s, i) => (

--- a/src/board/GameSidebar.tsx
+++ b/src/board/GameSidebar.tsx
@@ -1,0 +1,271 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { GameObject, LogEntry, LogSegment } from "../engine/types";
+import { useI18n } from "../i18n/I18nContext";
+import {
+  categoryIcon,
+  entryCards,
+  entryText,
+  isCurated,
+  isTurnMarker,
+  isVisibleTo,
+  prettyKeyword,
+} from "./gameLog";
+
+export interface LoggedEntry {
+  id: number;
+  entry: LogEntry;
+}
+
+interface GameSidebarProps {
+  stack: GameObject[];
+  log: LoggedEntry[];
+  images?: Record<string, string>;
+  humanSeat: number | null;
+  revealAll: boolean;
+  open: boolean;
+  onToggle: () => void;
+}
+
+const MANA_ABBR: Record<string, string> = {
+  White: "W",
+  Blue: "U",
+  Black: "B",
+  Red: "R",
+  Green: "G",
+  Colorless: "C",
+};
+
+export function GameSidebar({
+  stack,
+  log,
+  images,
+  humanSeat,
+  revealAll,
+  open,
+  onToggle,
+}: GameSidebarProps) {
+  const { t } = useI18n();
+  const [detailed, setDetailed] = useState(false);
+  const [expanded, setExpanded] = useState<Set<number>>(new Set());
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const atBottom = useRef(true);
+
+  const visible = useMemo(
+    () =>
+      log.filter(
+        ({ entry }) =>
+          isVisibleTo(entry, humanSeat, revealAll) &&
+          (detailed || isCurated(entry)),
+      ),
+    [log, humanSeat, revealAll, detailed],
+  );
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el && atBottom.current) el.scrollTop = el.scrollHeight;
+  }, [visible.length, open]);
+
+  if (!open) return null;
+
+  const stackTopFirst = [...stack].reverse();
+
+  function toggle(id: number) {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  return (
+    <>
+      <div className="sidebar-backdrop" onClick={onToggle} />
+      <aside className="game-sidebar" aria-label={t("sidebar.title")}>
+        <div className="game-sidebar__head">
+          <strong>{t("sidebar.title")}</strong>
+          <button
+            className="chip chip--btn"
+            onClick={onToggle}
+            aria-label={t("sidebar.hide")}
+          >
+            ✕
+          </button>
+        </div>
+
+        <section className="sidebar-section">
+          <div className="sidebar-section__title">
+            {t("sidebar.stack")}
+            {stack.length > 0 && (
+              <span className="sidebar-count">{stack.length}</span>
+            )}
+          </div>
+          {stackTopFirst.length === 0 ? (
+            <p className="hint sidebar-empty">{t("sidebar.stackEmpty")}</p>
+          ) : (
+            <ul className="stack-list">
+              {stackTopFirst.map((o, i) => {
+                const name = o.name ?? "";
+                const img = name ? images?.[name.toLowerCase()] : undefined;
+                return (
+                <li key={o.id} className="stack-card">
+                  {img ? (
+                    <img className="stack-card__img" src={img} alt={name} />
+                  ) : (
+                    <div className="stack-card__img stack-card__img--none" />
+                  )}
+                  <div className="stack-card__meta">
+                    <span className="stack-card__name">{name}</span>
+                    {i === 0 && stackTopFirst.length > 1 && (
+                      <span className="stack-card__tag">{t("sidebar.stackTop")}</span>
+                    )}
+                  </div>
+                </li>
+                );
+              })}
+            </ul>
+          )}
+        </section>
+
+        <section className="sidebar-section sidebar-section--log">
+          <div className="sidebar-section__title">
+            {t("sidebar.log")}
+            <label className="log-toggle">
+              <input
+                type="checkbox"
+                checked={detailed}
+                onChange={(e) => setDetailed(e.target.checked)}
+              />
+              {t("sidebar.detailed")}
+            </label>
+          </div>
+          <div
+            className="log-scroll"
+            ref={scrollRef}
+            onScroll={(e) => {
+              const el = e.currentTarget;
+              atBottom.current =
+                el.scrollHeight - el.scrollTop - el.clientHeight < 48;
+            }}
+          >
+            {visible.length === 0 ? (
+              <p className="hint sidebar-empty">{t("sidebar.logEmpty")}</p>
+            ) : (
+              visible.map(({ id, entry }) =>
+                isTurnMarker(entry) ? (
+                  <div key={id} className="log-turn">
+                    {entryText(entry)}
+                  </div>
+                ) : (
+                  <LogRow
+                    key={id}
+                    entry={entry}
+                    images={images}
+                    humanSeat={humanSeat}
+                    expanded={expanded.has(id)}
+                    onToggle={() => toggle(id)}
+                  />
+                ),
+              )
+            )}
+          </div>
+        </section>
+      </aside>
+    </>
+  );
+}
+
+function LogRow({
+  entry,
+  images,
+  humanSeat,
+  expanded,
+  onToggle,
+}: {
+  entry: LogEntry;
+  images?: Record<string, string>;
+  humanSeat: number | null;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const cards = entryCards(entry);
+  const hasCard = cards.length > 0;
+  const tone = entry.presentation.tone.toLowerCase();
+  return (
+    <div className={`log-row log-row--${tone}`}>
+      <button
+        type="button"
+        className="log-row__head"
+        onClick={hasCard ? onToggle : undefined}
+        disabled={!hasCard}
+        title={entryText(entry)}
+      >
+        <span className="log-row__chevron">
+          {hasCard ? (expanded ? "▾" : "▸") : ""}
+        </span>
+        <span className="log-row__icon" aria-hidden>
+          {categoryIcon(entry.category)}
+        </span>
+        <span className="log-row__msg">
+          {entry.segments.map((s, i) => (
+            <Segment key={i} s={s} humanSeat={humanSeat} />
+          ))}
+        </span>
+      </button>
+      {expanded && hasCard && (
+        <div className="log-row__cards">
+          {cards.map((c) => {
+            const url = images?.[c.name.toLowerCase()];
+            return url ? (
+              <img
+                key={c.objectId}
+                className="log-card__img"
+                src={url}
+                alt={c.name}
+              />
+            ) : (
+              <div key={c.objectId} className="log-card__none">
+                {c.name}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Segment({
+  s,
+  humanSeat,
+}: {
+  s: LogSegment;
+  humanSeat: number | null;
+}) {
+  switch (s.type) {
+    case "Text":
+      return <>{s.value}</>;
+    case "CardName":
+      return <span className="seg-card">{s.value.name}</span>;
+    case "PlayerName":
+      return (
+        <span
+          className={`seg-player ${s.value.player_id === humanSeat ? "seg-player--you" : ""}`}
+        >
+          {s.value.name}
+        </span>
+      );
+    case "Zone":
+      return <span className="seg-zone">{s.value}</span>;
+    case "Number":
+      return <span className="seg-num">{s.value}</span>;
+    case "Mana":
+      return (
+        <span className="seg-mana" title={s.value}>
+          {MANA_ABBR[s.value] ?? s.value}
+        </span>
+      );
+    case "Keyword":
+      return <span className="seg-kw">{prettyKeyword(s.value)}</span>;
+  }
+}

--- a/src/board/boardView.ts
+++ b/src/board/boardView.ts
@@ -29,6 +29,8 @@ export interface BoardView {
   gameOver: boolean;
   winner: number | null;
   seats: SeatView[];
+  /** Objects on the stack, bottom-to-top as the engine orders them. */
+  stack: GameObject[];
 }
 
 export interface SeatMeta {
@@ -95,6 +97,9 @@ export function toBoardView(
   const playerCount = st.players.length || 1;
   const round =
     turnNumber < 1 ? turnNumber : Math.floor((turnNumber - 1) / playerCount) + 1;
+  const stack = (st.stack ?? [])
+    .map((id) => objects[id])
+    .filter((o): o is GameObject => !!o);
   return {
     turn: round,
     phase: st.phase ?? "",
@@ -102,5 +107,6 @@ export function toBoardView(
     gameOver,
     winner: gameOver ? (st.waiting_for?.data?.winner ?? null) : null,
     seats,
+    stack,
   };
 }

--- a/src/board/gameLog.ts
+++ b/src/board/gameLog.ts
@@ -1,0 +1,99 @@
+import type { LogEntry, LogSegment } from "../engine/types";
+
+export const CATEGORY_ICON: Record<string, string> = {
+  Turn: "⏱",
+  Zone: "↪",
+  Combat: "⚔",
+  Mana: "◈",
+  Life: "♥",
+  Stack: "≡",
+  Trigger: "✦",
+  Destroy: "☠",
+  Token: "◉",
+  Special: "★",
+  State: "·",
+};
+
+export function categoryIcon(category: string): string {
+  return CATEGORY_ICON[category] ?? "·";
+}
+
+/** Curated view drops phase/step markers and the priority-pass firehose. */
+export function isCurated(entry: LogEntry): boolean {
+  if (entry.presentation.importance === "Context") return false;
+  if (entry.category === "Turn" && entry.presentation.importance === "Detail") {
+    return false;
+  }
+  return true;
+}
+
+/** A turn header ("Turn N — Player") that reads better as a divider than a row. */
+export function isTurnMarker(entry: LogEntry): boolean {
+  return entry.presentation.boundary === "Turn";
+}
+
+/**
+ * Hidden-info lines leak nothing when public; otherwise show them only when
+ * hands are revealed or the line is strictly about the human's own seat.
+ */
+export function isVisibleTo(
+  entry: LogEntry,
+  humanSeat: number | null,
+  revealAll: boolean,
+): boolean {
+  if (entry.presentation.visibility === "Public") return true;
+  if (revealAll) return true;
+  if (humanSeat == null) return false;
+  const players = entry.segments.filter(
+    (s): s is Extract<LogSegment, { type: "PlayerName" }> =>
+      s.type === "PlayerName",
+  );
+  return players.length > 0 && players.every((s) => s.value.player_id === humanSeat);
+}
+
+export interface EntryCard {
+  name: string;
+  objectId: number;
+}
+
+/** The card(s) a log entry refers to, for the expand-to-thumbnail affordance. */
+export function entryCards(entry: LogEntry): EntryCard[] {
+  const seen = new Set<number>();
+  const cards: EntryCard[] = [];
+  for (const s of entry.segments) {
+    if (s.type === "CardName" && !seen.has(s.value.object_id)) {
+      seen.add(s.value.object_id);
+      cards.push({ name: s.value.name, objectId: s.value.object_id });
+    }
+  }
+  return cards;
+}
+
+export function prettyKeyword(k: string): string {
+  if (k === "Plus1Plus1") return "+1/+1";
+  if (k === "Minus1Minus1") return "-1/-1";
+  return k.replace(/([a-z])([A-Z])/g, "$1 $2");
+}
+
+export function segmentText(s: LogSegment): string {
+  switch (s.type) {
+    case "Text":
+      return s.value;
+    case "CardName":
+      return s.value.name;
+    case "PlayerName":
+      return s.value.name;
+    case "Zone":
+      return s.value;
+    case "Number":
+      return String(s.value);
+    case "Mana":
+      return s.value;
+    case "Keyword":
+      return prettyKeyword(s.value);
+  }
+}
+
+export function entryText(entry: LogEntry): string {
+  return entry.segments.map(segmentText).join("");
+}

--- a/src/board/gameLog.ts
+++ b/src/board/gameLog.ts
@@ -1,27 +1,13 @@
 import type { LogEntry, LogSegment } from "../engine/types";
 
-export const CATEGORY_ICON: Record<string, string> = {
-  Turn: "⏱",
-  Zone: "↪",
-  Combat: "⚔",
-  Mana: "◈",
-  Life: "♥",
-  Stack: "≡",
-  Trigger: "✦",
-  Destroy: "☠",
-  Token: "◉",
-  Special: "★",
-  State: "·",
-};
-
-export function categoryIcon(category: string): string {
-  return CATEGORY_ICON[category] ?? "·";
-}
-
-/** Curated view drops phase/step markers and the priority-pass firehose. */
 export function isCurated(entry: LogEntry): boolean {
-  if (entry.presentation.importance === "Context") return false;
-  if (entry.category === "Turn" && entry.presentation.importance === "Detail") {
+  const { importance, visibility } = entry.presentation;
+  if (importance === "Context") return false;
+  if (entry.category === "Turn" && importance === "Detail") return false;
+  if (entry.category === "State") return false;
+  if (entry.category === "Mana") return false;
+  if (entry.category === "Special" && importance === "Detail") return false;
+  if (entry.category === "Zone" && visibility === "HiddenInformation") {
     return false;
   }
   return true;

--- a/src/engine/EngineClient.ts
+++ b/src/engine/EngineClient.ts
@@ -3,6 +3,7 @@ import type {
   AiDifficulty,
   EngineDeckList,
   GameStateEnvelope,
+  LogEntry,
 } from "./types";
 
 interface Pending {
@@ -22,6 +23,7 @@ export interface InitGameArgs {
 export interface AiStepResult {
   applied: boolean;
   actionType?: string;
+  logEntries?: LogEntry[];
   state: GameStateEnvelope | null;
 }
 
@@ -87,7 +89,10 @@ export class EngineClient {
     return this.req("legalActions");
   }
 
-  humanAction(actor: number, action: unknown): Promise<any> {
+  humanAction(
+    actor: number,
+    action: unknown,
+  ): Promise<{ result: any; logEntries?: LogEntry[]; state: GameStateEnvelope }> {
     return this.req("humanAction", { actor, action });
   }
 

--- a/src/engine/engine.worker.ts
+++ b/src/engine/engine.worker.ts
@@ -68,12 +68,17 @@ async function handle(cmd: string, args: any): Promise<any> {
       const { difficulty, player, wantState } = args;
       const proposal = get_ai_action_proposal(difficulty, player ?? 0);
       if (!proposal) {
-        return { applied: false, state: get_game_state() };
+        return { applied: false, state: get_game_state(), logEntries: [] };
       }
-      submit_ai_action_proposal(proposal.token, proposal.actor, proposal.action);
+      const res = submit_ai_action_proposal(
+        proposal.token,
+        proposal.actor,
+        proposal.action,
+      );
       return {
         applied: true,
         actionType: proposal.action?.type,
+        logEntries: res?.result?.log_entries ?? [],
         state: wantState ? get_game_state() : null,
       };
     }
@@ -88,7 +93,11 @@ async function handle(cmd: string, args: any): Promise<any> {
     case "humanAction": {
       const { actor, action } = args;
       const res = submit_action(actor, action);
-      return { result: res, state: get_game_state() };
+      return {
+        result: res,
+        logEntries: res?.log_entries ?? [],
+        state: get_game_state(),
+      };
     }
     default:
       throw new Error(`unknown engine command: ${cmd}`);

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -114,6 +114,36 @@ export interface AiProposal {
   semanticOwner?: number;
 }
 
+/** One typed piece of a log entry's message; card/player carry an id. */
+export type LogSegment =
+  | { type: "Text"; value: string }
+  | { type: "CardName"; value: { name: string; object_id: number } }
+  | { type: "PlayerName"; value: { name: string; player_id: number } }
+  | { type: "Zone"; value: string }
+  | { type: "Number"; value: number }
+  | { type: "Mana"; value: string }
+  | { type: "Keyword"; value: string };
+
+export type LogImportance = "Context" | "Detail" | "Essential";
+export type LogTone = "Neutral" | "Informational" | "Positive" | "Negative";
+export type LogBoundary = "None" | "Phase" | "Turn";
+export type LogVisibility = "Public" | "HiddenInformation";
+
+/** A single engine game-log line: typed message segments plus presentation hints. */
+export interface LogEntry {
+  seq: number;
+  turn: number;
+  phase: string;
+  category: string;
+  segments: LogSegment[];
+  presentation: {
+    importance: LogImportance;
+    tone: LogTone;
+    boundary: LogBoundary;
+    visibility: LogVisibility;
+  };
+}
+
 /** Error envelope some engine calls return instead of a value. */
 export interface EngineError {
   error: true;

--- a/src/i18n/LangToggle.tsx
+++ b/src/i18n/LangToggle.tsx
@@ -1,3 +1,4 @@
+import { Globe } from "lucide-react";
 import { LANGS, LANG_LABEL } from "./messages";
 import { useI18n } from "./I18nContext";
 
@@ -7,7 +8,7 @@ export function LangToggle() {
   return (
     <div className="lang" role="group" aria-label={t("lang.aria")}>
       <span className="lang__globe" aria-hidden>
-        🌐
+        <Globe size={14} />
       </span>
       {LANGS.map((l) => (
         <button

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -201,6 +201,16 @@ export const messages = {
 
   "select.noResults": { pt: "Nenhum resultado", en: "No matches" },
 
+  "sidebar.title": { pt: "Pilha e registro", en: "Stack & log" },
+  "sidebar.stack": { pt: "Pilha", en: "Stack" },
+  "sidebar.stackEmpty": { pt: "A pilha está vazia.", en: "The stack is empty." },
+  "sidebar.stackTop": { pt: "topo", en: "top" },
+  "sidebar.log": { pt: "Registro", en: "Game log" },
+  "sidebar.logEmpty": { pt: "Nada ainda.", en: "Nothing yet." },
+  "sidebar.detailed": { pt: "Detalhado", en: "Detailed" },
+  "sidebar.show": { pt: "Mostrar registro", en: "Show log" },
+  "sidebar.hide": { pt: "Ocultar", en: "Hide" },
+
   "report.title": { pt: "Resultado da série", en: "Series result" },
   "report.newSetup": { pt: "Nova configuração", en: "New setup" },
   "report.winRateDeck": { pt: "Win rate (seu deck)", en: "Win rate (your deck)" },

--- a/src/match/RunView.tsx
+++ b/src/match/RunView.tsx
@@ -41,6 +41,8 @@ import {
   type CreatureTypePrompt,
 } from "../sim/decisions/creatureType";
 import { toBoardView, type BoardView, type SeatMeta } from "../board/boardView";
+import { GameSidebar, type LoggedEntry } from "../board/GameSidebar";
+import type { LogEntry } from "../engine/types";
 import { abilitiesBySource } from "../sim/decisions/abilities";
 import { aggregate } from "../analysis/matchStats";
 import { fetchCardsCached } from "../lib/scryfallCache";
@@ -169,7 +171,18 @@ export function RunView({
     useState<CreatureTypeTurn | null>(null);
   const [creatureTypePick, setCreatureTypePick] = useState("");
   const [passingTurn, setPassingTurn] = useState(false);
+  const [logEntries, setLogEntries] = useState<LoggedEntry[]>([]);
+  const [sidebarOpen, setSidebarOpen] = useState<boolean>(() => {
+    const saved = localStorage.getItem("sidebarOpen");
+    if (saved != null) return saved === "1";
+    return window.matchMedia("(min-width: 900px)").matches;
+  });
+  const logIdRef = useRef(0);
   const runnerRef = useRef<MatchRunner | null>(null);
+
+  useEffect(() => {
+    localStorage.setItem("sidebarOpen", sidebarOpen ? "1" : "0");
+  }, [sidebarOpen]);
 
   const seatMeta: SeatMeta[] = useMemo(
     () =>
@@ -217,10 +230,24 @@ export function RunView({
               if (!cancelled) {
                 setCurrentMatch(m);
                 setPassingTurn(false);
+                setLogEntries([]);
               }
             },
             onMatchEnd: (r) => {
               if (!cancelled) setResults((prev) => [...prev, r]);
+            },
+            onLogEntries: (entries: LogEntry[]) => {
+              if (cancelled) return;
+              const tagged = entries.map((entry) => ({
+                id: logIdRef.current++,
+                entry,
+              }));
+              setLogEntries((prev) => {
+                const next = prev.concat(tagged);
+                return next.length > 800
+                  ? next.slice(next.length - 800)
+                  : next;
+              });
             },
             requestHumanAction: (env, legal) =>
               new Promise<HumanChoice>((resolve) => {
@@ -668,6 +695,12 @@ export function RunView({
                 <button className="btn btn--ghost btn--sm" onClick={togglePause}>
                   {paused ? t("run.resume") : t("run.pause")}
                 </button>
+                <button
+                  className="btn btn--ghost btn--sm"
+                  onClick={() => setSidebarOpen((v) => !v)}
+                >
+                  {sidebarOpen ? t("sidebar.hide") : t("sidebar.show")}
+                </button>
               </>
             )}
             <button
@@ -708,6 +741,8 @@ export function RunView({
         )}
       </section>
 
+      <div className="run-layout">
+        <div className="run-main">
       {board && (
         <section className="panel play-controls">
           <div className="panel__head">
@@ -1054,6 +1089,19 @@ export function RunView({
           />
         </section>
       )}
+        </div>
+        {board && (
+          <GameSidebar
+            stack={board.stack}
+            log={logEntries}
+            images={images}
+            humanSeat={config.mode === "play" ? 0 : null}
+            revealAll={config.revealHands || config.mode === "watch"}
+            open={sidebarOpen}
+            onToggle={() => setSidebarOpen((v) => !v)}
+          />
+        )}
+      </div>
 
       {phase === "done" && (
         <RunReport

--- a/src/sim/driver.ts
+++ b/src/sim/driver.ts
@@ -3,6 +3,7 @@ import type {
   AiDifficulty,
   EngineDeckList,
   GameStateEnvelope,
+  LogEntry,
   WaitingFor,
 } from "../engine/types";
 import { actingPlayer, isEngineError } from "../engine/types";
@@ -156,6 +157,8 @@ export interface DriverCallbacks {
   onMatchStart?: (matchIndex: number) => void;
   onMatchEnd?: (result: MatchResult) => void;
   onLog?: (msg: string) => void;
+  /** New engine game-log lines produced by the action that was just applied. */
+  onLogEntries?: (entries: LogEntry[]) => void;
   /** Called on the human's priority in play mode; resolves with their choice. */
   requestHumanAction?: (
     env: GameStateEnvelope,
@@ -253,6 +256,12 @@ export class MatchRunner {
     await new Promise<void>((r) => this.resumeWaiters.push(r));
   }
 
+  private emitLog(res: { logEntries?: LogEntry[] }): void {
+    if (res.logEntries && res.logEntries.length) {
+      this.cb.onLogEntries?.(res.logEntries);
+    }
+  }
+
   async run(): Promise<MatchResult[]> {
     const results: MatchResult[] = [];
     for (let m = 0; m < this.opts.matchCount; m++) {
@@ -309,6 +318,7 @@ export class MatchRunner {
 
       const wantState = actions % renderEvery === 0;
       const res = await engine.aiStep(opts.difficulty, 0, wantState);
+      this.emitLog(res);
 
       if (!res.applied) {
         const final = res.state ?? (await engine.getState());
@@ -387,8 +397,11 @@ export class MatchRunner {
 
       // Run the human's choice: play their action, or hand this decision to the AI.
       const applyChoice = async (choice: HumanChoice): Promise<void> => {
-        if ("action" in choice) await engine.humanAction(humanSeat, choice.action);
-        else await engine.aiStep(opts.difficulty, humanSeat, false);
+        const res =
+          "action" in choice
+            ? await engine.humanAction(humanSeat, choice.action)
+            : await engine.aiStep(opts.difficulty, humanSeat, false);
+        this.emitLog(res);
       };
 
       if (humanPriority) {
@@ -442,6 +455,7 @@ export class MatchRunner {
       } else {
         // AI seats, and the human's non-priority sub-decisions, are AI-driven.
         const res = await engine.aiStep(opts.difficulty, acting, false);
+        this.emitLog(res);
         if (!res.applied) {
           const wf2 = res.state?.state.waiting_for;
           if (wf2?.type === "GameOver") winner = wf2.data?.winner ?? null;


### PR DESCRIPTION
## What

A right-hand **sidebar** that shows the current **stack** and a running **game log**, so the player can see what's resolving and pause to back-check the game's history. Improves on the sketched draft with rich, engine-sourced entries.

- **Stack** — read from board state, listed top-first with the top item marked; an empty stack says so.
- **Game log** — the engine's *own* structured event stream. Each line renders typed segments (card / player / zone / number / mana) as chips, is coloured by outcome (tone), grouped under **turn headings**, and **expands to a card thumbnail** for any card it references.
- **Curated by default** (plays, casts, abilities, combat, life, zone moves, triggers); a **Detailed** toggle reveals the low-level lines (priority passes, phase markers).
- **Docked open on desktop, a collapsible overlay on mobile**, remembering its state.
- Opponents' **hidden-information** lines are withheld unless "reveal hands" is on.

## How

- The engine already emits `log_entries` (typed `segments` + `importance`/`tone`/`visibility` metadata) from every applied action; the worker discarded the AI actions' entries. `aiStep`/`humanAction` now surface them ([engine.worker.ts](src/engine/engine.worker.ts), [EngineClient.ts](src/engine/EngineClient.ts)), the driver accumulates them via a new `onLogEntries` callback ([driver.ts](src/sim/driver.ts)), and RunView holds them in state.
- `LogEntry`/`LogSegment` types in [types.ts](src/engine/types.ts); view helpers (curated/visibility filters, card extraction, category icons) in [gameLog.ts](src/board/gameLog.ts); the panel in [GameSidebar.tsx](src/board/GameSidebar.tsx). `boardView` now derives `stack`.

## Verification

- `npm run typecheck` · `lint` · `test` (61) · `build` — all green. `domainbook check` — 3 domains, nothing stale.
- Driven live (seed 8, Avengers vs Ahoy): the log populates with rich segments, turn dividers, tone-coloured combat/life lines, and the cast→stack→battlefield flow; the **Detailed** toggle switches 4↔26↔287 rows; expanding a card line shows its thumbnail; the mobile overlay drawer + backdrop render at 375px. Stack empty-state verified live; the card-render path shares the (verified) image lookup.

## Notes

- The log text is emitted by the engine in **English** regardless of the interface language — noted as an open question in the feature spec; localizing it would require translating every engine phrase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)