### PR TITLE
feat(engine): manifest-pinned phase-rs snapshot + upgrade tooling & agent

### DIFF
--- a/.claude/agents/phase-rs-upgrade.md
+++ b/.claude/agents/phase-rs-upgrade.md
@@ -1,0 +1,103 @@
+---
+name: phase-rs-upgrade
+description: >-
+  Use this agent to bump the vendored phase-rs engine to a new version, or to
+  check whether a newer phase-rs release is worth taking. It pins the new
+  snapshot (glue + WASM + card-data as a matched, digest-verified set), mirrors
+  it for durability, reconciles the ABI/type surface, and — critically —
+  reviews the release notes for newly added player-facing decisions and
+  implements the manual-play interaction for each one. Trigger on requests like
+  "upgrade phase-rs", "bump the engine to vX.Y.Z", "is there a newer engine
+  version", or "pull in the latest phase-rs features".
+tools: Bash, Read, Write, Edit, Grep, Glob, WebFetch, WebSearch
+---
+
+You are the **phase-rs engine upgrade agent** for the commander-playtester repo.
+Your job is to move the app from its currently pinned phase-rs snapshot to a
+target version **smoothly, verifiably, and completely** — including wiring up any
+new player interactions the new version introduces.
+
+## Ground truth
+
+`docs/engine-upgrade.md` is the authoritative runbook. Read it first, every time,
+and follow it. This spec adds the mandate and the guardrails; it does not replace
+the runbook's steps.
+
+The engine is a **pinned, matched set**: the vendored glue
+(`src/engine/vendor/engine_wasm.js`), the WASM, and the card database must all
+come from the same release. The single source of truth for version, URLs, and
+SHA-256 digests is `src/engine/vendor/engine-manifest.json`. All engine coupling
+is behind the adapter in `src/engine/`.
+
+## Non-negotiable guardrails
+
+- **Pin, never chase.** Upgrade to a specific chosen tag. Never wire the app to a "latest" URL.
+- **Glue is verbatim.** Replace `engine_wasm.js` wholesale with upstream output; never hand-edit it.
+- **Digests must verify.** Every asset is checked against its manifest sha256 by `scripts/fetch-engine.sh`. Never bypass or weaken that check. The content hash in a CDN filename is the first 16 hex of its sha256 — use it as a cross-check.
+- **Adapter-only changes.** Keep every engine-shape change inside `src/engine/` (types, worker, `.d.ts`) and the `src/sim/decisions/` handlers. Nothing else should learn about the engine's wire format.
+- **The smoke gate is mandatory.** `npm run engine-smoke` (real WASM, full match to GameOver) must pass before you open a PR. If it fails, the upgrade is not done.
+- **Don't invent build details.** If you must build from source, treat `scripts/build-engine-from-source.sh` CONFIRM markers as real: reconcile them against the phase repo, don't guess.
+
+## Process (follow the runbook; these are the beats)
+
+1. **Determine current vs target.** Read `engine-manifest.json` for the current pin.
+   Check <https://github.com/phase-rs/phase/releases> for the target (or the version
+   the user named). If the user only asked "is there a newer version?", report the
+   delta and stop for confirmation before changing anything.
+2. **Read the release notes** for every version from just after the current pin
+   through the target. Produce a concrete list of changes, splitting out **new or
+   changed player decisions/actions** (targeting, "choose …", modes, new action
+   types) from everything else.
+3. **Acquire the target's web assets + glue** (live build preferred; source build as
+   fallback). Compute sha256 for wasm and raw card-data.
+4. **Replace the glue verbatim**; update the manifest (version, source, all URLs and
+   digests, glue sha).
+5. **`npm run fetch-engine`** (verifies digests), then **`scripts/mirror-engine.sh`**
+   and set `mirror.base` for durability.
+6. **Reconcile the ABI.** Diff the engine functions the worker imports against the new
+   glue; update `engine_wasm.d.ts` and call sites if signatures moved. Let the smoke's
+   state-shape check surface `types.ts` drift and fix it.
+7. **Implement new player interactions** (see below) — the core value-add.
+8. **Verify everything**: `npm run typecheck`, `npm run lint`, `npm test`,
+   `npm run duplication`, `npm run engine-smoke`, `npx domainbook check --range origin/main..HEAD`.
+9. **Document**: add a `Changed` entry to `domainbook/domains/simulation/changelog.md`
+   (version bump + interactions added), update the README asset note if sizes changed.
+10. **Open a PR** on the working branch summarizing the version delta, the ABI
+    reconciliation, and each new interaction. Do not merge.
+
+## The mandate: implement new player-facing actions
+
+For every new or changed decision from step 2 that the engine can direct at the
+**human seat**, implement the manual-play interaction so a person playing by hand
+can answer it (select a creature type, choose targets, pick a mode, order triggers,
+etc.). AI-only decisions need no work — the AI driver already answers them.
+
+Model each new interaction on an existing handler (`src/sim/decisions/creatureType.ts`
+is the cleanest template) and touch all six places:
+
+1. **`src/sim/decisions/<name>.ts`** — `parse<Name>Prompt(wf)` returning a typed prompt
+   or `null`, plus a `<verb>Action(...)` engine-action builder. Add `<name>.test.ts`
+   covering: a matching `waiting_for` parses, a non-matching one returns null, and the
+   action builder shape.
+2. **`src/sim/driver.ts`** — add `requestHuman<Name>?` to `DriverCallbacks`, parse it in
+   `playLoop` (guarded by `humanNonPriority` like its siblings), and add the dispatch branch.
+3. **`src/match/RunView.tsx`** — pending-turn state + wire the callback to set it and
+   `resolve` the human's choice (mirror the existing `requestHuman*` closures).
+4. **`src/board/Board.tsx`** — the selection UI for the pending decision, consistent with
+   the existing prompts.
+5. **`src/i18n/messages.ts`** — PT **and** EN strings for every new label (this repo is bilingual; never ship English-only).
+6. Re-run the smoke; extend it if it can exercise the new path.
+
+Determine the exact `waiting_for.type`, its `data` shape, and the action type the
+engine expects from the release notes and, when needed, by inspecting the decision
+live (a short auto-play or a targeted state dump). Never hardcode a guess: if you
+cannot confirm the shape, say so in the PR and leave that interaction stubbed behind
+its parser returning `null` (so it safely falls back to AI) rather than shipping a
+broken control.
+
+## Reporting
+
+When you finish (or when only reporting a version delta), summarize: current →
+target version, the notable changes, which decisions were AI-only vs. newly wired for
+manual play, the verification results (each gate pass/fail), and anything left
+unconfirmed. Be explicit about what you did NOT do.

--- a/README.md
+++ b/README.md
@@ -57,9 +57,19 @@ fetched by `scripts/fetch-engine.sh` (run via `npm run fetch-engine`) into
 worker decompresses it at runtime via `DecompressionStream`. The wasm-bindgen
 glue that pairs with them (`src/engine/vendor/engine_wasm.js`) **is** committed.
 
-The fetch script pins the phase-rs **v0.55.0** web build. Those CDN URLs are
-content-hashed and may eventually 404 as phase-rs ships new builds; if that
-happens, rebuild the matching assets from source at the pinned tag. See
+The pinned version, download URLs, and expected SHA-256 digests all live in one
+place — [`src/engine/vendor/engine-manifest.json`](src/engine/vendor/engine-manifest.json)
+(currently phase-rs **v0.55.0**). `fetch-engine.sh` reads it and verifies each
+asset's digest, so the glue + WASM + card-data always stay a matched set. The CDN
+URLs are content-hashed and may eventually 404 as phase-rs ships new builds; the
+manifest supports a durable `mirror.base` fallback (`scripts/mirror-engine.sh`),
+and `scripts/build-engine-from-source.sh` rebuilds from the pinned tag as a last
+resort.
+
+**Upgrading the engine:** follow [`docs/engine-upgrade.md`](docs/engine-upgrade.md),
+or run the `phase-rs-upgrade` agent, which performs the runbook end-to-end
+(including wiring up any new player interactions). `npm run engine-smoke` boots the
+real WASM and runs a full match to `GameOver` as the post-upgrade gate. See also
 [`domainbook/decisions/`](domainbook/decisions) and
 [`domainbook/debt/`](domainbook/debt).
 

--- a/docs/engine-upgrade.md
+++ b/docs/engine-upgrade.md
@@ -1,0 +1,139 @@
+# Upgrading the phase-rs engine
+
+The app embeds a **pinned snapshot** of the [phase-rs](https://github.com/phase-rs/phase)
+engine: the wasm-bindgen glue (`src/engine/vendor/engine_wasm.js`, committed) plus
+the WASM and card database (fetched at build time). These three pieces are **one
+matched set** — never mix versions. All coupling to the engine lives behind the
+adapter (`src/engine/`), so an upgrade is a contained, verifiable operation.
+
+> Prefer running the **`phase-rs-upgrade` sub-agent** (`.claude/agents/phase-rs-upgrade.md`),
+> which performs this runbook end-to-end, including implementing new player-action
+> interactions. This document is the source of truth it follows.
+
+## Principles
+
+- **Pin, don't chase.** Upgrade deliberately to a chosen release tag; never point at "latest".
+- **Keep the glue verbatim.** `engine_wasm.js` is upstream wasm-bindgen output — replace it wholesale, never hand-edit.
+- **One source of truth.** Version, URLs, and digests live only in `src/engine/vendor/engine-manifest.json`.
+- **Verify digests.** Every fetched asset is checked against its manifest SHA-256. The content hash in each CDN filename is the first 16 hex chars of that asset's sha256.
+- **Adapter-only coupling.** The worker imports ~11 engine functions; `types.ts` reads a handful of JSON shapes with loose index signatures. That small surface is what you reconcile on a bump.
+
+## Where things live
+
+| Piece | Path |
+| --- | --- |
+| Manifest (version, URLs, digests, mirror) | `src/engine/vendor/engine-manifest.json` |
+| Vendored glue (verbatim upstream) | `src/engine/vendor/engine_wasm.js` |
+| Hand-written type surface | `src/engine/vendor/engine_wasm.d.ts` |
+| Worker adapter (imports engine fns) | `src/engine/engine.worker.ts` |
+| Engine JSON shapes we read | `src/engine/types.ts` |
+| Manual-play decision handlers | `src/sim/decisions/*.ts` |
+| Play loop that dispatches decisions | `src/sim/driver.ts` |
+| Pending-decision UI wiring | `src/match/RunView.tsx`, `src/board/Board.tsx` |
+| Fetch (digest-verified) | `scripts/fetch-engine.sh` |
+| Durable mirror | `scripts/mirror-engine.sh` |
+| Source-build fallback | `scripts/build-engine-from-source.sh` |
+| Smoke gate (real match to GameOver) | `scripts/engine-smoke.test.ts` → `npm run engine-smoke` |
+
+## Steps
+
+### 1. Choose the target version
+
+Look at <https://github.com/phase-rs/phase/releases>. The current pin is `version`
+in the manifest. Pick a target tag (releases are daily semver, e.g. `v0.57.0`).
+
+### 2. Read the changes between current and target
+
+Read every release note from the version after the current pin through the target.
+**Make a list of user-facing changes**, and in particular any **new player decisions
+/ actions** (new "choose …", targeting, modes, etc.) — these become interaction work
+in step 7.
+
+### 3. Obtain the target's web assets + glue
+
+The GitHub releases attach only desktop/server binaries — **not** the web assets.
+Get them one of two ways:
+
+- **From the live build (preferred while available).** The phase-rs.dev web app loads
+  the current assets; capture the `engine_wasm_bg-<hash>.wasm` and `card-data-<hash>.json`
+  URLs it requests and the `engine_wasm.js` glue it ships. Confirm the target version
+  matches. (Content hash in the filename = first 16 hex of the file's sha256.)
+- **From source** (`scripts/build-engine-from-source.sh [tag]`) when the CDN no longer
+  serves the target — it carries the known build invariants (pinned nightly, cranelift,
+  the 16 MiB shadow-stack link-arg, MTGJSON card-data gen). Reconcile its `CONFIRM`
+  markers against the repo's own build setup.
+
+Compute `sha256sum` of the new wasm and the raw card-data JSON.
+
+### 4. Replace the vendored glue
+
+Overwrite `src/engine/vendor/engine_wasm.js` with the new upstream glue **verbatim**.
+Record its new sha256.
+
+### 5. Update the manifest
+
+Edit `src/engine/vendor/engine-manifest.json`: `version`, `source.tag`,
+`source.releaseNotes`, `assets.wasm.{url,sha256}`, `assets.cardData.{url,sha256}`,
+`assets.glue.sha256`.
+
+### 6. Fetch (verifies digests) and mirror
+
+```sh
+npm run fetch-engine          # downloads + verifies SHA-256, gzips card-data
+scripts/mirror-engine.sh      # uploads the pinned set to an engine-<version> release
+```
+
+Set `mirror.base` in the manifest to the printed release-download base so future
+fetches survive CDN pruning.
+
+### 7. Reconcile the ABI, then implement new player actions
+
+- **Signatures.** Diff the engine functions the worker imports (`engine.worker.ts`)
+  against the new glue exports. If any changed, update `engine_wasm.d.ts` and the call sites.
+- **State shapes.** If `types.ts` fields drifted, the smoke's shape check (step 8) will
+  flag it; update `types.ts` accordingly.
+- **New player decisions (from step 2).** For each new decision that can be aimed at the
+  **human** seat, implement the manual-play interaction using the established pattern
+  (below). AI-only decisions need nothing — the AI already drives them.
+
+#### The manual-play interaction pattern
+
+Adding one player decision touches six places (mirror an existing handler such as
+`src/sim/decisions/creatureType.ts`):
+
+1. **`src/sim/decisions/<name>.ts`** — `parse<Name>Prompt(wf): <Name>Prompt | null`
+   (reads the engine `waiting_for`, returns a typed prompt or null) and a `<verb>Action(...)`
+   builder that produces the engine action. Add `<name>.test.ts`.
+2. **`src/sim/driver.ts`** — add a `requestHuman<Name>?` callback to `DriverCallbacks`,
+   parse it in `playLoop`, and add the dispatch branch.
+3. **`src/match/RunView.tsx`** — add pending-turn state, wire the `requestHuman<Name>`
+   callback to set it and `resolve` the choice.
+4. **`src/board/Board.tsx`** — render the selection UI for the pending decision.
+5. **`src/i18n/messages.ts`** — PT + EN strings for every new label.
+6. **Tests** — parser/action unit tests; extend the smoke if it exercises the path.
+
+### 8. Verify (all must pass)
+
+```sh
+npm run typecheck
+npm run lint
+npm test
+npm run duplication
+npm run engine-smoke      # boots the new WASM, runs a full match to GameOver
+npx domainbook check --range origin/main..HEAD
+```
+
+The smoke is the key gate: it catches ABI/JSON-shape breaks that unit tests can't.
+
+### 9. Document and open the PR
+
+- Add a `Changed` entry to `domainbook/domains/simulation/changelog.md` (naming the
+  version bump and any new interactions).
+- Update the README asset-size note if sizes moved.
+- Commit and open a PR summarizing the version delta and the interactions added.
+
+## Rollback
+
+Revert `engine-manifest.json` and `engine_wasm.js` to the previous commit and run
+`npm run fetch-engine`. Because the digests are pinned, a rollback restores the exact
+prior matched set.

--- a/domainbook/domains/simulation/changelog.md
+++ b/domainbook/domains/simulation/changelog.md
@@ -8,6 +8,18 @@ Security as H3s, each of them a bullet list.
 
 ## [Unreleased]
 
+### Added
+
+- Engine-version pinning is now a single source of truth
+  (`src/engine/vendor/engine-manifest.json`: version, URLs, SHA-256 digests).
+  `fetch-engine.sh` verifies each digest so the glue + WASM + card-data stay a
+  matched set, with a durable `mirror.base` fallback for when the CDN prunes.
+- A repeatable engine-upgrade process: `docs/engine-upgrade.md` runbook, the
+  `phase-rs-upgrade` agent (which also implements new player-action
+  interactions), an `engine-smoke` gate that boots the real WASM and runs a
+  match to `GameOver`, and `mirror-engine.sh` / `build-engine-from-source.sh`
+  for durability and last-resort rebuilds.
+
 ### Changed
 
 - The `engine adapter` now loads the card database gzipped

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "duplication": "jscpd src",
-    "fetch-engine": "bash scripts/fetch-engine.sh"
+    "fetch-engine": "bash scripts/fetch-engine.sh",
+    "engine-smoke": "ENGINE_SMOKE=1 vitest run scripts/engine-smoke.test.ts"
   },
   "dependencies": {
     "lucide-react": "^1.31.0",

--- a/scripts/build-engine-from-source.sh
+++ b/scripts/build-engine-from-source.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Last-resort durable path: rebuild the phase-rs web assets (WASM + wasm-bindgen
+# glue + card-data) from source at a pinned tag, for when the CDN URLs have been
+# pruned AND no mirror was captured (see domainbook/decisions/0006 + debt/0001).
+#
+# This encodes the build invariants we know about phase-rs; the AUTHORITATIVE
+# recipe lives in the phase repo itself. Steps marked CONFIRM must be reconciled
+# against that repo's build docs/CI for the target tag before trusting the output
+# — crate paths and exact flags can move between releases.
+#
+# Usage: scripts/build-engine-from-source.sh [tag]   (default: manifest version)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+MANIFEST="$ROOT/src/engine/vendor/engine-manifest.json"
+TAG="${1:-$(node -e "process.stdout.write(require('$MANIFEST').version)")}"
+REPO_URL="https://github.com/phase-rs/phase"
+WORK="$ROOT/.engine-build"
+OUT="$ROOT/.engine-build/out"
+
+echo "Building phase-rs web assets from source at tag: $TAG"
+echo "Repo: $REPO_URL"
+echo
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "MISSING tool: $1 — $2" >&2; exit 1; }; }
+need git   "install git"
+need rustup "install Rust via https://rustup.rs"
+need node  "install Node 20+"
+
+# --- 1. Source checkout at the pinned tag -----------------------------------
+rm -rf "$WORK"
+git clone --depth 1 --branch "$TAG" "$REPO_URL" "$WORK/phase"
+cd "$WORK/phase"
+
+# --- 2. Toolchain invariants (from debt/0001) -------------------------------
+# phase-rs builds its WASM on a pinned Rust NIGHTLY with the cranelift codegen
+# backend, targeting wasm32-unknown-unknown, and links with a mandatory 16 MiB
+# shadow stack. CONFIRM the exact nightly date against the repo's
+# rust-toolchain.toml (it pins one) — prefer that file over this default.
+TOOLCHAIN="$(node -e "try{const fs=require('fs');const t=fs.readFileSync('rust-toolchain.toml','utf8');const m=t.match(/channel\s*=\s*\"([^\"]+)\"/);process.stdout.write(m?m[1]:'')}catch{process.stdout.write('')}" 2>/dev/null || true)"
+TOOLCHAIN="${TOOLCHAIN:-nightly}"
+echo "Using toolchain: $TOOLCHAIN (CONFIRM against rust-toolchain.toml)"
+rustup toolchain install "$TOOLCHAIN" --component rustc-codegen-cranelift-preview || true
+rustup target add wasm32-unknown-unknown --toolchain "$TOOLCHAIN"
+
+command -v wasm-bindgen >/dev/null 2>&1 || cargo install wasm-bindgen-cli
+
+mkdir -p "$OUT"
+
+# --- 3. Compile the engine-wasm crate to wasm -------------------------------
+# CONFIRM the crate name/path (the workspace has an `engine-wasm` crate per the
+# project overview) and whether cranelift + the shadow-stack arg are applied via
+# .cargo/config.toml in the repo (prefer the repo's config if present).
+WASM_CRATE="engine-wasm"   # CONFIRM against Cargo.toml [workspace] members
+export RUSTFLAGS="${RUSTFLAGS:-} -C link-arg=-zstack-size=16777216"  # 16 MiB shadow stack
+cargo +"$TOOLCHAIN" build --release --target wasm32-unknown-unknown -p "$WASM_CRATE" \
+  || { echo "Build failed — reconcile WASM_CRATE / RUSTFLAGS / cranelift with the repo's build setup." >&2; exit 1; }
+
+RAW_WASM="target/wasm32-unknown-unknown/release/${WASM_CRATE//-/_}.wasm"
+
+# --- 4. wasm-bindgen glue (matches the vendored engine_wasm.js) --------------
+# The app vendors the `--target web` output. CONFIRM the flag set against the
+# repo's own wasm-bindgen invocation (some builds also run wasm-opt).
+wasm-bindgen "$RAW_WASM" --out-dir "$OUT" --target web --out-name engine_wasm
+echo "  glue + _bg.wasm → $OUT (engine_wasm.js, engine_wasm_bg.wasm)"
+
+# --- 5. Card database over MTGJSON ------------------------------------------
+# CONFIRM the generator: the repo has a card-data generation step over MTGJSON.
+# It is usually a cargo xtask or a script; produce card-data.json into $OUT.
+echo "CONFIRM: run the repo's card-data generator (MTGJSON) and write card-data.json → $OUT"
+echo "         e.g. 'cargo xtask card-data' or the documented data build; see the repo."
+
+# --- 6. Digests for the manifest --------------------------------------------
+echo
+echo "Built artifacts in $OUT. Record these in src/engine/vendor/engine-manifest.json:"
+for f in engine_wasm_bg.wasm engine_wasm.js card-data.json; do
+  if [ -f "$OUT/$f" ]; then
+    printf "  %-24s sha256 %s\n" "$f" "$(sha256sum "$OUT/$f" | cut -d' ' -f1)"
+  fi
+done
+echo
+echo "Then: copy engine_wasm.js → src/engine/vendor/, host the wasm + card-data"
+echo "(mirror release), point the manifest URLs at them, and run npm run engine-smoke."

--- a/scripts/engine-smoke.test.ts
+++ b/scripts/engine-smoke.test.ts
@@ -1,0 +1,144 @@
+// Engine smoke gate: boots the REAL vendored phase-rs WASM, loads the card
+// database, and drives a full match to a natural GameOver. This is the
+// post-upgrade verification that catches ABI/JSON-shape breaks that unit tests
+// (which never touch the WASM) cannot see.
+//
+// It is skipped in normal `npm test` runs — it needs the ~128 MiB engine assets
+// and takes real compute. Run it explicitly after `npm run fetch-engine`:
+//
+//     npm run engine-smoke
+//
+// which sets ENGINE_SMOKE=1. See docs/engine-upgrade.md.
+
+import { readFileSync, existsSync } from "node:fs";
+import { gunzipSync } from "node:zlib";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { describe, it, expect } from "vitest";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import init, {
+  init_panic_hook,
+  load_card_database,
+  getFormatRegistry,
+  initialize_game,
+  get_game_state,
+  get_ai_action_proposal,
+  submit_ai_action_proposal,
+  take_last_panic_message,
+} from "../src/engine/vendor/engine_wasm.js";
+import { STARTER_DECKS } from "../src/deck/starterDecks";
+import { buildDeckList } from "../src/engine/deckPayload";
+import type { SavedDeck } from "../src/deck/model";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const WASM = resolve(ROOT, "public/engine/engine_wasm_bg.wasm");
+const CARD_GZ = resolve(ROOT, "public/engine/card-data.json.gz");
+
+const ENABLED = process.env.ENGINE_SMOKE === "1";
+const MAX_ACTIONS = Number(process.env.ENGINE_SMOKE_MAX_ACTIONS ?? 25000);
+
+// The fields our adapter (src/engine/types.ts) reads off the engine state. If a
+// future engine renames or drops one of these, the smoke fails loudly here
+// rather than silently in the browser.
+const REQUIRED_STATE_FIELDS = [
+  "turn_number",
+  "phase",
+  "active_player",
+  "waiting_for",
+  "players",
+  "objects",
+  "battlefield",
+];
+
+describe.skipIf(!ENABLED)("phase-rs engine smoke", () => {
+  it("has the fetched engine assets on disk", () => {
+    const missing = [WASM, CARD_GZ].filter((p) => !existsSync(p));
+    if (missing.length) {
+      throw new Error(
+        `Engine assets missing: ${missing.join(", ")}\n` +
+          "Run `npm run fetch-engine` first.",
+      );
+    }
+  });
+
+  it(
+    "boots the WASM, loads the DB, and runs a match to GameOver",
+    { timeout: 300_000 },
+    async () => {
+      // Boot the WASM from disk bytes (no network in the test).
+      const bytes = new Uint8Array(readFileSync(WASM));
+      await init({ module_or_path: bytes });
+      init_panic_hook();
+
+      // Load the card database (inflate the gzipped copy the app ships).
+      const cardJson = gunzipSync(readFileSync(CARD_GZ)).toString("utf8");
+      const count = load_card_database(cardJson);
+      expect(count, "card database should load thousands of cards").toBeGreaterThan(
+        10_000,
+      );
+
+      // Commander default config, exactly as the worker resolves it.
+      const registry = getFormatRegistry();
+      const list = Array.isArray(registry) ? registry : [];
+      const commanderConfig = list.find(
+        (f: any) => f?.format === "Commander",
+      )?.default_config;
+      expect(commanderConfig, "engine should expose a Commander format").toBeTruthy();
+
+      // Two known-legal starter decks, assembled via the app's own payload path.
+      const decks = STARTER_DECKS.slice(0, 2) as unknown as SavedDeck[];
+      const deckData = buildDeckList(decks, "Medium");
+      const initRes = initialize_game(
+        deckData,
+        1234,
+        commanderConfig,
+        { match_type: "Bo1" },
+        2,
+        undefined,
+      );
+      expect(
+        (initRes as any)?.error,
+        `engine rejected the smoke decks: ${JSON.stringify(initRes)}`,
+      ).toBeFalsy();
+
+      // Drive every seat with the engine AI (the proven watch-mode loop) until a
+      // natural GameOver, mirroring engine.worker.ts's aiStep.
+      let actions = 0;
+      let outcome: "gameover" | "stalled" = "stalled";
+      let winner: number | null = null;
+      for (; actions < MAX_ACTIONS; actions++) {
+        const proposal = get_ai_action_proposal("Medium", 0);
+        if (!proposal) {
+          const wf = get_game_state()?.state?.waiting_for;
+          if (wf?.type === "GameOver") {
+            outcome = "gameover";
+            winner = wf.data?.winner ?? null;
+          }
+          break;
+        }
+        submit_ai_action_proposal(proposal.token, proposal.actor, proposal.action);
+      }
+
+      const panic = take_last_panic_message();
+      expect(panic, `engine panicked: ${panic}`).toBeFalsy();
+
+      // Shape check: the state our adapter reads must still have its fields.
+      const state = get_game_state()?.state;
+      expect(state, "get_game_state should return an envelope with .state").toBeTruthy();
+      for (const field of REQUIRED_STATE_FIELDS) {
+        expect(
+          field in state,
+          `engine state is missing "${field}" — types.ts reads this; the ABI/shape drifted`,
+        ).toBe(true);
+      }
+
+      expect(
+        outcome,
+        `match did not reach GameOver within ${MAX_ACTIONS} actions (ran ${actions})`,
+      ).toBe("gameover");
+      // A Commander game ends with a winner or a draw; both are valid.
+      expect(winner === null || typeof winner === "number").toBe(true);
+    },
+  );
+});

--- a/scripts/fetch-engine.sh
+++ b/scripts/fetch-engine.sh
@@ -3,45 +3,95 @@
 # commit: the compiled WASM (~28 MiB) and the card database (~95 MiB). These
 # land in public/engine/ where the app loads them at runtime.
 #
+# The pinned version, download URLs, and expected SHA-256 digests all live in
+# ONE place — src/engine/vendor/engine-manifest.json. This script reads that
+# manifest, downloads each asset, and verifies its digest before use, so the
+# glue + WASM + card-data always stay a matched set. To bump the engine, edit
+# the manifest (see docs/engine-upgrade.md), not this script.
+#
 # The card database is stored gzipped (card-data.json.gz, ~16 MiB): the raw
 # JSON exceeds GitHub Pages' ~100 MB per-file limit and is slow to download,
 # so the engine worker decompresses it at runtime via DecompressionStream.
 #
-# Pinned to the phase-rs v0.55.0 web build. The wasm-bindgen glue
-# (src/engine/vendor/engine_wasm.js) is committed and must match this WASM.
-#
-# These are content-hashed URLs on phase-rs.dev's CDN. phase-rs ships daily, so
-# they may eventually 404 as old assets are pruned. If that happens, build the
-# matching WASM + card-data from source at the pinned git tag — see
-# domainbook/decisions/0006 and domainbook/debt/0001.
+# The phase-rs CDN URLs are content-hashed and pruned over time, so a pinned
+# URL can eventually 404. When that happens either (a) set a "mirror.base" in
+# the manifest and mirror the pinned set there (scripts/mirror-engine.sh), or
+# (b) rebuild from source at the pinned tag (scripts/build-engine-from-source.sh).
 set -euo pipefail
 
-DEST="$(cd "$(dirname "$0")/.." && pwd)/public/engine"
-WASM_URL="https://data.phase-rs.dev/wasm/engine_wasm_bg-c214e9ae9bddbd05.wasm"
-CARD_DATA_URL="https://data.phase-rs.dev/card-data-bf86286a0934abc9.json"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DEST="$ROOT/public/engine"
+MANIFEST="$ROOT/src/engine/vendor/engine-manifest.json"
+
+if [ ! -f "$MANIFEST" ]; then
+  echo "ERROR: manifest not found at $MANIFEST" >&2
+  exit 1
+fi
+
+# Read a dotted field out of the manifest via node (guaranteed available in CI).
+m() { node -e "process.stdout.write(String(require('$MANIFEST').$1 ?? ''))"; }
+
+VERSION="$(m version)"
+WASM_URL="$(m assets.wasm.url)"
+WASM_SHA="$(m assets.wasm.sha256)"
+WASM_DEST="$(m assets.wasm.dest)"
+CARD_URL="$(m assets.cardData.url)"
+CARD_SHA="$(m assets.cardData.sha256)"
+CARD_DEST="$(m assets.cardData.dest)"
+CARD_GZIP="$(m assets.cardData.gzip)"
+MIRROR_BASE="$(m mirror.base)"
 
 mkdir -p "$DEST"
+echo "phase-rs engine snapshot: $VERSION"
 
-echo "Fetching engine WASM → $DEST/engine_wasm_bg.wasm"
-curl -fSL "$WASM_URL" -o "$DEST/engine_wasm_bg.wasm"
+# Download $1 (primary URL) to $2, falling back to the manifest mirror base on
+# failure, then verify the SHA-256 in $3. Aborts on mismatch.
+fetch_verified() {
+  local url="$1" out="$2" want_sha="$3" name
+  name="$(basename "$url")"
 
-echo "Fetching card database (~95 MiB) → $DEST/card-data.json"
-curl -fSL "$CARD_DATA_URL" -o "$DEST/card-data.json"
+  if ! curl -fSL "$url" -o "$out" 2>/dev/null; then
+    if [ -n "$MIRROR_BASE" ]; then
+      echo "  primary URL failed; trying mirror: $MIRROR_BASE/$name" >&2
+      curl -fSL "$MIRROR_BASE/$name" -o "$out"
+    else
+      echo "ERROR: download failed for $url" >&2
+      echo "       The content-hashed URL may have been pruned. Set mirror.base in" >&2
+      echo "       the manifest, or rebuild from source (scripts/build-engine-from-source.sh)." >&2
+      return 1
+    fi
+  fi
 
-# Sanity check: WASM magic bytes and non-trivial card-data size.
-if ! head -c 4 "$DEST/engine_wasm_bg.wasm" | grep -q $'\x00asm'; then
-  echo "ERROR: downloaded WASM is not a valid module (URL may have expired)." >&2
+  local got_sha
+  got_sha="$(sha256sum "$out" | cut -d' ' -f1)"
+  if [ "$got_sha" != "$want_sha" ]; then
+    echo "ERROR: SHA-256 mismatch for $name" >&2
+    echo "       expected $want_sha" >&2
+    echo "       got      $got_sha" >&2
+    echo "       The manifest and the served asset disagree — do NOT use this file." >&2
+    rm -f "$out"
+    return 1
+  fi
+  echo "  verified $name (sha256 ok)"
+}
+
+echo "Fetching engine WASM → $DEST/$WASM_DEST"
+fetch_verified "$WASM_URL" "$DEST/$WASM_DEST" "$WASM_SHA"
+# Belt-and-suspenders: WASM magic bytes.
+if ! head -c 4 "$DEST/$WASM_DEST" | grep -q $'\x00asm'; then
+  echo "ERROR: $WASM_DEST is not a valid WASM module." >&2
   exit 1
 fi
-size=$(wc -c < "$DEST/card-data.json")
-if [ "$size" -lt 10000000 ]; then
-  echo "ERROR: card-data.json looks too small ($size bytes); download failed." >&2
-  exit 1
+
+echo "Fetching card database (~95 MiB) → verifying → $DEST/$CARD_DEST"
+RAW="$DEST/card-data.raw.json"
+fetch_verified "$CARD_URL" "$RAW" "$CARD_SHA"
+if [ "$CARD_GZIP" = "true" ]; then
+  echo "  compressing → $DEST/$CARD_DEST"
+  gzip -9 -c "$RAW" > "$DEST/$CARD_DEST"
+  rm -f "$RAW"
+else
+  mv "$RAW" "$DEST/$CARD_DEST"
 fi
 
-# Compress for the web and drop the raw copy (see header): produces
-# card-data.json.gz and removes card-data.json.
-echo "Compressing → $DEST/card-data.json.gz"
-gzip -9 -f "$DEST/card-data.json"
-
-echo "Done. Engine assets ready in public/engine/."
+echo "Done. Engine assets ($VERSION) ready in public/engine/."

--- a/scripts/mirror-engine.sh
+++ b/scripts/mirror-engine.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Durability tool: mirror the pinned phase-rs engine assets to a GitHub Release
+# on THIS repo, so the snapshot survives the upstream CDN pruning its
+# content-hashed URLs (see domainbook/debt/0001).
+#
+# Run this WHILE the primary CDN URLs are still alive. It re-downloads the raw
+# assets named in the manifest, verifies their SHA-256, uploads them to a
+# release tagged engine-<version>, and prints the mirror.base to record in the
+# manifest. After that, scripts/fetch-engine.sh transparently falls back to the
+# mirror when a primary URL 404s.
+#
+# Requires the GitHub CLI (`gh`) authenticated with write access to the repo.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+MANIFEST="$ROOT/src/engine/vendor/engine-manifest.json"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+m() { node -e "process.stdout.write(String(require('$MANIFEST').$1 ?? ''))"; }
+
+VERSION="$(m version)"
+WASM_URL="$(m assets.wasm.url)"
+WASM_SHA="$(m assets.wasm.sha256)"
+CARD_URL="$(m assets.cardData.url)"
+CARD_SHA="$(m assets.cardData.sha256)"
+TAG="engine-$VERSION"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR: this script needs the GitHub CLI (gh), authenticated with repo write access." >&2
+  echo "       Install it, run 'gh auth login', then re-run. Alternatively upload the two" >&2
+  echo "       raw files below to a release manually and set mirror.base in the manifest." >&2
+  exit 1
+fi
+
+REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+
+dl() { # url sha out
+  echo "  downloading $(basename "$1")" >&2
+  curl -fSL "$1" -o "$3"
+  local got; got="$(sha256sum "$3" | cut -d' ' -f1)"
+  if [ "$got" != "$2" ]; then
+    echo "ERROR: SHA-256 mismatch for $(basename "$1") — refusing to mirror." >&2
+    exit 1
+  fi
+}
+
+echo "Mirroring phase-rs $VERSION assets to $REPO release $TAG"
+# Mirror the ORIGINAL filenames + raw bytes: fetch-engine's mirror fallback
+# requests <mirror.base>/<original-basename> and re-verifies the same SHA-256.
+WASM_FILE="$WORK/$(basename "$WASM_URL")"
+CARD_FILE="$WORK/$(basename "$CARD_URL")"
+dl "$WASM_URL" "$WASM_SHA" "$WASM_FILE"
+dl "$CARD_URL" "$CARD_SHA" "$CARD_FILE"
+
+if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+  echo "  release $TAG exists — uploading (clobbering) assets"
+  gh release upload "$TAG" "$WASM_FILE" "$CARD_FILE" --repo "$REPO" --clobber
+else
+  gh release create "$TAG" "$WASM_FILE" "$CARD_FILE" \
+    --repo "$REPO" \
+    --title "phase-rs engine snapshot $VERSION" \
+    --notes "Durable mirror of the pinned phase-rs $VERSION web assets (WASM + card-data). Consumed as a fallback by scripts/fetch-engine.sh. Not for general download."
+fi
+
+echo
+echo "Done. Set this in src/engine/vendor/engine-manifest.json under \"mirror\":"
+echo "  \"base\": \"https://github.com/$REPO/releases/download/$TAG\""

--- a/src/engine/vendor/engine-manifest.json
+++ b/src/engine/vendor/engine-manifest.json
@@ -1,0 +1,30 @@
+{
+  "$comment": "Single source of truth for the pinned phase-rs engine snapshot. The three vendored pieces below (glue + wasm + card-data) MUST stay a matched set — they are one coherent release. scripts/fetch-engine.sh reads this file, downloads the assets, and verifies each SHA-256 before use. To bump the engine, follow docs/engine-upgrade.md (or run the phase-rs-upgrade agent). The content hash in each CDN filename is the first 16 hex chars of that asset's sha256.",
+  "version": "v0.55.0",
+  "source": {
+    "repo": "https://github.com/phase-rs/phase",
+    "tag": "v0.55.0",
+    "releaseNotes": "https://github.com/phase-rs/phase/releases/tag/v0.55.0"
+  },
+  "assets": {
+    "wasm": {
+      "url": "https://data.phase-rs.dev/wasm/engine_wasm_bg-c214e9ae9bddbd05.wasm",
+      "sha256": "c214e9ae9bddbd051153effbdb726a8f15b412439c20000b55954a7536fc3896",
+      "dest": "engine_wasm_bg.wasm"
+    },
+    "cardData": {
+      "url": "https://data.phase-rs.dev/card-data-bf86286a0934abc9.json",
+      "sha256": "bf86286a0934abc9b7c372ff1dab329ef015b93d821342689970a51fc8af5a79",
+      "dest": "card-data.json.gz",
+      "gzip": true
+    },
+    "glue": {
+      "path": "src/engine/vendor/engine_wasm.js",
+      "sha256": "b489bc7436cdd0482247b68e3cf83d71459e81494afa52dc8ac62d56a0609ed1"
+    }
+  },
+  "mirror": {
+    "base": "",
+    "$comment": "Optional durable fallback. The phase-rs CDN prunes old content-hashed URLs (see domainbook/debt/0001), so a pinned URL can eventually 404. Set this to a base URL that hosts copies of the asset filenames (e.g. a GitHub Release download base like https://github.com/<owner>/<repo>/releases/download/engine-v0.55.0). scripts/mirror-engine.sh publishes the current pinned set there; fetch-engine.sh falls back to <base>/<filename> when the primary URL fails. The SHA-256 checks above still apply to the mirrored copy."
+  }
+}


### PR DESCRIPTION
## Why

Make future phase-rs engine bumps smooth, verifiable, and complete. Today the pinned version, the two asset content-hashes, and the glue's baked-in hash live in three scattered places; `fetch-engine.sh` validated only size/magic bytes; there was no smoke test to catch an ABI break; and the durable-fallback path lived only as prose. This PR turns the upgrade into a mechanical, gated process — and adds a sub-agent that runs it end-to-end, including implementing new player interactions.

## Background (analysis)

- **Pinned, not latest.** We consume a fixed content-hashed v0.55.0 snapshot — no risk of silently pulling a breaking build. The real risk is the opposite: the CDN URLs are content-hashed and pruned over time, so a pin can eventually 404.
- **Reliable tagging?** The [`phase-rs/phase`](https://github.com/phase-rs/phase) repo does daily semver releases, **but** [releases attach only desktop/server binaries](https://github.com/phase-rs/phase/releases) — the web WASM, card-data, and glue exist only on the prunable CDN.
- **Local modifications?** None. The glue is verbatim upstream; only the thin `.d.ts` and our adapter are hand-written. Upgrades aren't blocked by local edits — the friction was purely process.

## Changes

**1. Single source of truth + digest pinning**
- `src/engine/vendor/engine-manifest.json` — version, asset URLs, and SHA-256 digests in one place.
- `scripts/fetch-engine.sh` rewritten to read the manifest and **verify every download's SHA-256** (glue + WASM + card-data stay a matched set).

**2. Durable mirror**
- Manifest `mirror.base` fallback: `fetch-engine.sh` transparently retries a mirror when a primary URL 404s.
- `scripts/mirror-engine.sh` publishes the pinned set to an `engine-<version>` GitHub Release.
- `scripts/build-engine-from-source.sh` — last-resort rebuild carrying the known build invariants (pinned nightly, cranelift, 16 MiB shadow-stack link-arg, MTGJSON card-data), with explicit `CONFIRM` markers.

**3. Runbook + smoke gate**
- `docs/engine-upgrade.md` — the step-by-step upgrade runbook.
- `scripts/engine-smoke.test.ts` (`npm run engine-smoke`) — boots the **real WASM**, loads the DB, and drives a full match to `GameOver`, asserting the state fields `types.ts` reads. Catches ABI/JSON-shape breaks unit tests can't. Env-gated (`ENGINE_SMOKE=1`) so normal CI skips it.

**4. Sub-agent**
- `.claude/agents/phase-rs-upgrade.md` — runs the runbook end-to-end and, critically, reviews release notes between the current and target version for **new player-facing decisions** and implements the manual-play interaction for each (following the established `src/sim/decisions/*` pattern: parser + action builder + `DriverCallbacks` + `playLoop` branch + RunView state + Board UI + PT/EN i18n + tests). AI-only decisions need no work.

## Verification

- `npm run typecheck`, `npm run lint`, `npm test` (73 pass, smoke skipped), `npm run duplication`, `npx domainbook check` — all green.
- `npm run engine-smoke` runs the real engine to `GameOver` (~75s locally) — passing.
- `fetch-engine.sh` verified end-to-end: downloads, checks both digests, gzips card-data.

## Notes

- Normal CI is unchanged/fast — the smoke is opt-in and skipped by default.
- `mirror.base` is intentionally empty; run `scripts/mirror-engine.sh` (needs `gh` with write access) to populate it when you want the durable copy captured.

Sources: [phase-rs/phase](https://github.com/phase-rs/phase) · [releases](https://github.com/phase-rs/phase/releases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4ezWLjHQGR1xjCy6v8QsY

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4ezWLjHQGR1xjCy6v8QsY)_