### PR TITLE
Normalize card names through a shared import adapter

### DIFF
--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,6 +12,16 @@ depth live there. A purely-internal PR that touches no product or architecture m
 skip its version with a `Skip-Docs: <reason>` trailer instead. There are no
 per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
+## [0.1.9] - 2026-08-18
+
+### Fixed
+
+- Two-sided cards (split, MDFC, transform, adventure) no longer show up as "not
+  found": their decklist name is collapsed to the front face, which is how both
+  Scryfall and the engine key them — Moxfield/Archidekt export the full
+  "Front // Back" name, which resolved to nothing
+  (`domains/deck-library/features/import-from-a-url.md`).
+
 ## [0.1.8] - 2026-08-18
 
 ### Added

--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -16,10 +16,11 @@ per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
 ### Fixed
 
-- Two-sided cards (split, MDFC, transform, adventure) no longer show up as "not
-  found": their decklist name is collapsed to the front face, which is how both
-  Scryfall and the engine key them — Moxfield/Archidekt export the full
-  "Front // Back" name, which resolved to nothing
+- Pasting or importing a deck no longer needs two-sided cards edited by hand: a
+  shared card-name adapter collapses "Front // Back" (split, MDFC, transform,
+  adventure) to the front face — the only face Scryfall and the engine key on —
+  so an exported Moxfield/Archidekt list works as-is. The adapter runs on both
+  the pasted-text and URL-import paths
   (`domains/deck-library/features/import-from-a-url.md`).
 
 ## [0.1.8] - 2026-08-18

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",

--- a/src/lib/cardName.test.ts
+++ b/src/lib/cardName.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { normalizeCardName } from "./cardName";
+
+describe("normalizeCardName", () => {
+  it("leaves a plain name untouched", () => {
+    expect(normalizeCardName("Atraxa, Praetors' Voice")).toBe(
+      "Atraxa, Praetors' Voice",
+    );
+  });
+
+  it("strips Moxfield set + collector and foil suffixes", () => {
+    expect(normalizeCardName("Sol Ring (C21) 263")).toBe("Sol Ring");
+    expect(normalizeCardName("Sol Ring (C21) 263 *F*")).toBe("Sol Ring");
+  });
+
+  it("strips a trailing category tag in brackets", () => {
+    expect(normalizeCardName("Sol Ring [Ramp]")).toBe("Sol Ring");
+  });
+
+  it("collapses two-sided 'Front // Back' names to the front face", () => {
+    // Split, MDFC, transform, and adventure cards all export this way; Scryfall
+    // and the engine only key the front face.
+    expect(normalizeCardName("Never // Return")).toBe("Never");
+    expect(normalizeCardName("Malakir Rebirth // Malakir Mire")).toBe(
+      "Malakir Rebirth",
+    );
+    expect(normalizeCardName("Valki, God of Lies // Tibalt, Cosmic Impostor")).toBe(
+      "Valki, God of Lies",
+    );
+    // Still collapses when Moxfield appends set + collector metadata.
+    expect(normalizeCardName("Connive // Concoct (GRN) 222")).toBe("Connive");
+  });
+
+  it("keeps a slash that is part of the real name (not a face separator)", () => {
+    // The face separator is always " // " with surrounding spaces.
+    expect(normalizeCardName("SP//dr, Piloted by Peni")).toBe(
+      "SP//dr, Piloted by Peni",
+    );
+    expect(normalizeCardName("Summon: Choco/Mog")).toBe("Summon: Choco/Mog");
+  });
+});

--- a/src/lib/cardName.ts
+++ b/src/lib/cardName.ts
@@ -1,0 +1,38 @@
+/**
+ * Card-name adapter — the single anti-corruption point for card names.
+ *
+ * Turns a card name the way a deck platform writes it (a Moxfield or Archidekt
+ * export line, a URL-import API payload, or a plain paste) into the canonical
+ * name that Scryfall's collection endpoint and the engine's card database key
+ * on. Both the pasted-decklist parser and the URL importers run every name
+ * through here, so pasting an exported decklist needs no hand-editing.
+ *
+ * The one conversion the platforms always emit — and that the user cannot turn
+ * off — is the two-sided "Front // Back" name (split, MDFC, transform,
+ * adventure): Scryfall and the engine both key these on the front face alone,
+ * so the full name resolves to nothing. We collapse it to the front face. A
+ * slash that is part of the real name is preserved ("SP//dr, Piloted by Peni",
+ * "Summon: Choco/Mog") because the double-faced separator is always the spaced
+ * " // ".
+ *
+ * We also strip the optional set/collector/foil/category decorations Moxfield
+ * appends by default ("(C21) 263 *F*"); Archidekt's more decorated export is not
+ * special-cased — its export dialog can emit plain card names.
+ */
+export function normalizeCardName(input: string): string {
+  let name = input.trim();
+
+  // Remove a trailing foil/etched marker like "*F*" or "*E*".
+  name = name.replace(/\s*\*[a-z]\*\s*$/i, "");
+
+  // Remove a trailing "(SET) collector" block. Set codes are 2-6 alnum chars.
+  name = name.replace(/\s*\([0-9a-z]{2,6}\)\s*[0-9a-z-]*\s*$/i, "");
+
+  // Remove a trailing category tag in square brackets.
+  name = name.replace(/\s*\[[^\]]*\]\s*$/g, "");
+
+  // Collapse a two-sided "Front // Back" name to its front face.
+  name = name.split(/\s+\/\/\s+/)[0];
+
+  return name.trim();
+}

--- a/src/lib/deckImport.test.ts
+++ b/src/lib/deckImport.test.ts
@@ -64,6 +64,18 @@ describe("parseMoxfield", () => {
     expect(all).not.toContain("Grafdigger's Cage"); // sideboard
   });
 
+  it("collapses a two-sided card name to its front face", () => {
+    const deck = parseMoxfield({
+      name: "DFC deck",
+      boards: {
+        mainboard: {
+          cards: { a: { quantity: 1, card: { name: "Never // Return" } } },
+        },
+      },
+    });
+    expect(deck.mainboard.map((e) => e.name)).toEqual(["Never"]);
+  });
+
   it("routes the commanders board and ignores the maybeboard", () => {
     const deck = parseMoxfield(moxfieldCommanderFixture);
     expect(deck.commanders.map((e) => e.name)).toEqual(["Atraxa, Praetors' Voice"]);

--- a/src/lib/deckImport.ts
+++ b/src/lib/deckImport.ts
@@ -1,4 +1,5 @@
 import type { DecklistEntry } from "./types";
+import { normalizeCardName } from "./cardName";
 
 export type DeckSource = "moxfield" | "archidekt" | "ligamagic";
 
@@ -83,7 +84,7 @@ function moxfieldEntries(board?: { cards?: Record<string, MoxfieldCard> }): Deck
   const entries: DecklistEntry[] = [];
   for (const c of Object.values(cards)) {
     const name = c.card?.name;
-    if (name) entries.push({ quantity: c.quantity ?? 1, name });
+    if (name) entries.push({ quantity: c.quantity ?? 1, name: normalizeCardName(name) });
   }
   return entries;
 }
@@ -122,11 +123,11 @@ export function parseArchidekt(json: unknown): Omit<ImportedDeck, "source"> {
   const commanders: DecklistEntry[] = [];
   const mainboard: DecklistEntry[] = [];
   for (const c of d.cards ?? []) {
-    const name = c.card?.oracleCard?.name;
-    if (!name) continue;
+    const rawName = c.card?.oracleCard?.name;
+    if (!rawName) continue;
     const cats = c.categories ?? [];
     if (cats.some((cat) => excluded.has(cat))) continue;
-    const entry = { quantity: c.quantity ?? 1, name };
+    const entry = { quantity: c.quantity ?? 1, name: normalizeCardName(rawName) };
     if (cats.includes(ARCHIDEKT_COMMANDER)) commanders.push(entry);
     else mainboard.push(entry);
   }

--- a/src/lib/decklist.test.ts
+++ b/src/lib/decklist.test.ts
@@ -1,43 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseDecklist, cleanCardName } from "./decklist";
-
-describe("cleanCardName", () => {
-  it("strips Moxfield set + collector suffixes", () => {
-    expect(cleanCardName("Sol Ring (C21) 263")).toBe("Sol Ring");
-    expect(cleanCardName("Sol Ring (C21) 263 *F*")).toBe("Sol Ring");
-  });
-
-  it("strips Archidekt category brackets", () => {
-    expect(cleanCardName("Sol Ring [Ramp]")).toBe("Sol Ring");
-  });
-
-  it("leaves a plain name untouched", () => {
-    expect(cleanCardName("Atraxa, Praetors' Voice")).toBe(
-      "Atraxa, Praetors' Voice",
-    );
-  });
-
-  it("collapses two-sided 'Front // Back' names to the front face", () => {
-    // Split, MDFC, transform, and adventure cards all export this way.
-    expect(cleanCardName("Never // Return")).toBe("Never");
-    expect(cleanCardName("Malakir Rebirth // Malakir Mire")).toBe(
-      "Malakir Rebirth",
-    );
-    expect(cleanCardName("Valki, God of Lies // Tibalt, Cosmic Impostor")).toBe(
-      "Valki, God of Lies",
-    );
-    // Still collapses when Moxfield appends set + collector metadata.
-    expect(cleanCardName("Connive // Concoct (GRN) 222")).toBe("Connive");
-  });
-
-  it("keeps a slash that is part of the real name (not a face separator)", () => {
-    // The face separator is always " // " with surrounding spaces.
-    expect(cleanCardName("SP//dr, Piloted by Peni")).toBe(
-      "SP//dr, Piloted by Peni",
-    );
-    expect(cleanCardName("Summon: Choco/Mog")).toBe("Summon: Choco/Mog");
-  });
-});
+import { parseDecklist } from "./decklist";
 
 describe("parseDecklist", () => {
   it("parses quantities in both '1' and '1x' forms", () => {
@@ -73,6 +35,28 @@ describe("parseDecklist", () => {
   it("skips comments and blank lines", () => {
     const parsed = parseDecklist("// my deck\n\n1 Sol Ring\n# note");
     expect(parsed.mainboard).toEqual([{ quantity: 1, name: "Sol Ring" }]);
+    expect(parsed.warnings).toEqual([]);
+  });
+
+  it("normalizes a pasted Moxfield export, two-sided cards included", () => {
+    const paste = [
+      "Commander",
+      "1 Yuriko, the Tiger's Shadow (C18) 47",
+      "",
+      "Deck",
+      "1 Sol Ring (C21) 263 *F*",
+      "1 Never // Return (2X2) 456",
+      "1 Discovery // Dispersal (GRN) 223",
+    ].join("\n");
+    const parsed = parseDecklist(paste);
+    expect(parsed.commanders).toEqual([
+      { quantity: 1, name: "Yuriko, the Tiger's Shadow" },
+    ]);
+    expect(parsed.mainboard.map((e) => e.name)).toEqual([
+      "Sol Ring",
+      "Never",
+      "Discovery",
+    ]);
     expect(parsed.warnings).toEqual([]);
   });
 });

--- a/src/lib/decklist.test.ts
+++ b/src/lib/decklist.test.ts
@@ -16,6 +16,27 @@ describe("cleanCardName", () => {
       "Atraxa, Praetors' Voice",
     );
   });
+
+  it("collapses two-sided 'Front // Back' names to the front face", () => {
+    // Split, MDFC, transform, and adventure cards all export this way.
+    expect(cleanCardName("Never // Return")).toBe("Never");
+    expect(cleanCardName("Malakir Rebirth // Malakir Mire")).toBe(
+      "Malakir Rebirth",
+    );
+    expect(cleanCardName("Valki, God of Lies // Tibalt, Cosmic Impostor")).toBe(
+      "Valki, God of Lies",
+    );
+    // Still collapses when Moxfield appends set + collector metadata.
+    expect(cleanCardName("Connive // Concoct (GRN) 222")).toBe("Connive");
+  });
+
+  it("keeps a slash that is part of the real name (not a face separator)", () => {
+    // The face separator is always " // " with surrounding spaces.
+    expect(cleanCardName("SP//dr, Piloted by Peni")).toBe(
+      "SP//dr, Piloted by Peni",
+    );
+    expect(cleanCardName("Summon: Choco/Mog")).toBe("Summon: Choco/Mog");
+  });
 });
 
 describe("parseDecklist", () => {

--- a/src/lib/decklist.ts
+++ b/src/lib/decklist.ts
@@ -1,4 +1,5 @@
 import type { DecklistEntry, ParsedDecklist } from "./types";
+import { normalizeCardName } from "./cardName";
 
 /**
  * Parse a raw decklist pasted from Moxfield, Archidekt, or plain text.
@@ -80,37 +81,9 @@ function parseLine(line: string): DecklistEntry | null {
     rest = qtyMatch[2];
   }
 
-  const name = cleanCardName(rest);
+  const name = normalizeCardName(rest);
   if (!name) return null;
   if (!Number.isFinite(quantity) || quantity < 1) return null;
 
   return { quantity, name };
-}
-
-/**
- * Strip trailing set/collector/foil metadata and normalize a card name.
- * Handles Moxfield's "(SET) 123 *F*" suffix and Archidekt's "(SET)" suffix.
- */
-export function cleanCardName(input: string): string {
-  let name = input.trim();
-
-  // Remove a trailing foil/etched marker like "*F*" or "*E*".
-  name = name.replace(/\s*\*[a-z]\*\s*$/i, "");
-
-  // Remove a trailing "(SET) collector" block. Set codes are 3-5 alnum chars.
-  name = name.replace(/\s*\([0-9a-z]{2,6}\)\s*[0-9a-z-]*\s*$/i, "");
-
-  // Archidekt sometimes appends category tags in square brackets.
-  name = name.replace(/\s*\[[^\]]*\]\s*$/g, "");
-
-  // Collapse a two-sided "Front // Back" name (split, MDFC, transform, adventure)
-  // to its front face. Scryfall's collection endpoint and the engine's card
-  // database both key these cards by a single face, so the full name resolves to
-  // nothing — this is what Moxfield exports for every double-faced card. The
-  // separator is always " // " with surrounding spaces, so this leaves real
-  // names that contain a slash intact (e.g. "SP//dr, Piloted by Peni",
-  // "Summon: Choco/Mog").
-  name = name.split(/\s+\/\/\s+/)[0];
-
-  return name.trim();
 }

--- a/src/lib/decklist.ts
+++ b/src/lib/decklist.ts
@@ -103,8 +103,14 @@ export function cleanCardName(input: string): string {
   // Archidekt sometimes appends category tags in square brackets.
   name = name.replace(/\s*\[[^\]]*\]\s*$/g, "");
 
-  // Collapse a modal/split "Name // Other" to the front face for lookup
-  // safety is NOT applied here — Scryfall resolves full DFC names, so keep it.
+  // Collapse a two-sided "Front // Back" name (split, MDFC, transform, adventure)
+  // to its front face. Scryfall's collection endpoint and the engine's card
+  // database both key these cards by a single face, so the full name resolves to
+  // nothing — this is what Moxfield exports for every double-faced card. The
+  // separator is always " // " with surrounding spaces, so this leaves real
+  // names that contain a slash intact (e.g. "SP//dr, Piloted by Peni",
+  // "Summon: Choco/Mog").
+  name = name.split(/\s+\/\/\s+/)[0];
 
   return name.trim();
 }


### PR DESCRIPTION
## Summary

Pasting or importing a decklist no longer needs any card name edited by hand. A shared **card-name adapter** (`src/lib/cardName.ts` → `normalizeCardName`) converts names the way the platforms write them into the canonical name Scryfall and the engine key on, and it runs on **both** import paths — the pasted-text parser and the Moxfield/Archidekt URL importers.

Motivated by a real report: a Yuriko deck's two-sided cards imported as "not found," and manual entry didn't help because the user didn't know the format.

## The conversion that matters

The one thing every platform emits and the user **can't** turn off is the two-sided `Front // Back` name — split, MDFC, transform, and adventure cards. I confirmed directly that Scryfall's `/cards/collection` endpoint and the engine's card database both key these on the **front face only**:

- `Never // Return` → **NOT FOUND** on both
- `Never` (front face) → **FOUND** ✓

Moxfield and Archidekt export the full `Front // Back` name, so those cards failed Scryfall resolution (the "not found" chip) and were rejected by the engine at match start. The adapter collapses them to the front face. A slash that is part of a real name is preserved — the double-faced separator is always the spaced ` // ` (e.g. `SP//dr, Piloted by Peni`, `Summon: Choco/Mog` are left intact).

Moxfield's default `(C21) 263 *F*` set/collector/foil decorations are still stripped as before. Archidekt's more decorated export (`(set) 123 [Category]`) is intentionally **not** special-cased — its export dialog can emit plain card names, so that's left to the user rather than guessed at.

## Changes

- **`src/lib/cardName.ts`** (new) — `normalizeCardName`, the single anti-corruption point for card names: front-face collapse + the existing set/collector/foil/bracket stripping.
- **`src/lib/decklist.ts`** — the pasted-text parser now delegates to the adapter.
- **`src/lib/deckImport.ts`** — the Moxfield and Archidekt URL importers normalize names through the adapter directly, instead of relying on the editor's text round-trip.
- Tests: `cardName.test.ts` (the adapter, incl. all four two-sided types and the slash-in-name edge cases), an end-to-end "paste a Moxfield export" case in `decklist.test.ts`, and a two-sided URL-import case in `deckImport.test.ts`.
- Docs: changelog `0.1.9` + `package.json` bump (per ADR-0007).

## Verification

- Full suite **84 passed** (+ 2 skipped), `lint` and `build` clean.
- End to end against the actual reported Yuriko import (11 two-sided cards): after the fix, all 80 commander + mainboard cards resolve on Scryfall (0 not found) and exist in the engine database (0 missing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)