### PR TITLE
Default deck name to commander, tap-to-play on touch, resilient import

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/deck-proxy/README.md
+++ b/deck-proxy/README.md
@@ -6,9 +6,12 @@ Archidekt only send permissive CORS headers to their own front-ends, so a
 cross-origin `fetch` from the app is blocked. This tiny [Cloudflare Worker][cf]
 forwards one allowlisted request and adds the CORS headers the browser needs.
 
-By default the app falls back to a public proxy (`api.allorigins.win`), which is
-fine for trying it out but is rate-limited, occasionally down, and can't reach
-Moxfield (see below). Deploy this worker for a reliable import.
+By default the app tries a chain of public proxies (`api.allorigins.win`,
+`api.codetabs.com`) in turn, taking the first that answers. Each is
+rate-limited and intermittently down, so trying several is more reliable than
+one — but none is dependable, and reaching Moxfield needs an approved
+User-Agent (see below) that public proxies don't send. Deploy this worker for
+reliable imports.
 
 ## Deploy
 

--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,6 +12,27 @@ depth live there. A purely-internal PR that touches no product or architecture m
 skip its version with a `Skip-Docs: <reason>` trailer instead. There are no
 per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
+## [0.2.1] - 2026-08-18
+
+### Added
+
+- A deck left unnamed adopts its commander's name, and the name field previews
+  the commander as its placeholder, so imported or typed decks need no manual
+  naming (`domains/deck-library/features/author-a-named-deck.md`).
+
+### Changed
+
+- URL import tries a chain of public proxies and takes the first that answers,
+  instead of relying on one that may be rate-limited or down
+  (`domains/deck-library/features/import-from-a-url.md`).
+
+### Fixed
+
+- Play mode on touch devices: a hand card can be played by tapping it and then a
+  slot, not only by dragging — HTML5 drag doesn't fire on touch, so cards
+  previously couldn't be played on mobile
+  (`domains/simulation/features/step-through-a-turn.md`).
+
 ## [0.2.0] - 2026-08-18
 
 ### Added

--- a/domainbook/domains/board/index.md
+++ b/domainbook/domains/board/index.md
@@ -42,7 +42,9 @@ way whether they are playing or watching.
 
 ## Business Decisions
 
-- Fixed, Arena-style slots — no dragging cards, no fancy animation (project scope).
+- Fixed, Arena-style slots, no fancy animation (project scope); a hand card is
+  played onto a slot either by dragging it there or, for touch where HTML5 drag
+  doesn't fire, by tapping the card and then the slot.
 - A phase rail the human advances with space in `play mode`; the same rail is
   display-only in `watch mode`.
 - Reveal-hands renders opponents' hands face-up only when `match setup` turned it

--- a/domainbook/domains/deck-library/features/author-a-named-deck.md
+++ b/domainbook/domains/deck-library/features/author-a-named-deck.md
@@ -38,6 +38,25 @@ Example: A deck that isn't exactly 100 cards can't be saved
   Then saving is refused and the count is flagged with the 100-card rule
 ```
 
+## Rule: A deck left unnamed takes its commander's name
+
+The name field is optional. While it is empty it shows the commander's name as its
+placeholder, and saving with it still empty adopts that commander name as the deck
+name — so an imported or typed deck never has to be named by hand.
+
+```gherkin
+Example: Saving without typing a name
+  Given a decklist whose Commander section names "Krenko, Mob Boss"
+  And the author leaves the name field empty
+  When the author saves the deck
+  Then the deck is saved as "Krenko, Mob Boss"
+
+Example: The name field previews the commander
+  Given a decklist with a commander and an empty name field
+  When the author looks at the name field
+  Then its placeholder shows the commander's name
+```
+
 ## Rule: A saved deck round-trips
 
 ```gherkin

--- a/domainbook/domains/deck-library/features/import-from-a-url.md
+++ b/domainbook/domains/deck-library/features/import-from-a-url.md
@@ -60,11 +60,22 @@ Example: The deck can't be reached
   Then the author sees why — not found, or the import proxy is unreachable
 ```
 
-## Open Questions
+## Rule: The import survives a flaky proxy
 
-- Whether to rely on the default public proxy or require the owned `deck-proxy`
-  worker; Moxfield needs the owned proxy with an approved User-Agent, Archidekt
-  works through either.
+With no owned proxy configured, the import tries a chain of public proxies in
+turn and takes the first that answers, so one being rate-limited or down doesn't
+fail the import on its own. Full reliability still needs the owned `deck-proxy`
+worker — and Moxfield only answers it with an approved User-Agent.
+
+```gherkin
+Example: The first proxy is down
+  Given no owned proxy is configured
+  And the first public proxy is unreachable
+  When the author imports a supported deck
+  Then a later proxy in the chain fetches it and the import succeeds
+```
+
+## Open Questions
 - Whether Ligamagic could be supported later (its deck data is behind a page
   session token, so it would need a different approach than a plain fetch).
 - Whether to import more than the mainboard and commanders (companions,

--- a/domainbook/domains/simulation/features/step-through-a-turn.md
+++ b/domainbook/domains/simulation/features/step-through-a-turn.md
@@ -60,13 +60,19 @@ Example: Naming a creature type
   And you may instead let the AI choose for you
 ```
 
-## Rule: You put cards into play by dragging from hand, or clicking the commander in its zone
+## Rule: You put cards into play by dragging or tapping from hand, or clicking the commander in its zone
 
 ```gherkin
 Example: Playing a card from your hand
   Given it is your main phase and a hand card has a legal play
   When you drag it onto a matching battlefield slot
   Then the card is played and its cost is paid
+
+Example: Playing a card by tapping (touch)
+  Given it is your main phase and a hand card has a legal play
+  When you tap the card and then tap a matching battlefield slot
+  Then the card is played and its cost is paid
+  And tapping the card again instead clears the selection
 
 Example: Casting your commander from the command zone
   Given it is your main phase and you can pay for your commander

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",

--- a/src/App.css
+++ b/src/App.css
@@ -650,6 +650,10 @@ th {
 .card--draggable:active {
   cursor: grabbing;
 }
+.card--selected {
+  cursor: pointer;
+  box-shadow: 0 0 0 3px var(--accent);
+}
 .card--unplayable {
   opacity: 0.5;
 }

--- a/src/board/Board.tsx
+++ b/src/board/Board.tsx
@@ -457,6 +457,11 @@ function DropLane({ card, play }: { card: GameObject; play: PlayInteraction }) {
           <div
             key={cat}
             className={`slot ${ok ? "slot--ok" : "slot--no"}`}
+            onClick={() => {
+              if (!ok || play.dragging == null) return;
+              play.onPlay(play.dragging);
+              play.setDragging(null);
+            }}
             onDragOver={(e) => {
               if (ok) e.preventDefault();
             }}
@@ -506,6 +511,12 @@ function HandRow({
               onHover={onHover}
               draggable={playable}
               playable={play ? playable : undefined}
+              selected={play?.dragging === o.id}
+              onTapPlay={
+                playable && play
+                  ? () => play.setDragging(play.dragging === o.id ? null : o.id)
+                  : undefined
+              }
               onDragStart={
                 playable && play
                   ? () => {
@@ -576,6 +587,8 @@ function Card({
   onHover,
   draggable,
   playable,
+  selected,
+  onTapPlay,
   onDragStart,
   onDragEnd,
   targetable,
@@ -602,6 +615,8 @@ function Card({
   onHover?: (p: Preview | null) => void;
   draggable?: boolean;
   playable?: boolean;
+  selected?: boolean;
+  onTapPlay?: () => void;
   onDragStart?: () => void;
   onDragEnd?: () => void;
   targetable?: boolean;
@@ -629,6 +644,7 @@ function Card({
     "card",
     obj.tapped ? "card--tapped" : "",
     draggable ? "card--draggable" : "",
+    selected ? "card--selected" : "",
     playable === false ? "card--unplayable" : "",
     targetable ? "card--targetable" : "",
     targeted ? "card--targeted" : "",
@@ -669,7 +685,8 @@ function Card({
     onToggleAttack ??
     onSelectBlock ??
     onAssignBlock ??
-    onTapSource;
+    onTapSource ??
+    onTapPlay;
   const common = {
     className: url ? cls : `${cls} card--text`,
     title: obj.name,

--- a/src/deck/DeckEditor.tsx
+++ b/src/deck/DeckEditor.tsx
@@ -59,6 +59,7 @@ export function DeckEditor({
   }
 
   const parsed = useMemo(() => parseDecklist(text), [text]);
+  const commanderName = parsed.commanders.map((e) => e.name).join(" & ");
   const commanderCount = parsed.commanders.reduce((n, e) => n + e.quantity, 0);
   const mainboardCount = parsed.mainboard.reduce((n, e) => n + e.quantity, 0);
   const total = commanderCount + mainboardCount;
@@ -68,7 +69,7 @@ export function DeckEditor({
     const now = Date.now();
     const deck: SavedDeck = {
       id: initial?.id ?? newId(),
-      name: name.trim() || t("editor.untitled"),
+      name: name.trim() || commanderName || t("editor.untitled"),
       commanders: parsed.commanders,
       mainboard: parsed.mainboard,
       createdAt: initial?.createdAt ?? now,
@@ -122,7 +123,7 @@ export function DeckEditor({
           className="input"
           value={name}
           onChange={(e) => setName(e.target.value)}
-          placeholder={t("editor.namePlaceholder")}
+          placeholder={commanderName || t("editor.namePlaceholder")}
         />
       </label>
 

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -150,8 +150,8 @@ export const messages = {
 
   "turn.title": { pt: "Sua vez", en: "Your turn" },
   "turn.dragHint": {
-    pt: "Arraste uma carta da sua mão até um espaço para jogá-la.",
-    en: "Drag a card from your hand onto a slot to play it.",
+    pt: "Arraste uma carta da mão até um espaço — ou toque na carta e depois no espaço — para jogá-la.",
+    en: "Drag a hand card onto a slot — or tap the card, then a slot — to play it.",
   },
   "turn.spaceHint": { pt: "Espaço = passar prioridade", en: "Space = pass priority" },
   "turn.pass": { pt: "Passar (espaço)", en: "Pass (space)" },

--- a/src/lib/deckImport.test.ts
+++ b/src/lib/deckImport.test.ts
@@ -111,6 +111,18 @@ describe("importDeck", () => {
     );
   });
 
+  it("falls through to the next proxy when the first one fails", async () => {
+    let n = 0;
+    const flaky: FetchLike = async () => {
+      n += 1;
+      if (n === 1) throw new Error("proxy hung");
+      return { ok: true, status: 200, json: async () => archidektFixture };
+    };
+    const deck = await importDeck("https://archidekt.com/decks/1/fun", flaky);
+    expect(n).toBe(2);
+    expect(deck.name).toBe("Fun With Fungus");
+  });
+
   it("maps a 404 to not-found", async () => {
     await expect(
       importDeck("https://moxfield.com/decks/nope", stubFetch(null, false, 404)),

--- a/src/lib/deckImport.ts
+++ b/src/lib/deckImport.ts
@@ -32,19 +32,62 @@ export class DeckImportError extends Error {
 /** Minimal fetch shape, so tests can inject a stub (mirrors scryfall.ts). */
 export type FetchLike = (
   input: string,
+  init?: { signal?: AbortSignal },
 ) => Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }>;
 
-const DEFAULT_PROXY = "https://api.allorigins.win/raw?url=";
+/** One proxy hop: the request URL, plus how to unwrap the deck JSON from it. */
+interface ProxyAttempt {
+  url: string;
+  unwrap: (body: unknown) => unknown;
+}
+
+const identity = (body: unknown): unknown => body;
+
+/** allorigins `/get` returns `{ contents: "<json string>" }`; unpack it. */
+function unwrapAllOriginsGet(body: unknown): unknown {
+  const contents = (body as { contents?: unknown }).contents;
+  if (typeof contents !== "string") throw new Error("unexpected proxy wrapper");
+  return JSON.parse(contents);
+}
 
 /**
  * Deck sites block cross-origin browser requests, so a static build routes the
- * fetch through a proxy. `VITE_DECK_PROXY` overrides the default (set it to your
- * own deck-proxy worker for reliability, or to "" to fetch directly).
+ * fetch through a proxy. `VITE_DECK_PROXY` pins a single proxy (set it to your
+ * own deck-proxy worker for reliability, or to "" to fetch directly). Left
+ * unset, the app tries a chain of public proxies in turn — each is
+ * rate-limited and intermittently down, so trying several raises the odds one
+ * answers. Deploy the worker (see deck-proxy/README) for dependable imports.
  */
-function proxied(url: string): string {
+function proxyAttempts(apiUrl: string): ProxyAttempt[] {
   const configured = import.meta.env.VITE_DECK_PROXY as string | undefined;
-  const base = configured === undefined ? DEFAULT_PROXY : configured.trim();
-  return base ? base + encodeURIComponent(url) : url;
+  if (configured !== undefined) {
+    const base = configured.trim();
+    return [
+      { url: base ? base + encodeURIComponent(apiUrl) : apiUrl, unwrap: identity },
+    ];
+  }
+  const enc = encodeURIComponent(apiUrl);
+  return [
+    { url: `https://api.allorigins.win/raw?url=${enc}`, unwrap: identity },
+    { url: `https://api.codetabs.com/v1/proxy?quest=${apiUrl}`, unwrap: identity },
+    { url: `https://api.allorigins.win/get?url=${enc}`, unwrap: unwrapAllOriginsGet },
+  ];
+}
+
+const ATTEMPT_TIMEOUT_MS = 15000;
+
+/** Run a fetch with a hard timeout so one hung proxy can't stall the chain. */
+async function fetchWithTimeout(
+  fetchImpl: FetchLike,
+  url: string,
+): Promise<Awaited<ReturnType<FetchLike>>> {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), ATTEMPT_TIMEOUT_MS);
+  try {
+    return await fetchImpl(url, { signal: ctrl.signal });
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 function normalizeUrl(raw: string): URL | null {
@@ -165,22 +208,25 @@ export async function importDeck(
   const apiUrl = apiUrlFor(source, url);
   if (!apiUrl) throw new DeckImportError("no-id", source);
 
-  let res: Awaited<ReturnType<FetchLike>>;
-  try {
-    res = await fetchImpl(proxied(apiUrl));
-  } catch {
-    throw new DeckImportError("network", source);
+  let json: unknown | undefined;
+  for (const attempt of proxyAttempts(apiUrl)) {
+    let res: Awaited<ReturnType<FetchLike>>;
+    try {
+      res = await fetchWithTimeout(fetchImpl, attempt.url);
+    } catch {
+      continue; // proxy hung or refused — try the next one
+    }
+    // A missing deck answers 404 through every proxy, so stop asking.
+    if (res.status === 404) throw new DeckImportError("not-found", source);
+    if (!res.ok) continue;
+    try {
+      json = attempt.unwrap(await res.json());
+      break;
+    } catch {
+      continue; // proxy returned a non-JSON error/landing page
+    }
   }
-  if (!res.ok) {
-    throw new DeckImportError(res.status === 404 ? "not-found" : "network", source);
-  }
-
-  let json: unknown;
-  try {
-    json = await res.json();
-  } catch {
-    throw new DeckImportError("network", source);
-  }
+  if (json === undefined) throw new DeckImportError("network", source);
 
   const parsed =
     source === "moxfield" ? parseMoxfield(json) : parseArchidekt(json);


### PR DESCRIPTION
Three small updates for the next release.

## 1. Deck name defaults to the commander
The name field previews the commander's name as its placeholder, and saving with the name left blank adopts that commander name (falling back to "Untitled deck" only when there's no commander). Imported or typed decks no longer need to be named by hand.

## 2. Mobile play — tap-to-play
HTML5 drag-and-drop never fires on touch, so cards couldn't be played on mobile. Hand cards are now also tappable: tap a playable card → the drop-slots appear (the same lane as drag) → tap a slot to play it; tapping the card again clears the selection. Desktop drag is unchanged.

Verified end-to-end in a live match under mobile emulation: tapped a land, then the Land slot, and it moved from hand to the battlefield.

## 3. Import reliability
There's no documented public API for either site (Archidekt's is open-but-unofficial and already used; Moxfield's is private + ToS-restricted), and scraping doesn't help — browser CORS walls off the HTML page exactly like the API. A server-side hop is structural.

So the hop itself is made more reliable: with no owned proxy configured, the import tries a **chain of public proxies** and takes the first that answers, with a 15s per-attempt timeout so one hung proxy can't stall the rest. These proxies fail independently and intermittently, which a chain smooths over. Full reliability still wants the owned `deck-proxy` worker — the README and error copy say so.

## Verification
- `npm run typecheck`, `npm run lint`, `npm test` (91 passed) — all green
- New test covers the proxy fallback
- `domainbook check` passes; docs updated across board, simulation, and deck-library; changelog cut as `0.2.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)