### PR TITLE
fix(pages): deploy engine assets + ship card DB gzipped

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,6 +26,12 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
+      # Fetch the vendored phase-rs engine assets (WASM + card database) into
+      # public/engine/ so they get bundled into dist/. They are git-ignored and
+      # not present in a fresh checkout, so without this the deployed site 404s
+      # on engine_wasm_bg.wasm and the browser reports
+      # "Failed to execute 'compile' on 'WebAssembly': HTTP status code is not ok".
+      - run: npm run fetch-engine
       - run: npm run build
       # Reads the Pages config. Pages must already be enabled with
       # "GitHub Actions" as the source (Settings → Pages) — enabling it via

--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@ npm-debug.log*
 
 # phase-rs engine runtime assets (large; fetched via scripts/fetch-engine, not committed)
 public/engine/card-data.json
+public/engine/card-data.json.gz
 public/engine/engine_wasm_bg.wasm

--- a/README.md
+++ b/README.md
@@ -49,11 +49,13 @@ npm run lint      # lint
 
 ### Engine assets
 
-The compiled WASM (`engine_wasm_bg.wasm`, ~28 MiB) and card database
-(`card-data.json`, ~95 MiB) are too large to commit, so they are git-ignored and
+The compiled WASM (`engine_wasm_bg.wasm`, ~28 MiB) and card database (fetched as
+`card-data.json`, ~95 MiB) are too large to commit, so they are git-ignored and
 fetched by `scripts/fetch-engine.sh` (run via `npm run fetch-engine`) into
-`public/engine/`. The wasm-bindgen glue that pairs with them
-(`src/engine/vendor/engine_wasm.js`) **is** committed.
+`public/engine/`. The card database is stored gzipped as `card-data.json.gz`
+(~16 MiB) — the raw JSON exceeds GitHub Pages' per-file limit, so the engine
+worker decompresses it at runtime via `DecompressionStream`. The wasm-bindgen
+glue that pairs with them (`src/engine/vendor/engine_wasm.js`) **is** committed.
 
 The fetch script pins the phase-rs **v0.55.0** web build. Those CDN URLs are
 content-hashed and may eventually 404 as phase-rs ships new builds; if that

--- a/domainbook/domains/simulation/changelog.md
+++ b/domainbook/domains/simulation/changelog.md
@@ -7,3 +7,10 @@ release was pulled, holding Added, Changed, Deprecated, Removed, Fixed or
 Security as H3s, each of them a bullet list.
 
 ## [Unreleased]
+
+### Changed
+
+- The `engine adapter` now loads the card database gzipped
+  (`card-data.json.gz`) and inflates it at runtime via `DecompressionStream`,
+  cutting the download from ~100 MB to ~16 MB and keeping the asset under
+  GitHub Pages' per-file limit.

--- a/scripts/fetch-engine.sh
+++ b/scripts/fetch-engine.sh
@@ -3,6 +3,10 @@
 # commit: the compiled WASM (~28 MiB) and the card database (~95 MiB). These
 # land in public/engine/ where the app loads them at runtime.
 #
+# The card database is stored gzipped (card-data.json.gz, ~16 MiB): the raw
+# JSON exceeds GitHub Pages' ~100 MB per-file limit and is slow to download,
+# so the engine worker decompresses it at runtime via DecompressionStream.
+#
 # Pinned to the phase-rs v0.55.0 web build. The wasm-bindgen glue
 # (src/engine/vendor/engine_wasm.js) is committed and must match this WASM.
 #
@@ -34,5 +38,10 @@ if [ "$size" -lt 10000000 ]; then
   echo "ERROR: card-data.json looks too small ($size bytes); download failed." >&2
   exit 1
 fi
+
+# Compress for the web and drop the raw copy (see header): produces
+# card-data.json.gz and removes card-data.json.
+echo "Compressing → $DEST/card-data.json.gz"
+gzip -9 -f "$DEST/card-data.json"
 
 echo "Done. Engine assets ready in public/engine/."

--- a/src/engine/engine.worker.ts
+++ b/src/engine/engine.worker.ts
@@ -30,9 +30,27 @@ async function ensureStarted(): Promise<void> {
   started = true;
 }
 
+// The card database ships gzipped (~16 MiB) to stay under GitHub Pages'
+// per-file limit and keep the download small. Fetch and inflate it here.
+// If a host transparently decodes the gzip (Content-Encoding), the bytes are
+// already plain JSON — detected via the gzip magic — so we use them directly.
+async function fetchCardData(): Promise<string> {
+  const res = await fetch(`${BASE}engine/card-data.json.gz`);
+  if (!res.ok) {
+    throw new Error(`card-data fetch failed: HTTP ${res.status}`);
+  }
+  const bytes = new Uint8Array(await res.arrayBuffer());
+  const isGzip = bytes.length > 2 && bytes[0] === 0x1f && bytes[1] === 0x8b;
+  if (!isGzip) return new TextDecoder().decode(bytes);
+  const stream = new Response(bytes).body!.pipeThrough(
+    new DecompressionStream("gzip"),
+  );
+  return await new Response(stream).text();
+}
+
 async function ensureDb(): Promise<void> {
   if (dbLoaded) return;
-  const text = await (await fetch(`${BASE}engine/card-data.json`)).text();
+  const text = await fetchCardData();
   load_card_database(text);
   const reg = getFormatRegistry();
   const list = Array.isArray(reg) ? reg : [];


### PR DESCRIPTION
## Problem

Starting a game on the deployed site (https://rafaelaugustscherer.github.io/commander-playtester/) fails on every device with:

> Failed to execute 'compile' on 'WebAssembly': HTTP status code is not ok.

## Root cause

The phase-rs engine WASM (`public/engine/engine_wasm_bg.wasm`) and card database (`public/engine/card-data.json`) are large binaries that are **git-ignored** and downloaded at build time by `scripts/fetch-engine.sh` (`npm run fetch-engine`).

The Pages deploy workflow (`.github/workflows/pages.yml`) ran only `npm ci` → `npm run build` and never fetched these assets. So `public/engine/` was empty during CI, the WASM was never copied into `dist/`, and it 404s on the live site. The engine worker's `init()` call runs `WebAssembly` compile against that 404, producing the error. Local dev works only because the assets were fetched onto the developer's machine previously.

## Changes

**1. Fetch engine assets during the Pages deploy** (`pages.yml`)
Added an `npm run fetch-engine` step before `npm run build` so the WASM + card database are present and get bundled into `dist/`. This is the actual bug fix.

**2. Ship the card database gzipped** (`fetch-engine.sh`, `engine.worker.ts`)
The raw `card-data.json` is ~100 MB — right at GitHub Pages' per-file limit and a slow first load, especially on mobile. It's now stored as `card-data.json.gz` (~16 MB) and decompressed at runtime in the worker via the browser-native `DecompressionStream`:
- `fetch-engine.sh` gzips the downloaded database and keeps only the `.gz`.
- The worker fetches `card-data.json.gz`, checks the gzip magic bytes (so a host that transparently decodes the encoding still works), inflates, and loads the JSON.
- `.gitignore` and `README.md` updated for the new artifact.

Result: ~6× smaller card-DB download and the deploy stays comfortably under the file limit.

## Verification

- Pinned CDN asset URLs return `200` with correct MIME types.
- `npm run fetch-engine && npm run build` produces `dist/engine/engine_wasm_bg.wasm` (~29 MB) and `dist/engine/card-data.json.gz` (~16 MB), with no raw 100 MB file.
- Verified the `.gz` inflates via `DecompressionStream` to the full JSON and `JSON.parse`s (Node 20, same API as the browser).
- `npm run typecheck`, `npm run lint`, and `npm run test` (73 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4ezWLjHQGR1xjCy6v8QsY