### PR TITLE
Make ninjutsu playable by hand (normal and commander ninjutsu)

### DIFF
--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,6 +12,16 @@ depth live there. A purely-internal PR that touches no product or architecture m
 skip its version with a `Skip-Docs: <reason>` trailer instead. There are no
 per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
+## [0.2.2] - 2026-08-19
+
+### Added
+
+- Ninjutsu is now playable by hand: during your combat, a ninja that can be put
+  in — in your hand, or your commander in the command zone for commander
+  ninjutsu — is highlighted; you pick it, then the unblocked attacker it returns.
+  Previously the engine offered ninjutsu but no UI surfaced it, so it couldn't be
+  used at all (`domains/simulation/features/step-through-a-turn.md`).
+
 ## [0.2.1] - 2026-08-18
 
 ### Added

--- a/domainbook/domains/simulation/features/step-through-a-turn.md
+++ b/domainbook/domains/simulation/features/step-through-a-turn.md
@@ -80,6 +80,31 @@ Example: Casting your commander from the command zone
   And clicking it casts the commander from the command zone onto the stack
 ```
 
+## Rule: You put a ninja in with ninjutsu by choosing the ninja, then the attacker it swaps in for
+
+Ninjutsu (and commander ninjutsu) can be used during your combat once an
+unblocked attacker exists. Each playable ninja is highlighted where it waits — a
+ninja card in hand, or your commander in the command zone for commander
+ninjutsu. You choose the ninja, then which unblocked attacker returns to hand in
+its place; the ninja enters tapped and attacking. When only one attacker could
+be returned, choosing the ninja resolves it in one step.
+
+```gherkin
+Example: Commander ninjutsu from the command zone
+  Given it is your combat and an attacker you control is unblocked
+  And you can pay the commander ninjutsu cost
+  Then your commander is highlighted in the command zone as playable via ninjutsu
+  When you choose it and then an unblocked attacker
+  Then that attacker returns to your hand
+  And the commander enters the battlefield tapped and attacking
+
+Example: Ninjutsu from your hand
+  Given it is your combat, a ninja is in your hand, and an attacker is unblocked
+  When you choose the ninja and then the attacker to return
+  Then the attacker returns to your hand
+  And the ninja enters the battlefield tapped and attacking
+```
+
 ## Rule: Pass turn advances your own turn and stops when an opponent acts
 
 ```gherkin

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",

--- a/src/App.css
+++ b/src/App.css
@@ -689,6 +689,23 @@ th {
   box-shadow: 0 0 0 3px var(--accent);
 }
 
+/* ── Ninjutsu: pick a ninja, then the attacker it swaps in for ─── */
+.card--ninjutsu {
+  cursor: pointer;
+  box-shadow: 0 0 0 2px var(--accent);
+}
+.card--ninjutsu:hover,
+.card--ninjutsu-chosen {
+  box-shadow: 0 0 0 3px var(--accent);
+}
+.card--ninjutsu-return {
+  cursor: pointer;
+  box-shadow: 0 0 0 2px var(--warn);
+}
+.card--ninjutsu-return:hover {
+  box-shadow: 0 0 0 3px var(--warn);
+}
+
 /* ── Click-to-cast the commander from the command zone ─────────── */
 .card--castable {
   cursor: pointer;

--- a/src/board/Board.tsx
+++ b/src/board/Board.tsx
@@ -78,6 +78,48 @@ function abilityProps(
   return { activatable: true, onActivate: () => ability.onActivate(o.id) };
 }
 
+/** Ninjutsu: click a ninja (hand or command zone), then an unblocked attacker
+ * you control to return in its place. */
+export interface NinjutsuInteraction {
+  /** Ninja object ids playable via ninjutsu now (in hand or the command zone). */
+  sourceIds: Set<number>;
+  /** The ninja chosen, awaiting a creature to return (null before a pick). */
+  chosenSource: number | null;
+  /** Unblocked-attacker ids returnable for the chosen ninja. */
+  returnableIds: Set<number>;
+  onChooseSource: (objId: number) => void;
+  onChooseReturn: (creatureId: number) => void;
+}
+
+function ninjutsuSourceProps(
+  o: GameObject,
+  ninjutsu?: NinjutsuInteraction,
+): { ninjutsuSource?: boolean; ninjutsuChosen?: boolean; onNinjutsu?: () => void } {
+  if (!ninjutsu || !ninjutsu.sourceIds.has(o.id)) return {};
+  return {
+    ninjutsuSource: true,
+    ninjutsuChosen: ninjutsu.chosenSource === o.id,
+    onNinjutsu: () => ninjutsu.onChooseSource(o.id),
+  };
+}
+
+function ninjutsuReturnProps(
+  o: GameObject,
+  ninjutsu?: NinjutsuInteraction,
+): { ninjutsuReturn?: boolean; onNinjutsuReturn?: () => void } {
+  if (
+    !ninjutsu ||
+    ninjutsu.chosenSource === null ||
+    !ninjutsu.returnableIds.has(o.id)
+  ) {
+    return {};
+  }
+  return {
+    ninjutsuReturn: true,
+    onNinjutsuReturn: () => ninjutsu.onChooseReturn(o.id),
+  };
+}
+
 /** Declare-attackers interaction: toggle your creatures, aim at a defender. */
 export interface AttackInteraction {
   /** Your creatures that may attack (click to toggle). */
@@ -239,6 +281,7 @@ export function Board({
   play,
   target,
   ability,
+  ninjutsu,
   attack,
   block,
   mana,
@@ -248,6 +291,7 @@ export function Board({
   play?: PlayInteraction;
   target?: TargetInteraction;
   ability?: AbilityInteraction;
+  ninjutsu?: NinjutsuInteraction;
   attack?: AttackInteraction;
   block?: BlockInteraction;
   mana?: ManaInteraction;
@@ -294,6 +338,7 @@ export function Board({
             play={play}
             target={target}
             ability={ability}
+            ninjutsu={ninjutsu}
             attack={attack}
             block={block}
             mana={mana}
@@ -317,6 +362,7 @@ function Seat({
   play,
   target,
   ability,
+  ninjutsu,
   attack,
   block,
   mana,
@@ -331,6 +377,7 @@ function Seat({
   play?: PlayInteraction;
   target?: TargetInteraction;
   ability?: AbilityInteraction;
+  ninjutsu?: NinjutsuInteraction;
   attack?: AttackInteraction;
   block?: BlockInteraction;
   mana?: ManaInteraction;
@@ -427,12 +474,13 @@ function Seat({
                 {...(you ? blockerProps(c, block) : blockTargetProps(c, block))}
                 {...manaProps(c, you ? mana : undefined)}
                 {...commanderCastProps(c, you ? play : undefined)}
+                {...ninjutsuSourceProps(c, you ? ninjutsu : undefined)}
               />
             ))}
           </div>
         )}
 
-        <Row label={t("board.rowCreatures")} cards={seat.creatures} images={images} onHover={onHover} target={target} ability={ability} attack={you ? attack : undefined} block={block} you={you} mana={you ? mana : undefined} />
+        <Row label={t("board.rowCreatures")} cards={seat.creatures} images={images} onHover={onHover} target={target} ability={ability} ninjutsu={you ? ninjutsu : undefined} attack={you ? attack : undefined} block={block} you={you} mana={you ? mana : undefined} />
         <Row label={t("board.rowOthers")} cards={seat.others} images={images} onHover={onHover} target={target} ability={ability} mana={you ? mana : undefined} />
         <Row label={t("board.rowLands")} cards={seat.lands} images={images} onHover={onHover} target={target} ability={ability} mana={you ? mana : undefined} />
 
@@ -440,7 +488,7 @@ function Seat({
       </div>
 
       {seat.hand.length > 0 && (
-        <HandRow seat={seat} images={images} onHover={onHover} play={play} target={target} />
+        <HandRow seat={seat} images={images} onHover={onHover} play={play} target={target} ninjutsu={you ? ninjutsu : undefined} />
       )}
     </div>
   );
@@ -489,12 +537,14 @@ function HandRow({
   onHover,
   play,
   target,
+  ninjutsu,
 }: {
   seat: SeatView;
   images?: Record<string, string>;
   onHover?: (p: Preview | null) => void;
   play?: PlayInteraction;
   target?: TargetInteraction;
+  ninjutsu?: NinjutsuInteraction;
 }) {
   const { t } = useI18n();
   return (
@@ -527,6 +577,7 @@ function HandRow({
               }
               onDragEnd={play ? () => play.setDragging(null) : undefined}
               {...targetProps(o, target)}
+              {...ninjutsuSourceProps(o, ninjutsu)}
             />
           );
         })}
@@ -542,6 +593,7 @@ function Row({
   onHover,
   target,
   ability,
+  ninjutsu,
   attack,
   block,
   you,
@@ -553,6 +605,7 @@ function Row({
   onHover?: (p: Preview | null) => void;
   target?: TargetInteraction;
   ability?: AbilityInteraction;
+  ninjutsu?: NinjutsuInteraction;
   attack?: AttackInteraction;
   block?: BlockInteraction;
   you?: boolean;
@@ -571,6 +624,7 @@ function Row({
             onHover={onHover}
             {...targetProps(o, target)}
             {...abilityProps(o, ability)}
+            {...ninjutsuReturnProps(o, ninjutsu)}
             {...attackProps(o, attack)}
             {...(you ? blockerProps(o, block) : blockTargetProps(o, block))}
             {...manaProps(o, mana)}
@@ -596,6 +650,11 @@ function Card({
   onChoose,
   activatable,
   onActivate,
+  ninjutsuSource,
+  ninjutsuChosen,
+  onNinjutsu,
+  ninjutsuReturn,
+  onNinjutsuReturn,
   attacker,
   attacking,
   onToggleAttack,
@@ -624,6 +683,11 @@ function Card({
   onChoose?: () => void;
   activatable?: boolean;
   onActivate?: () => void;
+  ninjutsuSource?: boolean;
+  ninjutsuChosen?: boolean;
+  onNinjutsu?: () => void;
+  ninjutsuReturn?: boolean;
+  onNinjutsuReturn?: () => void;
   attacker?: boolean;
   attacking?: boolean;
   onToggleAttack?: () => void;
@@ -649,6 +713,9 @@ function Card({
     targetable ? "card--targetable" : "",
     targeted ? "card--targeted" : "",
     activatable ? "card--activatable" : "",
+    ninjutsuSource ? "card--ninjutsu" : "",
+    ninjutsuChosen ? "card--ninjutsu-chosen" : "",
+    ninjutsuReturn ? "card--ninjutsu-return" : "",
     attacker ? "card--attacker" : "",
     attacking ? "card--attacking" : "",
     blocker ? "card--blocker" : "",
@@ -680,6 +747,8 @@ function Card({
 
   const click =
     onChoose ??
+    onNinjutsuReturn ??
+    onNinjutsu ??
     onCast ??
     onActivate ??
     onToggleAttack ??

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -162,6 +162,14 @@ export const messages = {
     en: "Click a highlighted permanent to activate an ability.",
   },
   "turn.abilityN": { pt: "Habilidade {n}", en: "Ability {n}" },
+  "turn.ninjutsuHint": {
+    pt: "Clique em um ninja destacado (na mão ou na zona de comando) para usar ninjutsu.",
+    en: "Click a highlighted ninja (in hand or the command zone) to use ninjutsu.",
+  },
+  "turn.ninjutsuReturnHint": {
+    pt: "Agora clique no atacante não bloqueado que voltará para a mão.",
+    en: "Now click the unblocked attacker to return to hand.",
+  },
   "turn.cancel": { pt: "Cancelar", en: "Cancel" },
   "turn.keyHints": {
     pt: "Espaço = prioridade · Enter = passar turno",

--- a/src/match/RunView.tsx
+++ b/src/match/RunView.tsx
@@ -18,6 +18,7 @@ import {
   type PlayInteraction,
   type TargetInteraction,
   type AbilityInteraction,
+  type NinjutsuInteraction,
   type AttackInteraction,
   type BlockInteraction,
   type ManaInteraction,
@@ -50,6 +51,7 @@ import { toBoardView, type BoardView, type SeatMeta } from "../board/boardView";
 import { GameSidebar, type LoggedEntry } from "../board/GameSidebar";
 import type { LogEntry } from "../engine/types";
 import { abilitiesBySource } from "../sim/decisions/abilities";
+import { ninjutsuBySource } from "../sim/decisions/ninjutsu";
 import { aggregate } from "../analysis/matchStats";
 import { fetchCardsCached } from "../lib/scryfallCache";
 import { SearchableSelect } from "../components/SearchableSelect";
@@ -168,6 +170,7 @@ export function RunView({
   const [dragging, setDragging] = useState<number | null>(null);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [abilityPick, setAbilityPick] = useState<{ objId: number; actions: any[] } | null>(null);
+  const [ninjutsuSource, setNinjutsuSource] = useState<number | null>(null);
   const [targeting, setTargeting] = useState<TargetTurn | null>(null);
   const [chosen, setChosen] = useState<TargetRef[]>([]);
   const [attacking, setAttacking] = useState<AttackTurn | null>(null);
@@ -429,6 +432,7 @@ export function RunView({
   useEffect(() => {
     setDragging(null);
     setAbilityPick(null);
+    setNinjutsuSource(null);
   }, [humanTurn]);
 
   // Space bar passes priority during the human's turn.
@@ -544,6 +548,37 @@ export function RunView({
       },
     };
   }, [humanTurn]);
+
+  // Ninjutsu: pick a ninja (hand or command zone), then which unblocked
+  // attacker it returns. The engine enumerates one action per (ninja, attacker).
+  const ninjutsu: NinjutsuInteraction | undefined = useMemo(() => {
+    if (!humanTurn) return undefined;
+    const bySource = ninjutsuBySource(humanTurn.legal.actions);
+    if (bySource.size === 0) return undefined;
+    const chosen =
+      ninjutsuSource != null && bySource.has(ninjutsuSource)
+        ? ninjutsuSource
+        : null;
+    const returnable = new Set(
+      chosen != null ? bySource.get(chosen)!.map((o) => o.creatureId) : [],
+    );
+    return {
+      sourceIds: new Set(bySource.keys()),
+      chosenSource: chosen,
+      returnableIds: returnable,
+      onChooseSource: (objId: number) => {
+        const opts = bySource.get(objId);
+        if (!opts || opts.length === 0) return;
+        if (opts.length === 1) humanTurn.resolve({ action: opts[0].action });
+        else setNinjutsuSource(objId);
+      },
+      onChooseReturn: (creatureId: number) => {
+        if (chosen == null) return;
+        const opt = bySource.get(chosen)?.find((o) => o.creatureId === creatureId);
+        if (opt) humanTurn.resolve({ action: opt.action });
+      },
+    };
+  }, [humanTurn, ninjutsuSource]);
 
   // Highlight legal targets for the current slot and collect the human's picks.
   const target: TargetInteraction | undefined = useMemo(() => {
@@ -829,7 +864,14 @@ export function RunView({
             <>
               {hasPlayable && <p className="hint">{t("turn.dragHint")}</p>}
               {ability && <p className="hint">{t("turn.abilityHint")}</p>}
-              {!hasPlayable && !ability && (
+              {ninjutsu && (
+                <p className="hint">
+                  {ninjutsu.chosenSource != null
+                    ? t("turn.ninjutsuReturnHint")
+                    : t("turn.ninjutsuHint")}
+                </p>
+              )}
+              {!hasPlayable && !ability && !ninjutsu && (
                 <p className="hint">{t("turn.nothingToPlay")}</p>
               )}
               {abilityPick && (
@@ -1112,6 +1154,7 @@ export function RunView({
             play={play}
             target={target}
             ability={ability}
+            ninjutsu={ninjutsu}
             attack={attack}
             block={block}
             mana={mana}

--- a/src/sim/decisions/ninjutsu.test.ts
+++ b/src/sim/decisions/ninjutsu.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { ninjutsuBySource } from "./ninjutsu";
+
+// Real ActivateNinjutsu actions captured from the phase-rs priority legal
+// actions during combat: one entry per (ninja, returnable attacker) pair.
+const LEGAL_ACTIONS = [
+  { type: "PassPriority" },
+  { type: "ActivateNinjutsu", data: { ninjutsu_object_id: 74, creature_to_return: 8 } },
+  { type: "ActivateNinjutsu", data: { ninjutsu_object_id: 74, creature_to_return: 41 } },
+  { type: "ActivateNinjutsu", data: { ninjutsu_object_id: 199, creature_to_return: 8 } },
+];
+
+describe("ninjutsuBySource", () => {
+  it("groups ActivateNinjutsu actions by the ninja that would enter", () => {
+    const map = ninjutsuBySource(LEGAL_ACTIONS);
+    expect([...map.keys()].sort((a, b) => a - b)).toEqual([74, 199]);
+    expect(map.get(74)!.map((o) => o.creatureId)).toEqual([8, 41]);
+    expect(map.get(199)!.map((o) => o.creatureId)).toEqual([8]);
+    expect(map.get(74)![0].action.data.creature_to_return).toBe(8);
+  });
+
+  it("ignores non-ninjutsu actions and malformed entries", () => {
+    expect(ninjutsuBySource(undefined).size).toBe(0);
+    expect(
+      ninjutsuBySource([{ type: "ActivateAbility", data: { source_id: 1 } }]).size,
+    ).toBe(0);
+    expect(
+      ninjutsuBySource([{ type: "ActivateNinjutsu", data: {} }]).size,
+    ).toBe(0);
+  });
+});

--- a/src/sim/decisions/ninjutsu.ts
+++ b/src/sim/decisions/ninjutsu.ts
@@ -1,0 +1,30 @@
+// Ninjutsu (and commander ninjutsu) surfaces in the human's priority legal
+// actions as its own action type, one entry per (ninja, returnable attacker)
+// pair: `{ type: "ActivateNinjutsu", data: { ninjutsu_object_id, creature_to_return } }`.
+// We group the entries by the ninja that would enter so the board can offer
+// click-to-activate: choose the ninja, then which unblocked attacker to return.
+
+import type { LegalAction } from "./abilities";
+
+export interface NinjutsuOption {
+  /** The unblocked attacker returned to hand as the ninjutsu cost. */
+  creatureId: number;
+  action: LegalAction;
+}
+
+/** Map each ninja's object id (in hand or the command zone) to its options. */
+export function ninjutsuBySource(
+  actions: LegalAction[] | undefined,
+): Map<number, NinjutsuOption[]> {
+  const map = new Map<number, NinjutsuOption[]>();
+  for (const a of actions ?? []) {
+    if (a?.type !== "ActivateNinjutsu") continue;
+    const ninjaId = a.data?.ninjutsu_object_id;
+    const creatureId = a.data?.creature_to_return;
+    if (typeof ninjaId !== "number" || typeof creatureId !== "number") continue;
+    const list = map.get(ninjaId) ?? [];
+    list.push({ creatureId, action: a });
+    map.set(ninjaId, list);
+  }
+  return map;
+}


### PR DESCRIPTION
## Why

A player reported they couldn't use Yuriko's commander ninjutsu when piloting a game.

**Root cause:** the engine exposes ninjutsu as its own action type — `ActivateNinjutsu` with `{ninjutsu_object_id, creature_to_return}`, enumerated one entry per (ninja × unblocked-attacker) pair — but the UI only ever handled `ActivateAbility`. So ninjutsu, both normal and commander, never surfaced anywhere in play mode and couldn't be used at all.

## What

A two-step play interaction, matching the existing target/ability patterns:

- Each playable ninja is highlighted where it waits — a ninja card in **hand**, or the commander in the **command zone** for commander ninjutsu.
- You choose the ninja, then which unblocked attacker returns to your hand in its place; the ninja enters tapped and attacking.
- A single returnable attacker resolves on the ninja click.

Files:
- `src/sim/decisions/ninjutsu.ts` — `ninjutsuBySource()` groups actions by the entering ninja (+ unit tests).
- `src/board/Board.tsx` — `NinjutsuInteraction`, threaded through the command zone, creatures row, and hand row.
- `src/match/RunView.tsx` — derives the interaction from the priority actions and manages the pick.
- `src/App.css`, `src/i18n/messages.ts` — highlight styles and pt/en hints.

## Verification

- typecheck ✅, lint ✅, 93 tests pass (2 new) ✅, `domainbook check` clean ✅, app loads with no console errors.
- End-to-end against the **real vendored engine**, replaying exactly what RunView's memo does through the real parser:
  - *Normal ninjutsu* — the specifically-chosen (non-default) attacker returned to hand and the ninja entered tapped.
  - *Commander ninjutsu* — Yuriko moved command zone → battlefield tapped, and the chosen attacker returned to hand.

Docs: ninjutsu rule added to `step-through-a-turn`, changelog entry, version bump to 0.2.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)