### PR TITLE
Cast the commander from the command zone in play mode

### DIFF
--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,6 +12,15 @@ depth live there. A purely-internal PR that touches no product or architecture m
 skip its version with a `Skip-Docs: <reason>` trailer instead. There are no
 per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
+## [0.2.0] - 2026-08-18
+
+### Added
+
+- Play mode lets you cast your commander from the command zone: when you can pay
+  for it, the commander is highlighted and a click casts it — previously only
+  hand cards could be played, leaving no way to cast the commander by hand
+  (`domains/simulation/features/step-through-a-turn.md`).
+
 ## [0.1.10] - 2026-08-18
 
 ### Changed

--- a/domainbook/domains/simulation/features/step-through-a-turn.md
+++ b/domainbook/domains/simulation/features/step-through-a-turn.md
@@ -60,6 +60,20 @@ Example: Naming a creature type
   And you may instead let the AI choose for you
 ```
 
+## Rule: You put cards into play by dragging from hand, or clicking the commander in its zone
+
+```gherkin
+Example: Playing a card from your hand
+  Given it is your main phase and a hand card has a legal play
+  When you drag it onto a matching battlefield slot
+  Then the card is played and its cost is paid
+
+Example: Casting your commander from the command zone
+  Given it is your main phase and you can pay for your commander
+  Then the commander is highlighted as castable in the command zone
+  And clicking it casts the commander from the command zone onto the stack
+```
+
 ## Rule: Pass turn advances your own turn and stops when an opponent acts
 
 ```gherkin

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.1.10",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",

--- a/src/App.css
+++ b/src/App.css
@@ -685,6 +685,15 @@ th {
   box-shadow: 0 0 0 3px var(--accent);
 }
 
+/* ── Click-to-cast the commander from the command zone ─────────── */
+.card--castable {
+  cursor: pointer;
+  box-shadow: 0 0 0 2px var(--accent);
+}
+.card--castable:hover {
+  box-shadow: 0 0 0 3px var(--accent);
+}
+
 /* ── Combat: declare attackers ─────────────────────────────────── */
 .card--attacker {
   cursor: pointer;

--- a/src/board/Board.tsx
+++ b/src/board/Board.tsx
@@ -21,14 +21,15 @@ import type { BoardView, SeatView } from "./boardView";
 import { useI18n } from "../i18n/I18nContext";
 import { categoryLabel } from "../i18n/messages";
 
-/** Play-mode interaction for the human's seat: drag a hand card to a slot. */
+/** Play-mode interaction for the human's seat: drag a hand card to a slot, or
+ * click the commander in the command zone to cast it. */
 export interface PlayInteraction {
-  /** Hand object ids that have a legal play action right now. */
+  /** Object ids that have a legal play action right now (hand or command zone). */
   playableIds: Set<number>;
   /** Object id currently being dragged, or null. */
   dragging: number | null;
   setDragging: (id: number | null) => void;
-  /** Play the hand card with this object id (drag dropped on a valid slot). */
+  /** Play the object with this id (dropped on a valid slot, or clicked to cast). */
   onPlay: (objId: number) => void;
 }
 
@@ -165,6 +166,15 @@ function manaProps(
 ): { manaSource?: boolean; onTapSource?: () => void } {
   if (!mana || !mana.sourceIds.has(o.id)) return {};
   return { manaSource: true, onTapSource: () => mana.onTapSource(o.id) };
+}
+
+/** Command-zone cast: click your commander when the engine offers its cast. */
+function commanderCastProps(
+  o: GameObject,
+  play?: PlayInteraction,
+): { castable?: boolean; onCast?: () => void } {
+  if (!play || !play.playableIds.has(o.id)) return {};
+  return { castable: true, onCast: () => play.onPlay(o.id) };
 }
 
 const MANA_COLOR: Record<string, string> = {
@@ -416,6 +426,7 @@ function Seat({
                 {...attackProps(c, you ? attack : undefined)}
                 {...(you ? blockerProps(c, block) : blockTargetProps(c, block))}
                 {...manaProps(c, you ? mana : undefined)}
+                {...commanderCastProps(c, you ? play : undefined)}
               />
             ))}
           </div>
@@ -583,6 +594,8 @@ function Card({
   onAssignBlock,
   manaSource,
   onTapSource,
+  castable,
+  onCast,
 }: {
   obj: GameObject;
   images?: Record<string, string>;
@@ -607,6 +620,8 @@ function Card({
   onAssignBlock?: () => void;
   manaSource?: boolean;
   onTapSource?: () => void;
+  castable?: boolean;
+  onCast?: () => void;
 }) {
   const url = obj.name ? images?.[obj.name.toLowerCase()] : undefined;
   const isCreature = obj.card_types?.core_types?.includes("Creature") ?? false;
@@ -625,6 +640,7 @@ function Card({
     blockSelected ? "card--block-selected" : "",
     blockTarget ? "card--block-target" : "",
     manaSource ? "card--mana-source" : "",
+    castable ? "card--castable" : "",
   ]
     .filter(Boolean)
     .join(" ");
@@ -648,6 +664,7 @@ function Card({
 
   const click =
     onChoose ??
+    onCast ??
     onActivate ??
     onToggleAttack ??
     onSelectBlock ??


### PR DESCRIPTION
## What

In manual **play** mode you couldn't cast your commander. Casting was wired only to hand cards (drag onto a battlefield slot), so the commander sat inert in the command zone — not draggable, not clickable — even though the engine offers the cast as a normal `CastSpell` and `RunView`'s `playableIds` already contained its object id.

This surfaces that: when the commander is castable, its command-zone card is highlighted and a **click** casts it, routing through the existing `onPlay` used by hand cards.

## Changes

- `src/board/Board.tsx` — `commanderCastProps` helper; the command-zone card gets `castable`/`onCast` when its id is in `playableIds`; `onCast` added to `Card` and to the click chain (after target-selection, so a targeting window still wins).
- `src/App.css` — `.card--castable` highlight (pointer + accent glow), matching the activatable/mana-source affordances.
- `domainbook/domains/simulation/features/step-through-a-turn.md` — documents how cards enter play (hand drag) and commander casting.
- `changelog.md` + `package.json` — 0.2.0.

## Verification

Drove a real match (Isamaru + 99 Plains) in the browser:

1. Commander with no mana → not highlighted, not castable (baseline).
2. Played a Plains → command-zone card became `card--castable` (pointer + accent glow).
3. Clicked it → game log: *"Isamaru moves from Command to Stack" / "Player 1 casts Isamaru"*; a Plains auto-tapped for W.
4. Passed priority → *"Isamaru moves from Stack to Battlefield"*; now in the Creatures row.

`tsc` clean · `eslint` clean · 90 tests pass · `domainbook check --staged` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)