### PR TITLE
Apply "Copper Ember" dark theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=MedievalSharp&family=Alegreya:wght@400;700;800&display=swap"
+      rel="stylesheet"
+    />
     <title>Commander Playtester</title>
   </head>
   <body>

--- a/src/App.css
+++ b/src/App.css
@@ -20,7 +20,7 @@
 .panel {
   background: var(--panel);
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: var(--radius);
   padding: 1.25rem;
   margin-bottom: 1.25rem;
 }
@@ -32,7 +32,7 @@
   background: var(--panel-2);
   color: var(--text);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
   padding: 0.75rem;
   font-size: 0.85rem;
   line-height: 1.5;
@@ -61,9 +61,9 @@
 
 .btn {
   background: var(--accent);
-  color: #0b1020;
+  color: var(--accent-ink);
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
   padding: 0.55rem 1.1rem;
   font-weight: 600;
 }
@@ -93,7 +93,7 @@
 .stat {
   background: var(--panel-2);
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-sm);
   padding: 0.85rem;
 }
 
@@ -188,7 +188,7 @@ th {
   background: transparent;
   color: var(--muted);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
   padding: 0.45rem 1rem;
   font-weight: 600;
   cursor: pointer;
@@ -228,7 +228,7 @@ th {
   background: var(--panel-2);
   color: var(--text);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
   padding: 0.55rem 0.7rem;
   font-size: 0.95rem;
 }
@@ -259,7 +259,7 @@ th {
   gap: 1rem;
   background: var(--panel-2);
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-sm);
   padding: 0.75rem 1rem;
 }
 
@@ -303,7 +303,7 @@ th {
   background: var(--panel-2);
   color: var(--muted);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
   padding: 0.45rem 0.9rem;
   font-weight: 600;
   cursor: pointer;
@@ -340,7 +340,7 @@ th {
   margin-top: 1rem;
   background: var(--panel-2);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
   padding: 0.75rem;
   font-size: 0.8rem;
   line-height: 1.5;
@@ -411,7 +411,7 @@ th {
 .seat {
   background: var(--panel-2);
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-sm);
   padding: 0.6rem 0.7rem;
   min-height: 120px;
 }
@@ -619,7 +619,7 @@ th {
 }
 .lang__btn--active {
   background: var(--accent);
-  color: #0b1020;
+  color: var(--accent-ink);
 }
 
 /* ── Player playmat: larger cards ──────────────────────────────── */
@@ -761,7 +761,7 @@ th {
   justify-content: center;
   padding: 0.5rem;
   background: color-mix(in srgb, var(--bg) 78%, transparent);
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
   z-index: 5;
 }
 .slot {
@@ -774,7 +774,7 @@ th {
   min-height: 76px;
   padding: 0.5rem 0.75rem;
   border: 2px dashed var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-sm);
   color: var(--muted);
 }
 .slot__icon {
@@ -803,19 +803,19 @@ th {
   position: fixed;
   z-index: 50;
   pointer-events: none;
-  border-radius: 10px;
+  border-radius: var(--radius);
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.55);
 }
 .card-preview__img {
   width: 100%;
   height: auto;
   display: block;
-  border-radius: 10px;
+  border-radius: var(--radius);
 }
 .card-preview__text {
   background: var(--panel);
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius);
   padding: 0.75rem 0.9rem;
 }
 .card-preview__name {
@@ -847,12 +847,12 @@ th {
   overflow-y: auto;
   background: var(--panel);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius);
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.45);
 }
 .combobox__option {
   padding: 0.4rem 0.6rem;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   font-size: 0.9rem;
   cursor: pointer;
   white-space: nowrap;
@@ -918,7 +918,7 @@ th {
   color: var(--muted);
   cursor: pointer;
   padding: 0.25rem;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
 }
 .game-sidebar__toggle:hover {
   color: var(--text);
@@ -1177,4 +1177,9 @@ th {
     width: auto;
     border-left: none;
   }
+}
+
+/* Copper Ember — display face on the sidebar header title */
+.game-sidebar__head strong {
+  font-family: var(--font-display);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,17 +1,25 @@
 :root {
-  --bg: #0f1115;
-  --panel: #181b22;
-  --panel-2: #20242e;
-  --border: #2b303b;
-  --text: #e7e9ee;
-  --muted: #9aa2b1;
-  --accent: #7c9cff;
-  --good: #4ade80;
-  --warn: #fbbf24;
-  --bad: #f87171;
+  /* Copper Ember — warm medieval-tavern dark theme */
+  --bg: #1a120c; /* page background — deep walnut */
+  --panel: #291c12; /* cards / panels */
+  --panel-2: #372615; /* insets, rows, tiles */
+  --border: #5c4029; /* hairline borders */
+  --text: #f1e4d0; /* primary text — candlelight cream */
+  --muted: #c09c77; /* secondary text */
+  --accent: #c47f4d; /* copper — primary accent */
+  --accent-ink: #241207; /* text/icon on accent fills */
+  --good: #8aa35a; /* positive log events */
+  --warn: #dca24a; /* warnings */
+  --bad: #cf5a37; /* damage / concede / eliminate */
+
+  --radius: 6px; /* panels — sharp */
+  --radius-sm: 5px; /* buttons, tiles */
+
+  --font-display: "MedievalSharp", Georgia, serif; /* headings, turn/phase, panel titles */
+  --font-body: "Alegreya", Georgia, "Times New Roman", serif; /* body text */
 
   color-scheme: dark;
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  font-family: var(--font-body);
   color: var(--text);
   background: var(--bg);
 }
@@ -30,6 +38,7 @@ h2,
 h3 {
   margin: 0 0 0.5rem;
   line-height: 1.2;
+  font-family: var(--font-display);
 }
 
 a {


### PR DESCRIPTION
## Summary

Implements the **Copper Ember** dark-theme design overhaul from the Claude Design handoff — a warm, medieval-tavern re-skin of the app: walnut-brown surfaces, candlelight-cream text, a muted copper/terracotta accent, sharp (low-radius) corners, and a `MedievalSharp` display face for headings over an `Alegreya` body.

As the handoff specifies, this is an entirely **token-driven** re-theme: no component markup, layout, or behavior changes — only the shared CSS custom properties, corner radii, and web fonts.

## Changes

**`src/index.css`**
- Swap the `:root` color tokens to the Copper Ember palette (`--bg`, `--panel`, `--panel-2`, `--border`, `--text`, `--muted`, `--accent`, `--good`, `--warn`, `--bad`).
- Add the new design tokens: `--accent-ink` (text on accent fills), `--radius` / `--radius-sm` (sharp corners), and `--font-display` / `--font-body`.
- Drive the base body font from `--font-body` and headings (`h1/h2/h3`) from `--font-display` — this also covers panel titles and the turn/phase status bar, which are headings.

**`index.html`**
- Preconnect to and load `MedievalSharp` + `Alegreya` from Google Fonts.

**`src/App.css`**
- Point panel/control corner radii at the new `--radius` (panels, popovers) and `--radius-sm` (buttons, inputs, rows, seats, tiles) tokens for the sharp look; pill shapes (`999px`) and small card-image radii are intentionally left as-is, matching the prototype.
- Use `--accent-ink` for text on the accent-filled primary button and active language toggle (replacing the previous hard-coded on-accent color).
- Apply the display face to the Stack &amp; Log sidebar header.

## Verification
- `npm run build` — passes (tsc + vite).
- `npm run lint` — passes.
- Rendered the deck-library screen and confirmed computed styles: walnut background, `MedievalSharp` heading stack, `Alegreya` body stack, `6px` panel radius, and the copper accent button with `#241207` ink.

_MedievalSharp/Alegreya display as serif fallbacks in the offline build sandbox; they load normally in a networked browser via the added `<link>` tags._

🤖 Generated with [Claude Code](https://claude.com/claude-code)