### PR TITLE
Accept full Moxfield exports, gate decks at 100 cards, add prepare-match tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ logs
 *.log
 npm-debug.log*
 
+# prepare-match screenshots
+scripts/.artifacts
+
 # phase-rs engine runtime assets (large; fetched via scripts/fetch-engine, not committed)
 public/engine/card-data.json
 public/engine/card-data.json.gz

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,72 @@
+# Agent guide
+
+Notes for automated agents working in this repo. Human-facing docs live in
+`domainbook/` and `README`-style files; this file is about the tooling agents
+lean on.
+
+## Fast-forward to a match: `scripts/prepare-match.mjs`
+
+Validating a decklist by hand means clicking: new deck → paste → save → open →
+play → match setup. This script automates that whole path and stops at **match
+setup — the screen one click before a game starts** — so you can confirm a deck
+survives authoring and setup in seconds instead of driving the UI yourself.
+
+It always starts from a blank slate: **any existing saved decks are removed
+first**, then it creates a throwaway opponent (the built-in example) and the
+player deck under test, and drives through to match setup.
+
+### One-time setup
+
+The browser automation uses [Playwright](https://playwright.dev). It's a dev
+dependency of *this project* (nothing is installed globally), and the browser
+binary is pinned **inside `node_modules`** — `rm -rf node_modules` removes
+everything, and no machine-wide cache is touched.
+
+```bash
+npm install                 # installs the playwright dev dependency
+npm run prepare-match:install   # downloads Chromium into node_modules (~95 MB)
+```
+
+### Usage
+
+Needs the app running. Either start it yourself first:
+
+```bash
+npm run dev                 # in one terminal, then:
+npm run prepare-match       # validates the built-in example deck
+```
+
+…or let the script start and stop its own server with `--serve`:
+
+```bash
+npm run prepare-match -- --serve --deck path/to/decklist.txt
+```
+
+`--deck <file>` is a Moxfield/Archidekt-style decklist (the same text the deck
+editor accepts, `Commander` / `Deck` sections and all). Without it, the built-in
+example deck is used for both seats.
+
+### Flags
+
+| Flag | Effect |
+| --- | --- |
+| `--deck <file>` | Decklist file to load as the player deck (default: built-in example). |
+| `--serve` | Start `npm run dev`, use the URL it prints, and stop it on exit. |
+| `--headed` | Show the browser instead of running headless. |
+| `--keep-open` | Leave the browser open at match setup for hands-on takeover (implies `--headed`). |
+| `--screenshot <path>` | Where to write the final screenshot (default `scripts/.artifacts/pre-game.png`). |
+
+`BASE_URL` (env) overrides the app URL when not using `--serve` (default
+`http://localhost:5173`).
+
+### Output
+
+- **Success**: prints `READY`, the deck names, the enabled Start button label,
+  and writes a screenshot of the match-setup screen. Exit code `0`.
+- **Failure**: prints `FAILED: <reason>` and writes a screenshot of where it got
+  stuck. Exit code `1`. A deck that can't be saved reports the exact editor
+  error — e.g. a short deck yields
+  *"…is not saveable (99 cards): A Commander deck needs exactly 100 cards…"*.
+
+The exit code makes it usable as a check: a valid, engine-ready deck reaches
+match setup and exits `0`; anything that breaks authoring or setup exits `1`.

--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,6 +12,26 @@ depth live there. A purely-internal PR that touches no product or architecture m
 skip its version with a `Skip-Docs: <reason>` trailer instead. There are no
 per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
+## [0.1.10] - 2026-08-18
+
+### Changed
+
+- Two-sided cards (split, MDFC, transform, adventure) are now stored in full as
+  the canonical `Front // Back`, whatever a platform wrote — including Moxfield's
+  bare-slash `Front/Back` shorthand, which previously imported as an unknown card
+  and made the deck invalid. The Scryfall and engine boundaries collapse the
+  stored name to its front face when they query, since both key on that face
+  (`domains/deck-library/features/import-from-a-url.md`).
+- The deck editor now requires exactly 100 cards to save (commander + 99),
+  matching what the engine enforces at game start, so a short deck can no longer
+  be saved and then rejected mid-match
+  (`domains/deck-library/features/author-a-named-deck.md`).
+
+### Fixed
+
+- The built-in example deck is now a legal 100-card list (was 99), so loading it
+  and running a match works without a card-count rejection.
+
 ## [0.1.9] - 2026-08-18
 
 ### Fixed

--- a/domainbook/domains/deck-library/features/author-a-named-deck.md
+++ b/domainbook/domains/deck-library/features/author-a-named-deck.md
@@ -31,6 +31,13 @@ Example: A duplicate nonland is rejected
   And the offending card is named
 ```
 
+```gherkin
+Example: A deck that isn't exactly 100 cards can't be saved
+  Given a decklist with 99 cards (or any count other than 100)
+  When the author looks at the editor
+  Then saving is refused and the count is flagged with the 100-card rule
+```
+
 ## Rule: A saved deck round-trips
 
 ```gherkin
@@ -42,4 +49,5 @@ Example: Reload yields the same list
 
 ## Open Questions
 
-- Whether an incomplete deck (fewer than 99) can be saved as a draft.
+- Whether to also block on singleton and color-identity at save, or keep the
+  engine as the arbiter for those (only the exact-100 count is enforced here).

--- a/domainbook/domains/deck-library/features/import-from-a-url.md
+++ b/domainbook/domains/deck-library/features/import-from-a-url.md
@@ -33,6 +33,14 @@ Example: Importing a Moxfield deck
   And the sideboard and maybeboard are left out
 ```
 
+```gherkin
+Example: A two-sided card, however the platform wrote it
+  Given an exported list naming a split card as "Commit/Memory" or "Commit // Memory"
+  When the author imports or pastes it
+  Then the deck stores the full name "Commit // Memory"
+  And the deck is accepted — the card resolves by its front face "Commit"
+```
+
 ## Rule: The author is told when a URL can't be imported
 
 ```gherkin

--- a/domainbook/domains/deck-library/index.md
+++ b/domainbook/domains/deck-library/index.md
@@ -52,6 +52,12 @@ actually play, so `match setup` always has legal, playable decks to choose from.
 - Two legality gates are kept apart: format legality (`color identity`,
   `singleton`, banlist) is read from Scryfall data; engine `coverage` — is the card
   implemented — is asked of phase-rs. A card can be Commander-legal yet unplayable.
+- A two-sided card (split, MDFC, transform, adventure) is stored in its full
+  `Front // Back` form with the spaced separator, whatever the platform wrote —
+  including Moxfield's bare-slash `Front/Back` shorthand. The `src/lib/cardName.ts`
+  adapter canonicalizes on the way in; the Scryfall and engine boundaries collapse
+  the stored name to its `frontFace` at the point they query, since both key on
+  the front face alone.
 - The existing `src/lib/decklist.ts` parser and `src/lib/scryfall.ts` resolver are
   reused rather than rewritten.
 - A deck may also be brought in by its Moxfield or Archidekt URL, which is fetched
@@ -63,8 +69,9 @@ actually play, so `match setup` always has legal, playable decks to choose from.
 ## Assumptions
 
 - Canonical Scryfall names line up with the engine's card names in the common case;
-  split / modal-double-faced / adventure `//` names and diacritics are the known
-  exceptions.
+  the two both key two-sided cards on the front face, so the stored `Front // Back`
+  name is collapsed to that face before either is queried. Diacritics remain a
+  known exception.
 - The engine exposes a queryable list of implemented cards (phase-rs
   `classify_deck`), so coverage is checked before a game, not discovered during one.
 - The user maintains their own decks; the library does not curate or suggest.
@@ -78,8 +85,8 @@ actually play, so `match setup` always has legal, playable decks to choose from.
 
 ## Open Questions
 
-- How to match split / MDFC / adventure `//` names and diacritics against the
-  engine's card set without false misses.
+- How to match diacritics against the engine's card set without false misses
+  (split / MDFC / adventure `//` names now resolve via the front face).
 - Block a deck that contains unsupported cards, or only warn and let it run with
   those cards absent?
 - Where named decks persist — `localStorage` or IndexedDB — given decks are small

--- a/domainbook/domains/simulation/index.md
+++ b/domainbook/domains/simulation/index.md
@@ -55,6 +55,9 @@ and the finished-game result.
   that seat's move (`get_ai_action_proposal`) and submitting it (`simulation/ADR-0001`).
 - `play mode` keeps the human on their seat and advances phases on space; the AI
   fills the other seats and acts when priority passes to it.
+- The `engine adapter` builds phase-rs's name-only per-seat deck payload from the
+  stored deck, collapsing each two-sided `Front // Back` name to its front face —
+  the only face the engine's card database keys on (`src/engine/deckPayload.ts`).
 - One game runs per WASM instance, in a Web Worker; a `run` plays its matches
   sequentially (`ADR-0005`).
 - A match takes a seed from the session, so games are reproducible.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commander-playtester",
-  "version": "0.1.3",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commander-playtester",
-      "version": "0.1.3",
+      "version": "0.1.10",
       "dependencies": {
         "lucide-react": "^1.31.0",
         "react": "^18.3.1",
@@ -23,6 +23,7 @@
         "eslint-plugin-react-refresh": "^0.4.14",
         "globals": "^15.12.0",
         "jscpd": "^5.0.12",
+        "playwright": "^1.62.1",
         "typescript": "^5.6.3",
         "typescript-eslint": "^8.15.0",
         "vite": "^5.4.11",
@@ -3220,6 +3221,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",
@@ -14,7 +14,9 @@
     "test:watch": "vitest",
     "duplication": "jscpd src",
     "fetch-engine": "bash scripts/fetch-engine.sh",
-    "engine-smoke": "ENGINE_SMOKE=1 vitest run scripts/engine-smoke.test.ts"
+    "engine-smoke": "ENGINE_SMOKE=1 vitest run scripts/engine-smoke.test.ts",
+    "prepare-match": "PLAYWRIGHT_BROWSERS_PATH=0 node scripts/prepare-match.mjs",
+    "prepare-match:install": "PLAYWRIGHT_BROWSERS_PATH=0 playwright install chromium"
   },
   "dependencies": {
     "lucide-react": "^1.31.0",
@@ -32,6 +34,7 @@
     "eslint-plugin-react-refresh": "^0.4.14",
     "globals": "^15.12.0",
     "jscpd": "^5.0.12",
+    "playwright": "^1.62.1",
     "typescript": "^5.6.3",
     "typescript-eslint": "^8.15.0",
     "vite": "^5.4.11",

--- a/scripts/prepare-match.mjs
+++ b/scripts/prepare-match.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+// Drive the app from a blank slate to the match-setup screen — the point just
+// before a game starts — so agents can validate the authoring + setup path fast.
+//
+// Usage: node scripts/prepare-match.mjs [--deck <file>] [--serve]
+//                                       [--headed] [--keep-open]
+//                                       [--screenshot <path>]
+// See AGENTS.md for the full contract.
+
+import { chromium } from "playwright";
+import { spawn } from "node:child_process";
+import { readFileSync, mkdirSync } from "node:fs";
+import { dirname, basename, extname, resolve } from "node:path";
+
+const DECKS_KEY = "commander-playtester/decks/v1";
+const LANG_KEY = "commander-playtester/lang/v1";
+
+function parseArgs(argv) {
+  const opts = {
+    deck: null,
+    serve: false,
+    headed: false,
+    keepOpen: false,
+    screenshot: "scripts/.artifacts/pre-game.png",
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--deck") opts.deck = argv[++i];
+    else if (a === "--screenshot") opts.screenshot = argv[++i];
+    else if (a === "--serve") opts.serve = true;
+    else if (a === "--headed") opts.headed = true;
+    else if (a === "--keep-open") opts.keepOpen = true;
+    else throw new Error(`Unknown argument: ${a}`);
+  }
+  if (opts.keepOpen) opts.headed = true;
+  return opts;
+}
+
+function startDevServer() {
+  return new Promise((resolveUrl, reject) => {
+    const child = spawn("npm", ["run", "dev"], { stdio: ["ignore", "pipe", "pipe"] });
+    const timer = setTimeout(() => {
+      child.kill();
+      reject(new Error("dev server did not report a URL within 60s"));
+    }, 60_000);
+    const onData = (buf) => {
+      const m = String(buf).match(/Local:\s+(http:\/\/\S+)/);
+      if (m) {
+        clearTimeout(timer);
+        child.stdout.off("data", onData);
+        resolveUrl({ url: m[1].replace(/\/$/, ""), child });
+      }
+    };
+    child.stdout.on("data", onData);
+    child.stderr.on("data", () => {});
+    child.on("exit", (code) => reject(new Error(`dev server exited early (code ${code})`)));
+  });
+}
+
+async function shot(page, path) {
+  mkdirSync(dirname(resolve(path)), { recursive: true });
+  await page.screenshot({ path: resolve(path), fullPage: true });
+}
+
+async function createDeck(page, { name, deckText }) {
+  await page.getByRole("button", { name: "+ New deck" }).click();
+  await page.getByPlaceholder("e.g. Atraxa Superfriends").fill(name);
+  if (deckText === null) {
+    await page.getByRole("button", { name: "Load example" }).click();
+  } else {
+    await page.locator("textarea.import__textarea").fill(deckText);
+  }
+  const count = (await page.locator(".chip", { hasText: /cards/ }).first().textContent())?.trim();
+  const save = page.getByRole("button", { name: "Save deck" });
+  if (await save.isDisabled()) {
+    const err = (await page.locator(".error").first().textContent())?.trim() ?? "save is disabled";
+    throw new Error(`deck "${name}" is not saveable (${count}): ${err}`);
+  }
+  await save.click();
+  await page.locator(".deck-list__info", { hasText: name }).waitFor();
+  return count;
+}
+
+async function run(opts) {
+  let baseUrl = process.env.BASE_URL ?? "http://localhost:5173";
+  let devServer = null;
+  if (opts.serve) {
+    devServer = await startDevServer();
+    baseUrl = devServer.url;
+  }
+
+  const playerText = opts.deck ? readFileSync(resolve(opts.deck), "utf8") : null;
+  const playerName = opts.deck
+    ? basename(opts.deck, extname(opts.deck))
+    : "Sample Player";
+
+  const browser = await chromium.launch({ headless: !opts.headed });
+  const context = await browser.newContext({ locale: "en-US" });
+  await context.addInitScript(
+    ([key, lang]) => localStorage.setItem(key, lang),
+    [LANG_KEY, "en"],
+  );
+  const page = await context.newPage();
+
+  try {
+    try {
+      await page.goto(baseUrl, { waitUntil: "domcontentloaded", timeout: 15_000 });
+    } catch {
+      throw new Error(
+        `could not reach ${baseUrl} — start the dev server (npm run dev) or pass --serve`,
+      );
+    }
+
+    await page.evaluate((key) => localStorage.removeItem(key), DECKS_KEY);
+    await page.reload({ waitUntil: "domcontentloaded" });
+
+    await createDeck(page, { name: "Sample Opponent", deckText: null });
+    const playerCount = await createDeck(page, { name: playerName, deckText: playerText });
+
+    await page.locator(".deck-list__info", { hasText: playerName }).click();
+    await page.getByRole("button", { name: "Test in a match →" }).click();
+    await page.getByRole("heading", { name: "Match setup" }).waitFor();
+
+    const start = page.getByRole("button", { name: /^Start/ });
+    await start.waitFor();
+    if (await start.isDisabled()) {
+      throw new Error("reached match setup but the Start button is disabled");
+    }
+    const startLabel = (await start.textContent())?.trim();
+
+    await shot(page, opts.screenshot);
+
+    console.log("READY — at match setup, one click before the game starts.");
+    console.log(`  player deck : ${playerName} (${playerCount})`);
+    console.log(`  opponent    : Sample Opponent`);
+    console.log(`  start button: "${startLabel}" (enabled)`);
+    console.log(`  screenshot  : ${opts.screenshot}`);
+
+    if (opts.keepOpen) {
+      console.log("\n--keep-open: browser left at match setup. Press Ctrl+C to exit.");
+      await new Promise(() => {});
+    }
+  } catch (err) {
+    await shot(page, opts.screenshot).catch(() => {});
+    console.error(`  screenshot of failure: ${opts.screenshot}`);
+    throw err;
+  } finally {
+    if (!opts.keepOpen) await browser.close();
+    if (devServer) devServer.child.kill();
+  }
+}
+
+try {
+  await run(parseArgs(process.argv.slice(2)));
+} catch (err) {
+  console.error(`FAILED: ${err.message}`);
+  process.exit(1);
+}

--- a/src/deck/DeckEditor.tsx
+++ b/src/deck/DeckEditor.tsx
@@ -62,6 +62,7 @@ export function DeckEditor({
   const commanderCount = parsed.commanders.reduce((n, e) => n + e.quantity, 0);
   const mainboardCount = parsed.mainboard.reduce((n, e) => n + e.quantity, 0);
   const total = commanderCount + mainboardCount;
+  const isHundred = total === 100;
 
   function handleSave() {
     const now = Date.now();
@@ -144,7 +145,12 @@ export function DeckEditor({
           {parsed.commanders.map((e) => e.name).join(", ") ||
             t("deck.noCommander")}
         </span>
-        <span className="chip">{t("deck.cards", { n: total })}</span>
+        <span
+          className="chip"
+          style={total > 0 && !isHundred ? { color: "var(--bad)" } : undefined}
+        >
+          {t("deck.cards", { n: total })}
+        </span>
         {parsed.warnings.length > 0 && (
           <span className="chip" style={{ color: "var(--bad)" }}>
             {t("editor.linesUnread", { n: parsed.warnings.length })}
@@ -160,9 +166,12 @@ export function DeckEditor({
           })}
         </p>
       )}
+      {total > 0 && !isHundred && (
+        <p className="error">{t("editor.needHundred", { n: total })}</p>
+      )}
 
       <div className="import__row">
-        <button className="btn" onClick={handleSave} disabled={total === 0}>
+        <button className="btn" onClick={handleSave} disabled={!isHundred}>
           {t("editor.save")}
         </button>
         <button className="btn btn--ghost" onClick={onCancel}>

--- a/src/deck/model.test.ts
+++ b/src/deck/model.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { totalCards, deckToText } from "./model";
 import type { SavedDeck } from "./model";
 import { parseDecklist } from "../lib/decklist";
+import { SAMPLE_DECK } from "../lib/sampleDeck";
 
 const deck: SavedDeck = {
   id: "x",
@@ -24,5 +25,15 @@ describe("deck model", () => {
     const parsed = parseDecklist(deckToText(deck));
     expect(parsed.commanders).toEqual(deck.commanders);
     expect(parsed.mainboard).toEqual(deck.mainboard);
+  });
+
+  it("the sample deck is a legal 100-card Commander deck", () => {
+    const parsed = parseDecklist(SAMPLE_DECK);
+    const total = [...parsed.commanders, ...parsed.mainboard].reduce(
+      (n, e) => n + e.quantity,
+      0,
+    );
+    expect(total).toBe(100);
+    expect(parsed.warnings).toEqual([]);
   });
 });

--- a/src/deck/model.ts
+++ b/src/deck/model.ts
@@ -29,9 +29,9 @@ export function uniqueCardNames(deck: SavedDeck): string[] {
 }
 
 /**
- * Commander legality is exactly 100 cards (1-2 commanders + the rest).
- * We report the count rather than block on it — partners, companions, and
- * the odd 101-card list exist, and the engine is the real arbiter.
+ * Commander legality is exactly 100 cards (1-2 commanders + the rest). The
+ * editor blocks saving anything else, matching what the engine enforces at
+ * game start.
  */
 export function isHundredCards(deck: SavedDeck): boolean {
   return totalCards(deck) === 100;

--- a/src/engine/deckPayload.test.ts
+++ b/src/engine/deckPayload.test.ts
@@ -28,6 +28,11 @@ describe("toPlayerDeck", () => {
     expect(p.commander).toEqual(["Cmd A"]);
     expect(p.main_deck).toEqual(["Island", "Island", "Sol Ring"]);
   });
+
+  it("collapses a stored two-sided name to its front face for the engine", () => {
+    const p = toPlayerDeck(deck("A", "Cmd A", [[1, "Commit // Memory"]]));
+    expect(p.main_deck).toEqual(["Commit"]);
+  });
 });
 
 describe("buildDeckList", () => {

--- a/src/engine/deckPayload.ts
+++ b/src/engine/deckPayload.ts
@@ -1,11 +1,13 @@
 import type { SavedDeck } from "../deck/model";
 import type { DecklistEntry } from "../lib/types";
+import { frontFace } from "../lib/cardName";
 import type { EngineDeckList, PlayerDeckPayload } from "./types";
 
 function expand(entries: DecklistEntry[]): string[] {
   const names: string[] = [];
   for (const entry of entries) {
-    for (let i = 0; i < entry.quantity; i++) names.push(entry.name);
+    const name = frontFace(entry.name);
+    for (let i = 0; i < entry.quantity; i++) names.push(name);
   }
   return names;
 }

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -47,6 +47,10 @@ export const messages = {
   },
   "editor.linesUnread": { pt: "{n} linhas não lidas", en: "{n} lines not read" },
   "editor.unread": { pt: "Não lidas: {list}", en: "Not read: {list}" },
+  "editor.needHundred": {
+    pt: "Um deck de Commander precisa de exatamente 100 cartas (comandante + 99). Este tem {n}.",
+    en: "A Commander deck needs exactly 100 cards (commander + 99). This one has {n}.",
+  },
   "editor.untitled": { pt: "Deck sem nome", en: "Untitled deck" },
   "editor.save": { pt: "Salvar deck", en: "Save deck" },
   "editor.cancel": { pt: "Cancelar", en: "Cancel" },

--- a/src/lib/cardName.test.ts
+++ b/src/lib/cardName.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { normalizeCardName } from "./cardName";
+import { normalizeCardName, frontFace } from "./cardName";
 
 describe("normalizeCardName", () => {
   it("leaves a plain name untouched", () => {
@@ -17,25 +17,48 @@ describe("normalizeCardName", () => {
     expect(normalizeCardName("Sol Ring [Ramp]")).toBe("Sol Ring");
   });
 
-  it("collapses two-sided 'Front // Back' names to the front face", () => {
-    // Split, MDFC, transform, and adventure cards all export this way; Scryfall
-    // and the engine only key the front face.
-    expect(normalizeCardName("Never // Return")).toBe("Never");
+  it("keeps a two-sided name whole, with the canonical ' // ' separator", () => {
+    // Split, MDFC, transform, and adventure cards are stored in full; the
+    // engine and Scryfall boundaries collapse to the front face themselves.
+    expect(normalizeCardName("Never // Return")).toBe("Never // Return");
     expect(normalizeCardName("Malakir Rebirth // Malakir Mire")).toBe(
-      "Malakir Rebirth",
+      "Malakir Rebirth // Malakir Mire",
     );
-    expect(normalizeCardName("Valki, God of Lies // Tibalt, Cosmic Impostor")).toBe(
-      "Valki, God of Lies",
+    // Still normalizes when Moxfield appends set + collector metadata.
+    expect(normalizeCardName("Connive // Concoct (GRN) 222")).toBe(
+      "Connive // Concoct",
     );
-    // Still collapses when Moxfield appends set + collector metadata.
-    expect(normalizeCardName("Connive // Concoct (GRN) 222")).toBe("Connive");
+  });
+
+  it("rewrites Moxfield's bare-slash split shorthand to ' // '", () => {
+    // Moxfield exports some split cards as a bare slash between space-free faces.
+    expect(normalizeCardName("Commit/Memory")).toBe("Commit // Memory");
+    expect(normalizeCardName("Rags/Riches")).toBe("Rags // Riches");
+    expect(normalizeCardName("Discovery/Dispersal (GRN) 223")).toBe(
+      "Discovery // Dispersal",
+    );
   });
 
   it("keeps a slash that is part of the real name (not a face separator)", () => {
-    // The face separator is always " // " with surrounding spaces.
+    // Real names with a slash are never a bare token/token pair.
     expect(normalizeCardName("SP//dr, Piloted by Peni")).toBe(
       "SP//dr, Piloted by Peni",
     );
     expect(normalizeCardName("Summon: Choco/Mog")).toBe("Summon: Choco/Mog");
+  });
+});
+
+describe("frontFace", () => {
+  it("returns the front face of a two-sided name", () => {
+    expect(frontFace("Commit // Memory")).toBe("Commit");
+    expect(frontFace("Valki, God of Lies // Tibalt, Cosmic Impostor")).toBe(
+      "Valki, God of Lies",
+    );
+  });
+
+  it("leaves a plain name and a real slashed name untouched", () => {
+    expect(frontFace("Sol Ring")).toBe("Sol Ring");
+    expect(frontFace("Summon: Choco/Mog")).toBe("Summon: Choco/Mog");
+    expect(frontFace("SP//dr, Piloted by Peni")).toBe("SP//dr, Piloted by Peni");
   });
 });

--- a/src/lib/cardName.ts
+++ b/src/lib/cardName.ts
@@ -3,17 +3,20 @@
  *
  * Turns a card name the way a deck platform writes it (a Moxfield or Archidekt
  * export line, a URL-import API payload, or a plain paste) into the canonical
- * name that Scryfall's collection endpoint and the engine's card database key
- * on. Both the pasted-decklist parser and the URL importers run every name
- * through here, so pasting an exported decklist needs no hand-editing.
+ * name we persist in a deck. Both the pasted-decklist parser and the URL
+ * importers run every name through {@link normalizeCardName}, so pasting an
+ * exported decklist needs no hand-editing.
  *
- * The one conversion the platforms always emit — and that the user cannot turn
- * off — is the two-sided "Front // Back" name (split, MDFC, transform,
- * adventure): Scryfall and the engine both key these on the front face alone,
- * so the full name resolves to nothing. We collapse it to the front face. A
- * slash that is part of the real name is preserved ("SP//dr, Piloted by Peni",
- * "Summon: Choco/Mog") because the double-faced separator is always the spaced
- * " // ".
+ * A two-sided card (split, MDFC, transform, adventure) is stored in its full
+ * "Front // Back" form with the spaced separator. Platforms write it two ways:
+ * the spaced "Connive // Concoct" and Moxfield's bare-slash "Connive/Concoct"
+ * shorthand; both normalize to the canonical " // ". A slash that is part of a
+ * real name is left alone — such names are never a bare token/token pair
+ * ("Summon: Choco/Mog", "SP//dr, Piloted by Peni").
+ *
+ * Scryfall's collection endpoint and the engine's card database both key on the
+ * front face alone, so those boundaries collapse the stored name with
+ * {@link frontFace} at the point they use it.
  *
  * We also strip the optional set/collector/foil/category decorations Moxfield
  * appends by default ("(C21) 263 *F*"); Archidekt's more decorated export is not
@@ -31,8 +34,25 @@ export function normalizeCardName(input: string): string {
   // Remove a trailing category tag in square brackets.
   name = name.replace(/\s*\[[^\]]*\]\s*$/g, "");
 
-  // Collapse a two-sided "Front // Back" name to its front face.
-  name = name.split(/\s+\/\/\s+/)[0];
+  name = name.trim();
+
+  // Canonicalize a two-sided name to the spaced " // " separator. Moxfield's
+  // bare-slash shorthand is a chain of space-free faces ("Commit/Memory"); no
+  // real card name is shaped that way, so rewriting it is safe.
+  if (/^[^\s/]+(?:\/[^\s/]+)+$/.test(name)) {
+    name = name.split("/").join(" // ");
+  } else {
+    name = name.split(/\s+\/\/\s+/).join(" // ");
+  }
 
   return name.trim();
+}
+
+/**
+ * The front face of a stored "Front // Back" name — the key Scryfall's
+ * collection endpoint and the engine's card database resolve on. Plain names,
+ * and real names that merely contain a slash, are returned unchanged.
+ */
+export function frontFace(name: string): string {
+  return name.split(" // ")[0].trim();
 }

--- a/src/lib/deckImport.test.ts
+++ b/src/lib/deckImport.test.ts
@@ -64,7 +64,7 @@ describe("parseMoxfield", () => {
     expect(all).not.toContain("Grafdigger's Cage"); // sideboard
   });
 
-  it("collapses a two-sided card name to its front face", () => {
+  it("keeps a two-sided card name whole, canonicalized", () => {
     const deck = parseMoxfield({
       name: "DFC deck",
       boards: {
@@ -73,7 +73,7 @@ describe("parseMoxfield", () => {
         },
       },
     });
-    expect(deck.mainboard.map((e) => e.name)).toEqual(["Never"]);
+    expect(deck.mainboard.map((e) => e.name)).toEqual(["Never // Return"]);
   });
 
   it("routes the commanders board and ignores the maybeboard", () => {

--- a/src/lib/decklist.test.ts
+++ b/src/lib/decklist.test.ts
@@ -54,8 +54,8 @@ describe("parseDecklist", () => {
     ]);
     expect(parsed.mainboard.map((e) => e.name)).toEqual([
       "Sol Ring",
-      "Never",
-      "Discovery",
+      "Never // Return",
+      "Discovery // Dispersal",
     ]);
     expect(parsed.warnings).toEqual([]);
   });

--- a/src/lib/sampleDeck.ts
+++ b/src/lib/sampleDeck.ts
@@ -102,6 +102,7 @@ Deck
 1 Swamp
 1 Island
 1 Island
+1 Island
 1 Evolving Wilds
 1 Terramorphic Expanse
 1 Fabled Passage

--- a/src/lib/scryfall.test.ts
+++ b/src/lib/scryfall.test.ts
@@ -77,4 +77,21 @@ describe("resolveDeck", () => {
     expect(deck.library.every((c) => c.name === "Forest")).toBe(true);
     expect(deck.unresolved).toEqual(["Nonexistent Card"]);
   });
+
+  it("resolves a stored two-sided name by querying its front face", async () => {
+    const parsed = parseDecklist("Deck\n1 Commit // Memory");
+    // Scryfall knows the card only under the front face "Commit"; it echoes the
+    // full name back on the returned card.
+    const fetchImpl = fakeFetch({
+      Commit: {
+        name: "Commit // Memory",
+        cmc: 4,
+        type_line: "Instant // Sorcery",
+      },
+    });
+
+    const deck = await resolveDeck(parsed, fetchImpl);
+    expect(deck.library.map((c) => c.name)).toEqual(["Commit // Memory"]);
+    expect(deck.unresolved).toEqual([]);
+  });
 });

--- a/src/lib/scryfall.ts
+++ b/src/lib/scryfall.ts
@@ -5,6 +5,7 @@ import type {
   ResolvedDeck,
 } from "./types";
 import { classifyRoles } from "./roles";
+import { frontFace } from "./cardName";
 
 const SCRYFALL_COLLECTION_URL = "https://api.scryfall.com/cards/collection";
 const BATCH_SIZE = 75; // Scryfall's documented max identifiers per request.
@@ -88,8 +89,11 @@ export async function fetchCards(
   const notFound: string[] = [];
 
   for (const batch of chunk(uniqueNames, BATCH_SIZE)) {
+    // Scryfall keys two-sided cards on the front face; send that, not the
+    // stored "Front // Back" name. The returned card carries its full name, and
+    // lookup() reconciles it back to the requested name.
     const body = JSON.stringify({
-      identifiers: batch.map((name) => ({ name })),
+      identifiers: batch.map((name) => ({ name: frontFace(name) })),
     });
     const res = await fetchImpl(SCRYFALL_COLLECTION_URL, {
       method: "POST",


### PR DESCRIPTION
Ships changelog **0.1.10** plus a validation tool for developer agents.

## Product changes

- **Accept full Moxfield exports.** Two-sided cards (split, MDFC, transform, adventure) are stored as the canonical `Front // Back`, including Moxfield's bare-slash `Front/Back` shorthand — which previously imported as an unknown card and made the deck invalid. The Scryfall and engine boundaries collapse the stored name to its front face when they query, since both key on that face.
- **Gate decks at exactly 100 cards.** The deck editor now blocks saving anything that isn't 100 cards (commander + 99), with an inline reason and a red count chip, matching what the engine enforces at game start. A short deck can no longer be saved and then rejected mid-match.
- **Fix the built-in example deck.** It was 99 cards, so loading it and starting a match failed on the count check; it's now a legal 100, locked in by a test.

## Tooling

- **`scripts/prepare-match.mjs`** drives the app from a blank slate — removing any existing decks first — through deck authoring to the **Match setup** screen, the point one click before a game starts. It exits `0` when a deck reaches setup and `1` with the exact editor error when it can't, so it doubles as a deck-validation check, and writes a screenshot either way.
  - `npm run prepare-match [-- --deck <file>] [--serve] [--headed] [--keep-open] [--screenshot <path>]`
  - Uses Playwright (lighter than Selenium: no separate driver, bundled browser, auto-waiting). It's a **project-local** dev dependency with its Chromium pinned inside `node_modules` — nothing is installed globally.
  - Documented in **AGENTS.md**.

## Verification

- `npm run prepare-match` and `--deck <moxfield export>` both reach match setup and exit `0`; a deliberately 99-card deck exits `1` with `…is not saveable (99 cards): A Commander deck needs exactly 100 cards…`.
- `--serve` self-starts Vite on a free port and tears it down (no orphaned process).
- typecheck, lint, 90 tests, and `domainbook check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)