### PR TITLE
Import decks from Moxfield and Archidekt URLs

### DIFF
--- a/deck-proxy/README.md
+++ b/deck-proxy/README.md
@@ -1,0 +1,51 @@
+# Deck import proxy
+
+The playtester imports decks from Moxfield and Archidekt URLs. Because it's a
+static site, the browser can't call those deck APIs directly — Moxfield and
+Archidekt only send permissive CORS headers to their own front-ends, so a
+cross-origin `fetch` from the app is blocked. This tiny [Cloudflare Worker][cf]
+forwards one allowlisted request and adds the CORS headers the browser needs.
+
+By default the app falls back to a public proxy (`api.allorigins.win`), which is
+fine for trying it out but is rate-limited, occasionally down, and can't reach
+Moxfield (see below). Deploy this worker for a reliable import.
+
+## Deploy
+
+```bash
+npm install -g wrangler   # or: npx wrangler ...
+cd deck-proxy
+wrangler deploy
+```
+
+Then build the app pointing at your worker:
+
+```bash
+VITE_DECK_PROXY="https://<your-worker>.workers.dev/?url=" npm run build
+```
+
+(Locally, put that line in a `.env.local` at the repo root.) Set
+`VITE_DECK_PROXY=""` to fetch directly instead — only useful if you run the app
+from a browser extension or another context where CORS doesn't apply.
+
+## Moxfield
+
+Moxfield sits behind Cloudflare bot protection and answers automated requests
+only when they carry a **User-Agent it has approved**. Email
+`support@moxfield.com` to request one, then store it as a secret:
+
+```bash
+wrangler secret put MOXFIELD_USER_AGENT
+```
+
+Without an approved User-Agent, Moxfield imports return a network error (their
+edge replies 403). Archidekt imports work with no extra setup.
+
+## Ligamagic
+
+Ligamagic isn't supported for automatic import: its deck contents load through a
+page session with a per-request token, so there's no stable URL a proxy can
+fetch. Open the deck on Ligamagic, use its export, and paste the list into the
+editor instead.
+
+[cf]: https://developers.cloudflare.com/workers/

--- a/deck-proxy/worker.js
+++ b/deck-proxy/worker.js
@@ -1,0 +1,62 @@
+// Cloudflare Worker: a small same-origin CORS proxy for the deck importer.
+//
+// The playtester is a static site, so it can't fetch Moxfield/Archidekt deck
+// APIs directly (their CORS policies block cross-origin browser requests).
+// This worker forwards a single allowlisted GET and adds permissive CORS.
+//
+// Deploy with `wrangler deploy`, then build the app with
+// VITE_DECK_PROXY="https://<your-worker>.workers.dev/?url=".
+//
+// Moxfield only answers requests carrying a User-Agent they have approved —
+// email support@moxfield.com, then set the MOXFIELD_USER_AGENT secret/var.
+
+const ALLOWED_HOSTS = new Set(["api.moxfield.com", "archidekt.com"]);
+
+const CORS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+};
+
+export default {
+  async fetch(request, env) {
+    if (request.method === "OPTIONS") {
+      return new Response(null, { status: 204, headers: CORS });
+    }
+    if (request.method !== "GET") {
+      return new Response("Method not allowed", { status: 405, headers: CORS });
+    }
+
+    const target = new URL(request.url).searchParams.get("url");
+    if (!target) {
+      return new Response("Missing url", { status: 400, headers: CORS });
+    }
+
+    let upstream;
+    try {
+      upstream = new URL(target);
+    } catch {
+      return new Response("Bad url", { status: 400, headers: CORS });
+    }
+    if (upstream.protocol !== "https:" || !ALLOWED_HOSTS.has(upstream.hostname)) {
+      return new Response("Host not allowed", { status: 403, headers: CORS });
+    }
+
+    const userAgent =
+      env.MOXFIELD_USER_AGENT ||
+      "Mozilla/5.0 (compatible; commander-playtester deck importer)";
+
+    const res = await fetch(upstream.toString(), {
+      headers: { Accept: "application/json", "User-Agent": userAgent },
+    });
+
+    return new Response(res.body, {
+      status: res.status,
+      headers: {
+        ...CORS,
+        "Content-Type": res.headers.get("Content-Type") || "application/json",
+        "Cache-Control": "public, max-age=300",
+      },
+    });
+  },
+};

--- a/deck-proxy/wrangler.toml
+++ b/deck-proxy/wrangler.toml
@@ -1,0 +1,8 @@
+name = "commander-playtester-deck-proxy"
+main = "worker.js"
+compatibility_date = "2026-08-01"
+
+# Moxfield only answers requests with a User-Agent they've approved. Request one
+# at support@moxfield.com, then set it as a secret:
+#   wrangler secret put MOXFIELD_USER_AGENT
+# Archidekt needs no special header.

--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -10,13 +10,9 @@ Security as H3s, each of them a bullet list.
 
 ### Added
 
-- Import a deck from its Moxfield or Archidekt URL: paste a public or unlisted
-  deck link and its commander and cards fill the editor, ready to review and save.
-  Because the app is a static site and those sites block cross-origin browser
-  requests, the fetch goes through a proxy — a bundled Cloudflare Worker
-  (`deck-proxy/`) for reliability, with a public proxy as the zero-config default.
-  Ligamagic URLs are recognized but can't be auto-imported (their deck data sits
-  behind a page session), so the author is pointed to paste the exported list.
+- Import a deck from its Moxfield or Archidekt URL: paste the link and its
+  commander and cards fill the editor, ready to review and save
+  (`import-from-a-url`, `deck-library/ADR-0001`).
 
 ## [0.1.2] - 2026-08-16
 

--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -8,6 +8,16 @@ Security as H3s, each of them a bullet list.
 
 ## [Unreleased]
 
+### Added
+
+- Import a deck from its Moxfield or Archidekt URL: paste a public or unlisted
+  deck link and its commander and cards fill the editor, ready to review and save.
+  Because the app is a static site and those sites block cross-origin browser
+  requests, the fetch goes through a proxy — a bundled Cloudflare Worker
+  (`deck-proxy/`) for reliability, with a public proxy as the zero-config default.
+  Ligamagic URLs are recognized but can't be auto-imported (their deck data sits
+  behind a page session), so the author is pointed to paste the exported list.
+
 ## [0.1.2] - 2026-08-16
 
 ### Added

--- a/domainbook/domains/deck-library/decisions/0001-route-deck-url-imports-through-a-proxy.md
+++ b/domainbook/domains/deck-library/decisions/0001-route-deck-url-imports-through-a-proxy.md
@@ -1,0 +1,54 @@
+---
+status: accepted
+date: 2026-08-16
+decision-makers: [RafaelAugustScherer]
+authored-by: agent
+---
+
+# Route deck-URL imports through a proxy
+
+## Context and Problem Statement
+
+`import-from-a-url` fetches a deck from Moxfield or Archidekt and turns it into the
+same decklist text the author would paste. But the app runs fully client-side as a
+static site (`ADR-0003`), and every target site blocks a direct browser fetch from
+our origin: Archidekt pins CORS to `localhost:3000`, Moxfield is Cloudflare
+bot-gated (403 to non-approved clients), and Ligamagic loads its cards through a
+per-request page session with no stable URL. How can a backend-less site fetch them?
+
+## Considered Options
+
+- **Direct browser fetch** to each site's API.
+- **Route through a proxy** that adds the CORS/headers the browser can't.
+- **Drop URL import** and keep paste-only.
+
+## Decision Outcome
+
+Chosen: **route the fetch through a proxy**, selected by `VITE_DECK_PROXY`
+(a `?url=`-style base).
+
+- **Owned Cloudflare Worker (`deck-proxy/`)** is the recommended path: reliable, and
+  able to send an approved User-Agent.
+- **A public proxy** is the zero-config default so a fresh clone isn't inert, at the
+  cost of rate limits and occasional downtime.
+
+Per site: **Archidekt** works through either proxy. **Moxfield** answers only
+requests carrying a User-Agent it has approved, so it needs the owned worker;
+Moxfield's ToS also prohibits unapproved scraping. **Ligamagic** is not
+auto-importable — its per-request session token means no stable URL a static-site
+proxy can fetch — so the URL is recognized and the author is told to export and
+paste instead.
+
+### Consequences
+
+- Good: URL import works from a static site with no backend of our own; the owned
+  worker gives a reliable, ToS-respecting path; the default keeps the feature live
+  out of the box.
+- Bad: a proxy is now on the fetch path (a dependency and a trust boundary); the
+  public default is unreliable; Moxfield depends on holding an approved UA;
+  Ligamagic stays paste-only.
+
+## More Information
+
+Consequence of `ADR-0003`. Open questions (public vs owned proxy, later Ligamagic
+support) are tracked in the `import-from-a-url` feature spec.

--- a/domainbook/domains/deck-library/features/import-from-a-url.md
+++ b/domainbook/domains/deck-library/features/import-from-a-url.md
@@ -1,0 +1,63 @@
+---
+id: import-from-a-url
+name: Import a deck from a URL
+status: draft
+---
+
+## Story
+
+As a deck author
+I want to paste a Moxfield or Archidekt deck URL and have its cards filled in
+So that I don't have to copy the list by hand
+
+## Rule: A recognized deck URL fills the editor
+
+The fetched deck becomes the same pasted-decklist text the author would type — its
+commander lands in the Commander section, the rest in the deck — ready to review
+and save. The deck's name pre-fills the name field only when it is still empty.
+
+```gherkin
+Example: Importing an Archidekt deck
+  Given a public or unlisted Archidekt deck URL
+  When the author imports it
+  Then the commander and the rest of the cards fill the decklist
+  And the deck name fills the name field if it was empty
+  And the author can review and save it like any typed deck
+```
+
+```gherkin
+Example: Importing a Moxfield deck
+  Given a public or unlisted Moxfield deck URL
+  When the author imports it
+  Then the mainboard and commanders fill the decklist
+  And the sideboard and maybeboard are left out
+```
+
+## Rule: The author is told when a URL can't be imported
+
+```gherkin
+Example: A Ligamagic URL
+  Given a Ligamagic deck URL
+  When the author imports it
+  Then they are told to export the list on Ligamagic and paste it instead
+
+Example: A URL that isn't a deck site
+  Given a URL that is not Moxfield, Archidekt, or Ligamagic
+  When the author imports it
+  Then they are told it isn't a supported deck URL
+
+Example: The deck can't be reached
+  Given a supported URL whose deck can't be fetched
+  When the import fails
+  Then the author sees why — not found, or the import proxy is unreachable
+```
+
+## Open Questions
+
+- Whether to rely on the default public proxy or require the owned `deck-proxy`
+  worker; Moxfield needs the owned proxy with an approved User-Agent, Archidekt
+  works through either.
+- Whether Ligamagic could be supported later (its deck data is behind a page
+  session token, so it would need a different approach than a plain fetch).
+- Whether to import more than the mainboard and commanders (companions,
+  signature spells) for the formats that use them.

--- a/domainbook/domains/deck-library/index.md
+++ b/domainbook/domains/deck-library/index.md
@@ -10,6 +10,7 @@ code:
   - src/deck/**
   - src/lib/decklist.ts
   - src/lib/scryfall.ts
+  - src/lib/deckImport.ts
 ---
 
 ## Purpose
@@ -53,6 +54,11 @@ actually play, so `match setup` always has legal, playable decks to choose from.
   implemented — is asked of phase-rs. A card can be Commander-legal yet unplayable.
 - The existing `src/lib/decklist.ts` parser and `src/lib/scryfall.ts` resolver are
   reused rather than rewritten.
+- A deck may also be brought in by its Moxfield or Archidekt URL, which is fetched
+  and turned into the same pasted-decklist text the author would otherwise type.
+  This does not walk back `ADR-0004`: the user still supplies one deck they chose,
+  and no field of decks is curated or browsed. The deck sites block cross-origin
+  browser calls, so the fetch goes through a proxy (`deck-proxy/`).
 
 ## Assumptions
 

--- a/domainbook/domains/deck-library/index.md
+++ b/domainbook/domains/deck-library/index.md
@@ -58,7 +58,7 @@ actually play, so `match setup` always has legal, playable decks to choose from.
   and turned into the same pasted-decklist text the author would otherwise type.
   This does not walk back `ADR-0004`: the user still supplies one deck they chose,
   and no field of decks is curated or browsed. The deck sites block cross-origin
-  browser calls, so the fetch goes through a proxy (`deck-proxy/`).
+  browser calls, so the fetch goes through a proxy (`ADR-0001`, `deck-proxy/`).
 
 ## Assumptions
 

--- a/src/App.css
+++ b/src/App.css
@@ -46,6 +46,19 @@
   flex-wrap: wrap;
 }
 
+.import-url {
+  display: flex;
+  gap: 0.5rem;
+  align-items: stretch;
+}
+.import-url .input {
+  flex: 1 1 auto;
+}
+.import-url .btn {
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
 .btn {
   background: var(--accent);
   color: #0b1020;

--- a/src/deck/DeckEditor.tsx
+++ b/src/deck/DeckEditor.tsx
@@ -1,6 +1,11 @@
 import { useMemo, useState } from "react";
 import { parseDecklist } from "../lib/decklist";
 import { SAMPLE_DECK } from "../lib/sampleDeck";
+import {
+  importDeck,
+  DeckImportError,
+  type ImportErrorKind,
+} from "../lib/deckImport";
 import type { SavedDeck } from "./model";
 import { deckToText } from "./model";
 import { useI18n } from "../i18n/I18nContext";
@@ -8,6 +13,15 @@ import { useI18n } from "../i18n/I18nContext";
 function newId(): string {
   return crypto.randomUUID();
 }
+
+const IMPORT_ERROR_KEY = {
+  "not-a-url": "import.errNotAUrl",
+  unsupported: "import.errUnsupported",
+  "no-id": "import.errNoId",
+  network: "import.errNetwork",
+  "not-found": "import.errNotFound",
+  empty: "import.errEmpty",
+} as const satisfies Record<ImportErrorKind, string>;
 
 /** Create or edit a named deck from pasted decklist text. */
 export function DeckEditor({
@@ -22,6 +36,27 @@ export function DeckEditor({
   const { t } = useI18n();
   const [name, setName] = useState(initial?.name ?? "");
   const [text, setText] = useState(initial ? deckToText(initial) : "");
+  const [url, setUrl] = useState("");
+  const [importing, setImporting] = useState(false);
+  const [importError, setImportError] = useState<string | null>(null);
+  const [importDone, setImportDone] = useState<string | null>(null);
+
+  async function handleImport() {
+    setImporting(true);
+    setImportError(null);
+    setImportDone(null);
+    try {
+      const deck = await importDeck(url);
+      setText(deckToText(deck));
+      setName((prev) => prev.trim() || deck.name);
+      setImportDone(t("import.done", { name: deck.name }));
+    } catch (err) {
+      const kind = err instanceof DeckImportError ? err.kind : "network";
+      setImportError(t(IMPORT_ERROR_KEY[kind]));
+    } finally {
+      setImporting(false);
+    }
+  }
 
   const parsed = useMemo(() => parseDecklist(text), [text]);
   const commanderCount = parsed.commanders.reduce((n, e) => n + e.quantity, 0);
@@ -44,6 +79,41 @@ export function DeckEditor({
   return (
     <section className="panel">
       <h2>{initial ? t("editor.editTitle") : t("editor.newTitle")}</h2>
+
+      <label className="field">
+        <span className="field__label">{t("import.label")}</span>
+        <div className="import-url">
+          <input
+            className="input"
+            type="url"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder={t("import.placeholder")}
+            spellCheck={false}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && url.trim() && !importing) {
+                e.preventDefault();
+                void handleImport();
+              }
+            }}
+          />
+          <button
+            type="button"
+            className="btn"
+            onClick={() => void handleImport()}
+            disabled={importing || url.trim() === ""}
+          >
+            {importing ? t("import.importing") : t("import.button")}
+          </button>
+        </div>
+        <p className="hint">{t("import.hint")}</p>
+        {importError && <p className="error">{importError}</p>}
+        {importDone && !importError && (
+          <p className="hint" style={{ color: "var(--good)" }}>
+            {importDone}
+          </p>
+        )}
+      </label>
 
       <label className="field">
         <span className="field__label">{t("editor.nameLabel")}</span>

--- a/src/deck/model.ts
+++ b/src/deck/model.ts
@@ -38,7 +38,7 @@ export function isHundredCards(deck: SavedDeck): boolean {
 }
 
 /** Serialize a deck back into paste-able decklist text (round-trips the parser). */
-export function deckToText(deck: SavedDeck): string {
+export function deckToText(deck: Pick<SavedDeck, "commanders" | "mainboard">): string {
   const line = (e: DecklistEntry) => `${e.quantity} ${e.name}`;
   const parts: string[] = [];
   if (deck.commanders.length > 0) {

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -52,6 +52,46 @@ export const messages = {
   "editor.cancel": { pt: "Cancelar", en: "Cancel" },
   "editor.loadSample": { pt: "Carregar exemplo", en: "Load example" },
 
+  "import.label": { pt: "Importar de uma URL", en: "Import from a URL" },
+  "import.placeholder": {
+    pt: "Cole uma URL de deck do Moxfield ou Archidekt",
+    en: "Paste a Moxfield or Archidekt deck URL",
+  },
+  "import.button": { pt: "Importar", en: "Import" },
+  "import.importing": { pt: "Importando…", en: "Importing…" },
+  "import.hint": {
+    pt: "Decks públicos ou não listados do Moxfield e Archidekt.",
+    en: "Public or unlisted decks from Moxfield and Archidekt.",
+  },
+  "import.done": {
+    pt: 'Importado "{name}" — revise e salve.',
+    en: 'Imported "{name}" — review and save.',
+  },
+  "import.errNotAUrl": {
+    pt: "Isso não é uma URL do Moxfield, Archidekt ou Ligamagic.",
+    en: "That's not a Moxfield, Archidekt, or Ligamagic URL.",
+  },
+  "import.errUnsupported": {
+    pt: "Decks do Ligamagic não podem ser importados automaticamente — abra o deck, exporte a lista e cole acima.",
+    en: "Ligamagic decks can't be imported automatically — open the deck, export the list, and paste it above.",
+  },
+  "import.errNoId": {
+    pt: "Não encontrei o id do deck nessa URL.",
+    en: "Couldn't find a deck id in that URL.",
+  },
+  "import.errNetwork": {
+    pt: "Não consegui acessar o deck. O proxy de importação pode estar fora do ar (veja deck-proxy/README).",
+    en: "Couldn't reach the deck. The import proxy may be down (see deck-proxy/README).",
+  },
+  "import.errNotFound": {
+    pt: "Deck não encontrado. Verifique se é público ou não listado.",
+    en: "Deck not found. Make sure it's public or unlisted.",
+  },
+  "import.errEmpty": {
+    pt: "Nenhuma carta encontrada nesse deck.",
+    en: "No cards found in that deck.",
+  },
+
   "detail.resolving": { pt: "Resolvendo cartas no Scryfall…", en: "Resolving cards on Scryfall…" },
   "detail.noneResolved": { pt: "Nenhuma carta resolvida. Confira a lista.", en: "No cards resolved. Check the list." },
   "detail.simulating": { pt: "Simulando aberturas…", en: "Simulating opening hands…" },

--- a/src/lib/__fixtures__/archidekt.json
+++ b/src/lib/__fixtures__/archidekt.json
@@ -1,0 +1,82 @@
+{
+  "name": "Fun With Fungus",
+  "categories": [
+    {
+      "name": "Commander",
+      "includedInDeck": true
+    },
+    {
+      "name": "Maybeboard",
+      "includedInDeck": false
+    }
+  ],
+  "cards": [
+    {
+      "quantity": 1,
+      "categories": [
+        "Commander"
+      ],
+      "card": {
+        "oracleCard": {
+          "name": "Thelon of Havenwood"
+        }
+      }
+    },
+    {
+      "quantity": 1,
+      "categories": null,
+      "card": {
+        "oracleCard": {
+          "name": "Mana Crypt"
+        }
+      }
+    },
+    {
+      "quantity": 1,
+      "categories": null,
+      "card": {
+        "oracleCard": {
+          "name": "Spread the Sickness"
+        }
+      }
+    },
+    {
+      "quantity": 1,
+      "categories": null,
+      "card": {
+        "oracleCard": {
+          "name": "Plaguemaw Beast"
+        }
+      }
+    },
+    {
+      "quantity": 1,
+      "categories": null,
+      "card": {
+        "oracleCard": {
+          "name": "Contagion Engine"
+        }
+      }
+    },
+    {
+      "quantity": 1,
+      "categories": null,
+      "card": {
+        "oracleCard": {
+          "name": "Contagion Clasp"
+        }
+      }
+    },
+    {
+      "quantity": 1,
+      "categories": [
+        "Maybeboard"
+      ],
+      "card": {
+        "oracleCard": {
+          "name": "Llanowar Elves"
+        }
+      }
+    }
+  ]
+}

--- a/src/lib/__fixtures__/moxfield-commander.json
+++ b/src/lib/__fixtures__/moxfield-commander.json
@@ -1,0 +1,25 @@
+{
+  "name": "Atraxa Superfriends",
+  "format": "commander",
+  "boards": {
+    "mainboard": {
+      "count": 2,
+      "cards": {
+        "aa1": { "quantity": 1, "card": { "name": "Sol Ring" } },
+        "aa2": { "quantity": 1, "card": { "name": "Arcane Signet" } }
+      }
+    },
+    "commanders": {
+      "count": 1,
+      "cards": {
+        "cc1": { "quantity": 1, "card": { "name": "Atraxa, Praetors' Voice" } }
+      }
+    },
+    "maybeboard": {
+      "count": 1,
+      "cards": {
+        "mm1": { "quantity": 1, "card": { "name": "Rhystic Study" } }
+      }
+    }
+  }
+}

--- a/src/lib/__fixtures__/moxfield.json
+++ b/src/lib/__fixtures__/moxfield.json
@@ -1,0 +1,24 @@
+{
+  "name": "CloudFlare Hammer",
+  "format": "modern",
+  "boards": {
+    "mainboard": {
+      "count": 60,
+      "cards": {
+        "EbPg6": { "quantity": 3, "card": { "name": "Plains" } },
+        "LzdO8": { "quantity": 1, "card": { "name": "Shadowspear" } },
+        "k9z24": { "quantity": 4, "card": { "name": "Colossus Hammer" } },
+        "EbJJ0": { "quantity": 4, "card": { "name": "Sigarda's Aid" } },
+        "YxQ6G": { "quantity": 4, "card": { "name": "Stoneforge Mystic" } }
+      }
+    },
+    "commanders": { "count": 0, "cards": {} },
+    "sideboard": {
+      "count": 4,
+      "cards": {
+        "YelzP": { "quantity": 1, "card": { "name": "Grafdigger's Cage" } },
+        "Y845w": { "quantity": 3, "card": { "name": "Spell Pierce" } }
+      }
+    }
+  }
+}

--- a/src/lib/deckImport.test.ts
+++ b/src/lib/deckImport.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import {
+  detectSource,
+  parseArchidekt,
+  parseMoxfield,
+  importDeck,
+  DeckImportError,
+  type FetchLike,
+} from "./deckImport";
+import archidektFixture from "./__fixtures__/archidekt.json";
+import moxfieldFixture from "./__fixtures__/moxfield.json";
+import moxfieldCommanderFixture from "./__fixtures__/moxfield-commander.json";
+
+function stubFetch(payload: unknown, ok = true, status = 200): FetchLike {
+  return async () => ({ ok, status, json: async () => payload });
+}
+
+const qty = (entries: { name: string; quantity: number }[], name: string) =>
+  entries.find((e) => e.name === name)?.quantity;
+
+describe("detectSource", () => {
+  it("recognizes each site by host, scheme-optional", () => {
+    expect(detectSource("https://www.moxfield.com/decks/abc123")).toBe("moxfield");
+    expect(detectSource("archidekt.com/decks/42-my-deck")).toBe("archidekt");
+    expect(detectSource("https://www.ligamagic.com.br/?view=dks/deck&id=99")).toBe(
+      "ligamagic",
+    );
+  });
+
+  it("returns null for non-deck URLs and junk", () => {
+    expect(detectSource("https://example.com/decks/1")).toBeNull();
+    expect(detectSource("not a url")).toBeNull();
+    expect(detectSource("")).toBeNull();
+  });
+});
+
+describe("parseArchidekt", () => {
+  const deck = parseArchidekt(archidektFixture);
+
+  it("reads the deck name and routes the Commander category", () => {
+    expect(deck.name).toBe("Fun With Fungus");
+    expect(deck.commanders.map((e) => e.name)).toEqual(["Thelon of Havenwood"]);
+  });
+
+  it("keeps mainboard cards with their quantities", () => {
+    expect(qty(deck.mainboard, "Mana Crypt")).toBe(1);
+    expect(deck.mainboard.some((e) => e.name === "Thelon of Havenwood")).toBe(false);
+  });
+
+  it("drops cards in a not-included category (Maybeboard)", () => {
+    const all = [...deck.commanders, ...deck.mainboard].map((e) => e.name);
+    expect(all).not.toContain("Llanowar Elves");
+  });
+});
+
+describe("parseMoxfield", () => {
+  it("reads a real deck's mainboard and ignores the sideboard", () => {
+    const deck = parseMoxfield(moxfieldFixture);
+    expect(deck.name).toBe("CloudFlare Hammer");
+    expect(qty(deck.mainboard, "Plains")).toBe(3);
+    expect(qty(deck.mainboard, "Stoneforge Mystic")).toBe(4);
+    const all = [...deck.commanders, ...deck.mainboard].map((e) => e.name);
+    expect(all).not.toContain("Spell Pierce"); // sideboard
+    expect(all).not.toContain("Grafdigger's Cage"); // sideboard
+  });
+
+  it("routes the commanders board and ignores the maybeboard", () => {
+    const deck = parseMoxfield(moxfieldCommanderFixture);
+    expect(deck.commanders.map((e) => e.name)).toEqual(["Atraxa, Praetors' Voice"]);
+    expect(deck.mainboard.map((e) => e.name).sort()).toEqual([
+      "Arcane Signet",
+      "Sol Ring",
+    ]);
+    const all = [...deck.commanders, ...deck.mainboard].map((e) => e.name);
+    expect(all).not.toContain("Rhystic Study"); // maybeboard
+  });
+});
+
+describe("importDeck", () => {
+  it("fetches and parses an Archidekt URL", async () => {
+    const deck = await importDeck(
+      "https://archidekt.com/decks/1/fun",
+      stubFetch(archidektFixture),
+    );
+    expect(deck.source).toBe("archidekt");
+    expect(deck.name).toBe("Fun With Fungus");
+    expect(deck.commanders).toHaveLength(1);
+  });
+
+  it("rejects Ligamagic as unsupported", async () => {
+    await expect(
+      importDeck("https://www.ligamagic.com.br/?view=dks/deck&id=99"),
+    ).rejects.toMatchObject({ kind: "unsupported", source: "ligamagic" });
+  });
+
+  it("rejects an unrecognized URL", async () => {
+    await expect(importDeck("https://example.com/x")).rejects.toBeInstanceOf(
+      DeckImportError,
+    );
+  });
+
+  it("maps a 404 to not-found", async () => {
+    await expect(
+      importDeck("https://moxfield.com/decks/nope", stubFetch(null, false, 404)),
+    ).rejects.toMatchObject({ kind: "not-found" });
+  });
+
+  it("flags an empty deck", async () => {
+    await expect(
+      importDeck("https://moxfield.com/decks/empty", stubFetch({ name: "x", boards: {} })),
+    ).rejects.toMatchObject({ kind: "empty" });
+  });
+});

--- a/src/lib/deckImport.ts
+++ b/src/lib/deckImport.ts
@@ -1,0 +1,190 @@
+import type { DecklistEntry } from "./types";
+
+export type DeckSource = "moxfield" | "archidekt" | "ligamagic";
+
+/** A decklist pulled from a deck-hosting URL, ready to feed the editor. */
+export interface ImportedDeck {
+  source: DeckSource;
+  name: string;
+  commanders: DecklistEntry[];
+  mainboard: DecklistEntry[];
+}
+
+export type ImportErrorKind =
+  | "not-a-url"
+  | "unsupported"
+  | "no-id"
+  | "network"
+  | "not-found"
+  | "empty";
+
+export class DeckImportError extends Error {
+  constructor(
+    readonly kind: ImportErrorKind,
+    readonly source?: DeckSource,
+  ) {
+    super(kind);
+    this.name = "DeckImportError";
+  }
+}
+
+/** Minimal fetch shape, so tests can inject a stub (mirrors scryfall.ts). */
+export type FetchLike = (
+  input: string,
+) => Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }>;
+
+const DEFAULT_PROXY = "https://api.allorigins.win/raw?url=";
+
+/**
+ * Deck sites block cross-origin browser requests, so a static build routes the
+ * fetch through a proxy. `VITE_DECK_PROXY` overrides the default (set it to your
+ * own deck-proxy worker for reliability, or to "" to fetch directly).
+ */
+function proxied(url: string): string {
+  const configured = import.meta.env.VITE_DECK_PROXY as string | undefined;
+  const base = configured === undefined ? DEFAULT_PROXY : configured.trim();
+  return base ? base + encodeURIComponent(url) : url;
+}
+
+function normalizeUrl(raw: string): URL | null {
+  const trimmed = raw.trim();
+  if (trimmed === "") return null;
+  try {
+    return new URL(/^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`);
+  } catch {
+    return null;
+  }
+}
+
+/** Which deck site a URL points at, or null if it's not one we recognize. */
+export function detectSource(raw: string): DeckSource | null {
+  const url = normalizeUrl(raw);
+  if (!url) return null;
+  const host = url.hostname.toLowerCase();
+  if (host.includes("moxfield")) return "moxfield";
+  if (host.includes("archidekt")) return "archidekt";
+  if (host.includes("ligamagic")) return "ligamagic";
+  return null;
+}
+
+// ── Moxfield ────────────────────────────────────────────────────────────────
+
+interface MoxfieldCard {
+  quantity?: number;
+  card?: { name?: string };
+}
+interface MoxfieldResponse {
+  name?: string;
+  boards?: Record<string, { cards?: Record<string, MoxfieldCard> }>;
+}
+
+function moxfieldEntries(board?: { cards?: Record<string, MoxfieldCard> }): DecklistEntry[] {
+  const cards = board?.cards ?? {};
+  const entries: DecklistEntry[] = [];
+  for (const c of Object.values(cards)) {
+    const name = c.card?.name;
+    if (name) entries.push({ quantity: c.quantity ?? 1, name });
+  }
+  return entries;
+}
+
+export function parseMoxfield(json: unknown): Omit<ImportedDeck, "source"> {
+  const d = json as MoxfieldResponse;
+  return {
+    name: d.name?.trim() || "Moxfield deck",
+    commanders: moxfieldEntries(d.boards?.commanders),
+    mainboard: moxfieldEntries(d.boards?.mainboard),
+  };
+}
+
+// ── Archidekt ───────────────────────────────────────────────────────────────
+
+interface ArchidektCard {
+  quantity?: number;
+  categories?: string[] | null;
+  card?: { oracleCard?: { name?: string } };
+}
+interface ArchidektResponse {
+  name?: string;
+  categories?: Array<{ name?: string; includedInDeck?: boolean }> | null;
+  cards?: ArchidektCard[];
+}
+
+const ARCHIDEKT_COMMANDER = "Commander";
+
+export function parseArchidekt(json: unknown): Omit<ImportedDeck, "source"> {
+  const d = json as ArchidektResponse;
+  const excluded = new Set(
+    (d.categories ?? [])
+      .filter((c) => c.includedInDeck === false && c.name)
+      .map((c) => c.name as string),
+  );
+  const commanders: DecklistEntry[] = [];
+  const mainboard: DecklistEntry[] = [];
+  for (const c of d.cards ?? []) {
+    const name = c.card?.oracleCard?.name;
+    if (!name) continue;
+    const cats = c.categories ?? [];
+    if (cats.some((cat) => excluded.has(cat))) continue;
+    const entry = { quantity: c.quantity ?? 1, name };
+    if (cats.includes(ARCHIDEKT_COMMANDER)) commanders.push(entry);
+    else mainboard.push(entry);
+  }
+  return { name: d.name?.trim() || "Archidekt deck", commanders, mainboard };
+}
+
+// ── Orchestration ─────────────────────────────────────────────────────────────
+
+function apiUrlFor(source: DeckSource, url: URL): string | null {
+  if (source === "moxfield") {
+    const id = url.pathname.match(/\/decks\/(?:all\/)?([A-Za-z0-9_-]+)/)?.[1];
+    return id ? `https://api.moxfield.com/v3/decks/all/${id}` : null;
+  }
+  if (source === "archidekt") {
+    const id = url.pathname.match(/\/(?:api\/)?decks\/(\d+)/)?.[1];
+    return id ? `https://archidekt.com/api/decks/${id}/` : null;
+  }
+  return null;
+}
+
+/**
+ * Fetch a deck from a Moxfield or Archidekt URL and return its commanders and
+ * mainboard. Ligamagic gates its deck data behind a page session, so it can't
+ * be imported from a static client; it is detected only to give a clear message.
+ */
+export async function importDeck(
+  rawUrl: string,
+  fetchImpl: FetchLike = fetch,
+): Promise<ImportedDeck> {
+  const source = detectSource(rawUrl);
+  if (!source) throw new DeckImportError("not-a-url");
+  if (source === "ligamagic") throw new DeckImportError("unsupported", source);
+
+  const url = normalizeUrl(rawUrl)!;
+  const apiUrl = apiUrlFor(source, url);
+  if (!apiUrl) throw new DeckImportError("no-id", source);
+
+  let res: Awaited<ReturnType<FetchLike>>;
+  try {
+    res = await fetchImpl(proxied(apiUrl));
+  } catch {
+    throw new DeckImportError("network", source);
+  }
+  if (!res.ok) {
+    throw new DeckImportError(res.status === 404 ? "not-found" : "network", source);
+  }
+
+  let json: unknown;
+  try {
+    json = await res.json();
+  } catch {
+    throw new DeckImportError("network", source);
+  }
+
+  const parsed =
+    source === "moxfield" ? parseMoxfield(json) : parseArchidekt(json);
+  if (parsed.commanders.length + parsed.mainboard.length === 0) {
+    throw new DeckImportError("empty", source);
+  }
+  return { source, ...parsed };
+}


### PR DESCRIPTION
## What

Adds a URL importer to the deck editor: paste a public/unlisted **Moxfield** or **Archidekt** deck URL and its commander + cards fill the decklist, ready to review and save. It reuses the existing paste → parse → save flow (the import just produces the same decklist text a user would paste), so the coverage check, warnings, and round-trip all work unchanged.


## The proxy constraint (please read)

This app is a **static GitHub Pages site with no backend**, and all three sites block direct cross-origin browser fetches. I verified this empirically:

| Site | Data | Browser fetch from our origin |
|------|------|-------------------------------|
| **Archidekt** | clean JSON API | blocked — CORS pinned to `localhost:3000` |
| **Moxfield** | JSON API, but Cloudflare bot-gated | blocked — 403 to non-approved clients |
| **Ligamagic** | cards load via JS + a per-request session token | blocked — no stable URL to fetch |

So a proxy is unavoidable. The client routes through `VITE_DECK_PROXY` (a `?url=`-style base):

- **Default (zero-config):** a public proxy (`api.allorigins.win`) — fine to try it out, but rate-limited and occasionally down.
- **Recommended:** the bundled **Cloudflare Worker** in [`deck-proxy/`](deck-proxy/README.md). `wrangler deploy`, then build with `VITE_DECK_PROXY="https://<worker>.workers.dev/?url="`.

## Per-site status

- **Archidekt** — works fully, no extra setup. Verified end-to-end (real deck → proxy → editor).
- **Moxfield** — adapter is done and unit-tested against a real v3 response, but Moxfield only answers requests carrying a **User-Agent they've approved** (email `support@moxfield.com`). Without the owned worker + approved UA, Moxfield imports return a network error. Their ToS also prohibits unapproved scraping — flagging so you can decide whether to pursue approval.
- **Ligamagic** — **not auto-importable.** Its deck contents load through a page session with a per-request token (the direct endpoints return "access denied"), so there's no stable URL a static-site proxy can fetch. The URL is recognized and the author is told to export on Ligamagic and paste the list.

## Decisions I made (flagging since you were away)

1. **Versioned under `[Unreleased]`**, no `package.json` bump — to avoid colliding with the sidebar PR (#4) which claims `0.1.3`. Stamp a version at merge.
2. **Didn't ship a fragile Ligamagic scraper.** Reverse-engineering the token/session flow would be brittle and I couldn't verify it; a clear "export and paste" message is honest and stable. Left as an open question in the feature spec.
3. **Kept a public-proxy default** so the feature isn't inert for a fresh clone, while shipping the worker as the real path.

## Verification

- 12 new unit tests over **real captured API responses** (Archidekt + Moxfield fixtures) — name, commander routing, quantities, sideboard/maybeboard exclusion, URL detection, and every error path. Full suite: 73 passing.
- **Live E2E**: ran the worker's logic as a local proxy, imported a real Archidekt deck through the full UI (commander correctly routed, 17 cards). Confirmed the Moxfield (Cloudflare) and Ligamagic (unsupported) messages render.
- typecheck / lint / build / `domainbook check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
