### PR TITLE
fix(engine): resolve engine asset base against the page, not the worker

### DIFF
--- a/domainbook/domains/simulation/changelog.md
+++ b/domainbook/domains/simulation/changelog.md
@@ -26,3 +26,11 @@ Security as H3s, each of them a bullet list.
   (`card-data.json.gz`) and inflates it at runtime via `DecompressionStream`,
   cutting the download from ~100 MB to ~16 MB and keeping the asset under
   GitHub Pages' per-file limit.
+
+### Fixed
+
+- The `engine adapter` worker no longer 404s the WASM and card database under
+  a subpath deploy (e.g. GitHub Pages project sites). A relative `BASE_URL`
+  (`./`) resolved against the worker's own `/assets/` location instead of the
+  app root; the main thread now resolves it against the page URL and passes the
+  absolute base to the worker on `ready`.

--- a/src/engine/EngineClient.ts
+++ b/src/engine/EngineClient.ts
@@ -61,7 +61,8 @@ export class EngineClient {
   /** Boot the WASM and load the card database (idempotent, ~95 MiB one-time). */
   ready(): Promise<{ commanderConfig: unknown }> {
     if (!this.readyPromise) {
-      this.readyPromise = this.req("ready").then((r: any) => {
+      const base = new URL(import.meta.env.BASE_URL, location.href).href;
+      this.readyPromise = this.req("ready", { base }).then((r: any) => {
         this.commanderConfig = r.commanderConfig;
         return r;
       });

--- a/src/engine/engine.worker.ts
+++ b/src/engine/engine.worker.ts
@@ -17,7 +17,11 @@ import init, {
   submit_action,
 } from "./vendor/engine_wasm.js";
 
-const BASE = import.meta.env.BASE_URL;
+// Absolute base URL for engine assets, supplied by the main thread on "ready".
+// It must be resolved against the *page* location, not the worker's: a relative
+// base like "./" resolves against the worker's own URL (`/assets/`) rather than
+// the app root, which 404s the WASM and card database.
+let assetBase = import.meta.env.BASE_URL;
 
 let started = false;
 let dbLoaded = false;
@@ -25,7 +29,7 @@ let commanderConfig: any = null;
 
 async function ensureStarted(): Promise<void> {
   if (started) return;
-  await init({ module_or_path: `${BASE}engine/engine_wasm_bg.wasm` });
+  await init({ module_or_path: `${assetBase}engine/engine_wasm_bg.wasm` });
   init_panic_hook();
   started = true;
 }
@@ -35,7 +39,7 @@ async function ensureStarted(): Promise<void> {
 // If a host transparently decodes the gzip (Content-Encoding), the bytes are
 // already plain JSON — detected via the gzip magic — so we use them directly.
 async function fetchCardData(): Promise<string> {
-  const res = await fetch(`${BASE}engine/card-data.json.gz`);
+  const res = await fetch(`${assetBase}engine/card-data.json.gz`);
   if (!res.ok) {
     throw new Error(`card-data fetch failed: HTTP ${res.status}`);
   }
@@ -61,6 +65,7 @@ async function ensureDb(): Promise<void> {
 async function handle(cmd: string, args: any): Promise<any> {
   switch (cmd) {
     case "ready": {
+      if (args?.base) assetBase = args.base;
       await ensureStarted();
       await ensureDb();
       return { commanderConfig };


### PR DESCRIPTION
## Problem

Starting a match on the deployed site (https://rafaelaugustscherer.github.io/commander-playtester/) fails with:

> Failed to execute 'compile' on 'WebAssembly': HTTP status code is not ok

The engine worker fetches its WASM and card database via `import.meta.env.BASE_URL`, which is the **relative** string `"./"` (chosen in `vite.config.ts` so the build works at both root and the GitHub Pages subpath).

Inside the worker — served from `/commander-playtester/assets/` — `"./engine/engine_wasm_bg.wasm"` resolves to `/commander-playtester/assets/engine/engine_wasm_bg.wasm`, which **404s**. The assets actually live at `/commander-playtester/engine/...`. A relative base is fine on the main thread (resolves against the page) but wrong in the worker (resolves against `/assets/`).

## Fix

The main thread resolves `BASE_URL` against the page URL into an absolute base and passes it to the worker on `ready`; the worker uses it for both the WASM and `card-data.json.gz` fetches. This keeps the intended relative `base: "./"` working for root, subpath, and dev.

## Verification

Built, then served `dist/` under a `/commander-playtester/` subpath (simulating GitHub Pages) with the real pinned engine assets (`npm run fetch-engine`). Ran a match: WASM compiled, the ~100 MB card DB loaded and inflated, and a full 4-seat game simulated with a live log — the error is gone. `npm run lint`, `npm run typecheck`, and `domainbook check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)