### PR TITLE
Add jscpd duplication check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,5 +17,7 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run typecheck
+      - name: Duplication (jscpd)
+        run: npm run duplication
       - run: npm test
       - run: npm run build

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,0 +1,21 @@
+{
+  "_comment": "Duplication floor — set to current ceiling + margin. Tighten over time. Paths are passed positionally on the CLI (npm run duplication) because jscpd's `path` config field is unreliable.",
+  "threshold": 7,
+  "reporters": ["console", "threshold"],
+  "absolute": true,
+  "gitignore": true,
+  "ignore": [
+    "**/node_modules/**",
+    "**/dist/**",
+    "**/build/**",
+    "**/coverage/**",
+    "**/__tests__/**",
+    "**/__fixtures__/**",
+    "**/*.{test,spec}.{ts,tsx}",
+    "**/test/**",
+    ".claude/**"
+  ],
+  "min-tokens": 60,
+  "min-lines": 6,
+  "format": ["typescript", "tsx"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "eslint-plugin-react-hooks": "^5.0.0",
         "eslint-plugin-react-refresh": "^0.4.14",
         "globals": "^15.12.0",
+        "jscpd": "^5.0.12",
         "typescript": "^5.6.3",
         "typescript-eslint": "^8.15.0",
         "vite": "^5.4.11",
@@ -2797,6 +2798,111 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jscpd": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/jscpd/-/jscpd-5.0.15.tgz",
+      "integrity": "sha512-PJF3ALlPVJGiMoCtSHg6Ln3/dnRVd27sD/UTUv62MAS5I0jdhvqI0x0p8D1LP8xJ35GLTgHzCMSQvjoa/JNZkg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jscpd": "run-jscpd.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "jscpd-darwin-arm64": "5.0.15",
+        "jscpd-darwin-x64": "5.0.15",
+        "jscpd-linux-arm64-gnu": "5.0.15",
+        "jscpd-linux-x64-gnu": "5.0.15",
+        "jscpd-linux-x64-musl": "5.0.15",
+        "jscpd-windows-x64-msvc": "5.0.15"
+      }
+    },
+    "node_modules/jscpd-darwin-arm64": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/jscpd-darwin-arm64/-/jscpd-darwin-arm64-5.0.15.tgz",
+      "integrity": "sha512-7UIRxKkvqN7bVIl2nXYsTOs7a2M6Y1Ll58KehquQbI6gUC3I7AAd/vz2HNWIdo+f5lJB0tiN1E9B/i6CUM4WHQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/jscpd-darwin-x64": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/jscpd-darwin-x64/-/jscpd-darwin-x64-5.0.15.tgz",
+      "integrity": "sha512-ifknlGR2xW9yZ5BCeUBkBOrOFBAFMQmugpzFnx1y8/BDve0pyBLjxIOVnN/bqeqLDV+sd/zxkx5Gf/xD9UlRKA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/jscpd-linux-arm64-gnu": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/jscpd-linux-arm64-gnu/-/jscpd-linux-arm64-gnu-5.0.15.tgz",
+      "integrity": "sha512-JrlE0Nk2NRt9EmGD+5ZjMI0il5t/zxj3uwcintnugJumRmbKy2ncr2MALJLeulUTHLT7uYMEveLK2b79DLtDAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/jscpd-linux-x64-gnu": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/jscpd-linux-x64-gnu/-/jscpd-linux-x64-gnu-5.0.15.tgz",
+      "integrity": "sha512-Hb37UrME4X3tAyw4EYNTuSOeet0uq2UYwyeWUphdjTY8Z9GB4qzniDyCClvNjzAbz9EZ47LXHYvZSP6hlzhgIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/jscpd-linux-x64-musl": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/jscpd-linux-x64-musl/-/jscpd-linux-x64-musl-5.0.15.tgz",
+      "integrity": "sha512-dFHCSfL+h3irvmkRCn8MojdA5R1NuUPswVUrr3vrCI+3v5VjBBrERWfq1rpnFdKOgK7T/4Fvkj4L04vnWPTRiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/jscpd-windows-x64-msvc": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/jscpd-windows-x64-msvc/-/jscpd-windows-x64-msvc-5.0.15.tgz",
+      "integrity": "sha512-OJ5F5qePxS9EVyw5pdCOAAR7SRm02LJyCMAHXB5bSUfo4mOZrEKkhgO+EUHgK4p7Blpovw9acpgf1/R2o1Z4Ig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/jsesc": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc -b --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
+    "duplication": "jscpd src",
     "fetch-engine": "bash scripts/fetch-engine.sh"
   },
   "dependencies": {
@@ -29,6 +30,7 @@
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.14",
     "globals": "^15.12.0",
+    "jscpd": "^5.0.12",
     "typescript": "^5.6.3",
     "typescript-eslint": "^8.15.0",
     "vite": "^5.4.11",


### PR DESCRIPTION
## What

Adds [jscpd](https://github.com/kucherenko/jscpd) copy/paste detection and runs it as a step in the CI workflow, so code duplication is validated on every push and pull request.

## Settings

Mirrors the jscpd configuration from `tournament-brackets-management`, adapted to this repo's single-package `src/` layout:

- **Threshold:** 7% (a floor to tighten over time — CI fails if duplication climbs above it)
- **Detection:** min 60 tokens / 6 lines, `typescript` + `tsx` formats
- **Reporters:** `console` + `threshold` (the `threshold` reporter is what fails the build)
- **Ignores:** `node_modules`, build output, coverage, tests, fixtures, `.claude/`
- **Target:** `jscpd src` (paths passed positionally via `npm run duplication`)

## Changes

- `.jscpd.json` — the duplication config.
- `package.json` — `jscpd` devDependency and a `duplication` script.
- `.github/workflows/ci.yml` — a `Duplication (jscpd)` step after typecheck.

## Verification

- `npm run duplication` reports **0.10%** duplication (1 small clone: an 8-line overlap between `src/lib/scryfall.ts` and `src/lib/scryfallCache.ts`) — well under the 7% floor, so the check passes.
- `lint`, `typecheck`, `test` (73), and `build` all still pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rot8XhXDXYvEQJjE5Q9ACX)_