### PR TITLE
0.3.0: mobile board UX, accessibility pass, and icon playback controls

### DIFF
--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,6 +12,38 @@ depth live there. A purely-internal PR that touches no product or architecture m
 skip its version with a `Skip-Docs: <reason>` trailer instead. There are no
 per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
+## [0.3.0] - 2026-08-19
+
+### Added
+
+- Mobile board: the hand is now a horizontal strip of larger, readable cards, and
+  a multi-opponent pod shows opponents as a swipeable gallery that follows whose
+  turn it is (holding put on your own turn)
+  (`domains/board/features/read-the-board-on-a-phone.md`).
+
+### Changed
+
+- Mobile play no longer scrolls the page sideways: the play-controls toolbar wraps
+  and the log drawer is contained, so only the hand and opponents gallery scroll
+  horizontally (`domains/board/features/read-the-board-on-a-phone.md`).
+- On mobile, keyboard hints (space/enter) are dropped and the pass buttons lose
+  their key labels, and the stack & log drawer always starts closed so it never
+  covers the board on entry (`domains/board/features/follow-the-game.md`).
+- The playback controls are now icons — a pause icon that stays lit while paused,
+  then Slow / Normal / Fast as one, two, and three play triangles; pressing a
+  speed resumes. Each carries an accessible name
+  (`domains/match-setup/features/configure-a-run.md`).
+- The game log reads newest-first — the latest entry is on top, with each turn
+  heading above its own group (`domains/board/features/follow-the-game.md`).
+
+### Fixed
+
+- Accessibility: a visible keyboard focus ring across the app, touch targets raised
+  to at least 44px on mobile, selected state exposed on the nav tabs and the
+  pod/mode/difficulty/speed toggles, and the opening-hand popup now traps and
+  restores focus as a dialog. The mulligan popup also fits within a phone screen
+  (`domains/match-setup/features/configure-a-run.md`).
+
 ## [0.2.2] - 2026-08-19
 
 ### Added

--- a/domainbook/domains/board/features/follow-the-game.md
+++ b/domainbook/domains/board/features/follow-the-game.md
@@ -34,6 +34,12 @@ Example: Turns and phases group the history
   Given several turns have passed
   When I scan the log
   Then each turn is separated by a heading
+
+Example: The newest entry is on top
+  Given the log has several entries
+  When I look at it
+  Then the most recent entry is at the top, with older ones below
+  And each turn heading still sits above its own group of entries
 ```
 
 ## Rule: The log is readable by default, complete on demand
@@ -56,11 +62,16 @@ Example: Sliding the drawer open and closed
   And on desktop it reserves board space while open
   And on a narrow, mobile-width screen it covers the full screen while open
 
-Example: Its state is remembered
+Example: Its state is remembered on desktop
   Given a desktop screen
   Then the drawer starts open
-  And on a mobile-width screen it starts collapsed
-  And the choice is remembered
+  And the choice is remembered across games
+
+Example: It always starts closed on mobile
+  Given a mobile-width screen
+  When a game starts
+  Then the drawer is closed so it never covers the board on entry
+  And an open/closed choice made on mobile is not carried over
 ```
 
 ## Rule: Hidden information stays hidden

--- a/domainbook/domains/board/features/read-the-board-on-a-phone.md
+++ b/domainbook/domains/board/features/read-the-board-on-a-phone.md
@@ -1,0 +1,67 @@
+---
+id: read-the-board-on-a-phone
+name: Read the board on a phone
+status: implemented
+---
+
+## Story
+
+As a player on a phone
+I want the board to fit my screen and enlarge what I'm reading
+So that I can follow and pilot a game without fighting sideways page scroll
+
+## Rule: The page itself never scrolls sideways; only chosen regions do
+
+On a narrow screen the whole board fits the viewport width — the play-controls
+toolbar wraps rather than overflowing, and the log drawer stays off-canvas until
+opened. Horizontal scrolling is reserved for the hand and the opponents gallery,
+each contained to its own strip.
+
+```gherkin
+Example: No accidental page scroll
+  Given a mobile-width screen during a match
+  When I view the board
+  Then the page does not scroll horizontally
+  And the speed / pause / exit controls wrap onto multiple rows if needed
+```
+
+## Rule: The hand is one horizontal strip of larger cards
+
+On mobile the hand becomes a single row that scrolls sideways, with cards drawn
+larger than the battlefield's so their text is readable, rather than a wrapped
+grid of small cards.
+
+```gherkin
+Example: Swiping through a full hand
+  Given a mobile-width screen and several cards in hand
+  When I look at the hand
+  Then the cards sit in one horizontally-scrollable row, enlarged for reading
+  And I swipe sideways to reach the rest
+```
+
+## Rule: Opponents are a swipeable gallery that follows the turn
+
+With more than one opponent, the opponents' mats become a horizontal gallery
+showing one at a time. It scrolls itself to the opponent whose turn it is, and
+holds on the last-shown opponent while the human is the active player.
+
+```gherkin
+Example: The gallery follows the active opponent
+  Given a multi-opponent pod on a mobile-width screen
+  When an opponent's turn begins
+  Then the gallery scrolls that opponent's mat into view
+
+Example: It holds put on the human's turn
+  Given the gallery is showing one opponent
+  When it becomes the human's turn
+  Then the gallery stays on that opponent rather than jumping away
+
+Example: On desktop the mats stay side by side
+  Given a wide screen
+  Then all opponents are shown together in a grid, not a gallery
+```
+
+## Open Questions
+
+- Whether the human's own hand should also collapse to counts (like opponents')
+  when it grows very large on a small screen.

--- a/domainbook/domains/match-setup/features/configure-a-run.md
+++ b/domainbook/domains/match-setup/features/configure-a-run.md
@@ -40,6 +40,31 @@ Example: A seed makes a run repeatable
   Then the same matches play out
 ```
 
+## Rule: The controls are reachable and legible to assistive tech
+
+The toggle groups (pod size, mode, difficulty, and playback speed) expose which
+option is selected, not only by colour, and the opening-hand popup behaves as a
+modal dialog — focus moves into it, stays trapped while it is open, and returns
+to where it was on close. Where a control shows only an icon — the icon-based
+playback speed and pause/resume — it still carries a text accessible name.
+
+```gherkin
+Example: A chosen option is announced
+  Given a segmented control such as pod size or mode
+  When one option is selected
+  Then it is exposed to assistive tech as the pressed option
+
+Example: An icon-only control still has a name
+  Given a control shown only as an icon, such as playback speed or pause
+  When assistive tech reads it
+  Then it announces a text label, not just the icon
+
+Example: The opening-hand dialog keeps focus
+  Given the opening-hand popup is open
+  When I move focus with the keyboard
+  Then focus stays within the dialog until I resolve it
+```
+
 ## Open Questions
 
 - The default match count, given each match is slow.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",

--- a/src/App.css
+++ b/src/App.css
@@ -206,6 +206,7 @@ th {
   align-items: flex-start;
   gap: 1rem;
   margin-bottom: 0.5rem;
+  flex-wrap: wrap;
 }
 
 .panel__head h2 {
@@ -291,6 +292,7 @@ th {
   display: flex;
   gap: 0.4rem;
   flex-shrink: 0;
+  flex-wrap: wrap;
 }
 
 .seg {
@@ -313,6 +315,61 @@ th {
   color: var(--text);
   border-color: var(--accent);
   background: color-mix(in srgb, var(--accent) 18%, var(--panel-2));
+}
+
+.seg__btn--speed {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.45rem 0.7rem;
+}
+
+.seg__btn--speed svg + svg {
+  margin-left: -5px;
+}
+
+.btn--icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.btn--active {
+  color: var(--text);
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 18%, var(--panel-2));
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .has-tooltip {
+    position: relative;
+  }
+
+  .has-tooltip::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    top: calc(100% + 6px);
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 0.25rem 0.5rem;
+    background: var(--panel-2);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    font-size: 0.75rem;
+    font-weight: 500;
+    line-height: 1;
+    white-space: nowrap;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.12s ease;
+    z-index: 20;
+  }
+
+  .has-tooltip:hover::after,
+  .has-tooltip:focus-visible::after {
+    opacity: 1;
+  }
 }
 
 .opponent-grid {
@@ -1207,6 +1264,68 @@ th {
     width: auto;
     border-left: none;
   }
+
+  /* Stack the play-controls header so its toolbar can wrap instead of overflow. */
+  .panel__head {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .deck-list__actions {
+    flex-shrink: 1;
+  }
+
+  /* Touch targets: WCAG 2.5.5 — bump the tappable controls to >=44px. */
+  .btn,
+  .seg__btn,
+  .tab {
+    min-height: 44px;
+  }
+  .lang__btn {
+    min-height: 44px;
+  }
+
+  /* Hand: one horizontally-scrollable strip with larger, more readable cards. */
+  .seat--you .seat__hand .seat__cards {
+    flex: 1 1 0;
+    min-width: 0;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    scroll-snap-type: x proximity;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 0.4rem;
+  }
+  .seat--you .seat__hand .card {
+    flex: 0 0 auto;
+    scroll-snap-align: start;
+  }
+  .seat--you .seat__hand .card__img {
+    width: 112px;
+  }
+  .seat--you .seat__hand .card--text {
+    max-width: 168px;
+    font-size: 0.82rem;
+  }
+
+  /* Opponents: a swipeable gallery — one mat at a time, snap to each. */
+  .board__opponents,
+  .board__opponents--n2,
+  .board__opponents--n3 {
+    display: flex;
+    grid-template-columns: none;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    -webkit-overflow-scrolling: touch;
+    scroll-padding-inline: 0.6rem;
+    padding-bottom: 0.4rem;
+  }
+  .board__opponents > * {
+    flex: 0 0 86%;
+    scroll-snap-align: center;
+  }
+  .board__opponents--n1 {
+    display: block;
+    max-width: none;
+  }
 }
 
 /* Copper Ember — display face on the sidebar header title */
@@ -1228,6 +1347,7 @@ th {
 }
 .mull-modal {
   width: min(760px, 100%);
+  min-width: 0;
   max-height: 90vh;
   overflow-y: auto;
   background: var(--panel);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,12 +35,14 @@ export function App() {
             <button
               className={`tab ${view === "decks" ? "tab--active" : ""}`}
               onClick={() => setView("decks")}
+              aria-current={view === "decks" ? "page" : undefined}
             >
               {t("nav.decks")}
             </button>
             <button
               className={`tab ${view === "play" ? "tab--active" : ""}`}
               onClick={() => setView("play")}
+              aria-current={view === "play" ? "page" : undefined}
             >
               {t("nav.play")}
             </button>

--- a/src/board/Board.tsx
+++ b/src/board/Board.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { MouseEvent as ReactMouseEvent } from "react";
 import {
   Biohazard,
@@ -298,16 +298,38 @@ export function Board({
 }) {
   const { t } = useI18n();
   const [preview, setPreview] = useState<Preview | null>(null);
+  const oppScrollRef = useRef<HTMLDivElement>(null);
 
   const you = view.seats.find((s) => s.seat === 0);
   const opponents = view.seats.filter((s) => s.seat !== 0);
+
+  // In the mobile opponents gallery, follow the active opponent into view. When
+  // the human (seat 0) is active, leave the gallery on the last-shown opponent.
+  const activePlayer = view.activePlayer;
+  useEffect(() => {
+    const container = oppScrollRef.current;
+    if (!container || activePlayer === 0) return;
+    if (container.scrollWidth <= container.clientWidth) return;
+    const el = container.querySelector<HTMLElement>(
+      `[data-seat="${activePlayer}"]`,
+    );
+    if (!el) return;
+    const cRect = container.getBoundingClientRect();
+    const eRect = el.getBoundingClientRect();
+    const delta =
+      eRect.left - cRect.left - (container.clientWidth - el.clientWidth) / 2;
+    container.scrollBy({ left: delta, behavior: "auto" });
+  }, [activePlayer]);
 
   const onHover = play?.dragging != null ? undefined : setPreview;
   const seatName = (s: SeatView) => s.name || t("board.player", { n: s.seat + 1 });
 
   return (
     <div className="board">
-      <div className={`board__opponents board__opponents--n${opponents.length}`}>
+      <div
+        className={`board__opponents board__opponents--n${opponents.length}`}
+        ref={oppScrollRef}
+      >
         {opponents.map((seat) => (
           <Seat
             key={seat.seat}
@@ -411,7 +433,7 @@ function Seat({
       : undefined;
 
   return (
-    <div className={cls} onClick={seatClick}>
+    <div className={cls} onClick={seatClick} data-seat={seat.seat}>
       <div className="seat__head">
         <div className="seat__id">
           <span className="seat__name">

--- a/src/board/GameSidebar.tsx
+++ b/src/board/GameSidebar.tsx
@@ -78,7 +78,7 @@ export function GameSidebar({
   const [detailed, setDetailed] = useState(false);
   const [expanded, setExpanded] = useState<Set<number>>(new Set());
   const scrollRef = useRef<HTMLDivElement>(null);
-  const atBottom = useRef(true);
+  const atTop = useRef(true);
 
   const visible = useMemo(
     () =>
@@ -90,10 +90,26 @@ export function GameSidebar({
     [log, humanSeat, revealAll, detailed],
   );
 
+  const ordered = useMemo(() => {
+    const groups: LoggedEntry[][] = [];
+    for (const item of visible) {
+      if (isTurnMarker(item.entry) || groups.length === 0) groups.push([]);
+      groups[groups.length - 1].push(item);
+    }
+    const out: LoggedEntry[] = [];
+    for (let g = groups.length - 1; g >= 0; g--) {
+      const group = groups[g];
+      const start = isTurnMarker(group[0].entry) ? 1 : 0;
+      if (start === 1) out.push(group[0]);
+      for (let r = group.length - 1; r >= start; r--) out.push(group[r]);
+    }
+    return out;
+  }, [visible]);
+
   useEffect(() => {
     const el = scrollRef.current;
-    if (el && atBottom.current) el.scrollTop = el.scrollHeight;
-  }, [visible.length, open]);
+    if (el && atTop.current) el.scrollTop = 0;
+  }, [ordered.length, open]);
 
   const stackTopFirst = [...stack].reverse();
 
@@ -185,15 +201,13 @@ export function GameSidebar({
             className="log-scroll"
             ref={scrollRef}
             onScroll={(e) => {
-              const el = e.currentTarget;
-              atBottom.current =
-                el.scrollHeight - el.scrollTop - el.clientHeight < 48;
+              atTop.current = e.currentTarget.scrollTop < 48;
             }}
           >
-            {visible.length === 0 ? (
+            {ordered.length === 0 ? (
               <p className="hint sidebar-empty">{t("sidebar.logEmpty")}</p>
             ) : (
-              visible.map(({ id, entry }) =>
+              ordered.map(({ id, entry }) =>
                 isTurnMarker(entry) ? (
                   <div key={id} className="log-turn">
                     {entryText(entry)}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -142,7 +142,6 @@ export const messages = {
   "run.matchOf": { pt: "Partida {i} de {n}", en: "Match {i} of {n}" },
   "run.match": { pt: "Partida", en: "Match" },
   "run.pause": { pt: "Pausar", en: "Pause" },
-  "run.resume": { pt: "Retomar", en: "Resume" },
   "run.exit": { pt: "Sair", en: "Exit" },
   "run.yourWins": { pt: "Vitórias suas: {w}/{n}", en: "Your wins: {w}/{n}" },
   "run.winRate": { pt: "Win rate: {p}%", en: "Win rate: {p}%" },
@@ -155,6 +154,8 @@ export const messages = {
   },
   "turn.spaceHint": { pt: "Espaço = passar prioridade", en: "Space = pass priority" },
   "turn.pass": { pt: "Passar (espaço)", en: "Pass (space)" },
+  "turn.passShort": { pt: "Passar", en: "Pass" },
+  "turn.passTurnShort": { pt: "Passar turno", en: "Pass turn" },
   "turn.letAi": { pt: "IA joga por mim", en: "Let the AI play" },
   "turn.nothingToPlay": { pt: "Nada para jogar agora — passe a vez.", en: "Nothing to play right now — pass." },
   "turn.abilityHint": {

--- a/src/index.css
+++ b/src/index.css
@@ -31,6 +31,16 @@
 body {
   margin: 0;
   min-height: 100vh;
+  /* Contain accidental horizontal scroll (e.g. the off-canvas drawer) while
+     still letting inner regions opt into horizontal scrolling of their own. */
+  overflow-x: clip;
+}
+
+/* Visible keyboard focus across the app (custom dark theme suppresses the UA ring). */
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 3px;
 }
 
 h1,

--- a/src/match/MatchSetup.tsx
+++ b/src/match/MatchSetup.tsx
@@ -84,6 +84,7 @@ export function MatchSetup({
               key={count}
               className={`seg__btn ${seatCount === count ? "seg__btn--active" : ""}`}
               onClick={() => setSeatCount(count)}
+              aria-pressed={seatCount === count}
             >
               {t("setup.players", { n: count })}
             </button>
@@ -123,12 +124,14 @@ export function MatchSetup({
           <button
             className={`seg__btn ${mode === "play" ? "seg__btn--active" : ""}`}
             onClick={() => setMode("play")}
+            aria-pressed={mode === "play"}
           >
             {t("setup.modePlay")}
           </button>
           <button
             className={`seg__btn ${mode === "watch" ? "seg__btn--active" : ""}`}
             onClick={() => setMode("watch")}
+            aria-pressed={mode === "watch"}
           >
             {t("setup.modeWatch")}
           </button>
@@ -146,6 +149,7 @@ export function MatchSetup({
               key={d}
               className={`seg__btn ${difficulty === d ? "seg__btn--active" : ""}`}
               onClick={() => setDifficulty(d)}
+              aria-pressed={difficulty === d}
             >
               {DIFFICULTY_LABEL[d][lang]}
             </button>

--- a/src/match/RunView.tsx
+++ b/src/match/RunView.tsx
@@ -67,6 +67,33 @@ const SPEED_LABEL: Record<Speed, Record<Lang, string>> = {
   normal: { pt: "Normal", en: "Normal" },
   fast: { pt: "Rápido", en: "Fast" },
 };
+const SPEED_TICKS: Record<Speed, number> = { slow: 1, normal: 2, fast: 3 };
+
+function PlayGlyph({ size = 15 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      stroke="currentColor"
+      strokeWidth="1"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M6 4 L20 12 L6 20 Z" />
+    </svg>
+  );
+}
+
+function PauseGlyph({ size = 16 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <rect x="6" y="4.5" width="4.5" height="15" rx="1.5" />
+      <rect x="13.5" y="4.5" width="4.5" height="15" rx="1.5" />
+    </svg>
+  );
+}
 
 /** Cast/play action types that put a hand card onto the board (drag targets). */
 const PLAYABLE_TYPES = new Set([
@@ -188,15 +215,30 @@ export function RunView({
   const [bottomPick, setBottomPick] = useState<Set<number>>(new Set());
   const [passingTurn, setPassingTurn] = useState(false);
   const [logEntries, setLogEntries] = useState<LoggedEntry[]>([]);
+  // On mobile the log is a full-screen drawer, so it always starts closed and
+  // its state isn't persisted (a remembered "open" would cover the board). On
+  // desktop it starts open and remembers the last choice.
   const [sidebarOpen, setSidebarOpen] = useState<boolean>(() => {
+    if (!window.matchMedia("(min-width: 900px)").matches) return false;
     const saved = localStorage.getItem("sidebarOpen");
-    if (saved != null) return saved === "1";
-    return window.matchMedia("(min-width: 900px)").matches;
+    return saved != null ? saved === "1" : true;
   });
+  // Touch/narrow screens: drop keyboard hints (space/enter don't apply).
+  const [compact, setCompact] = useState<boolean>(() =>
+    window.matchMedia("(max-width: 899px)").matches,
+  );
+  useEffect(() => {
+    const mq = window.matchMedia("(max-width: 899px)");
+    const onChange = () => setCompact(mq.matches);
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
+
   const logIdRef = useRef(0);
   const runnerRef = useRef<MatchRunner | null>(null);
 
   useEffect(() => {
+    if (!window.matchMedia("(min-width: 900px)").matches) return;
     localStorage.setItem("sidebarOpen", sidebarOpen ? "1" : "0");
   }, [sidebarOpen]);
 
@@ -411,21 +453,20 @@ export function RunView({
     [results, config.seatDeckIds.length],
   );
 
-  function togglePause() {
-    const runner = runnerRef.current;
-    if (!runner) return;
-    if (paused) {
-      runner.resume();
-      setPaused(false);
-    } else {
-      runner.pause();
-      setPaused(true);
-    }
+  function pauseGame() {
+    if (paused) return;
+    runnerRef.current?.pause();
+    setPaused(true);
   }
 
   function changeSpeed(s: Speed) {
+    const runner = runnerRef.current;
     setSpeed(s);
-    runnerRef.current?.setPace(PACE_MS[s]);
+    runner?.setPace(PACE_MS[s]);
+    if (paused) {
+      runner?.resume();
+      setPaused(false);
+    }
   }
 
   // Reset any in-flight drag / ability pick when the priority window changes.
@@ -745,20 +786,31 @@ export function RunView({
           <div className="deck-list__actions">
             {phase === "running" && (
               <>
+                <button
+                  className={`btn btn--ghost btn--sm btn--icon has-tooltip ${paused ? "btn--active" : ""}`}
+                  onClick={pauseGame}
+                  aria-pressed={paused}
+                  aria-label={t("run.pause")}
+                  data-tooltip={t("run.pause")}
+                >
+                  <PauseGlyph size={16} />
+                </button>
                 <div className="seg">
                   {(["slow", "normal", "fast"] as Speed[]).map((s) => (
                     <button
                       key={s}
-                      className={`seg__btn ${speed === s ? "seg__btn--active" : ""}`}
+                      className={`seg__btn seg__btn--speed has-tooltip ${speed === s && !paused ? "seg__btn--active" : ""}`}
                       onClick={() => changeSpeed(s)}
+                      aria-pressed={speed === s && !paused}
+                      aria-label={SPEED_LABEL[s][lang]}
+                      data-tooltip={SPEED_LABEL[s][lang]}
                     >
-                      {SPEED_LABEL[s][lang]}
+                      {Array.from({ length: SPEED_TICKS[s] }).map((_, i) => (
+                        <PlayGlyph key={i} />
+                      ))}
                     </button>
                   ))}
                 </div>
-                <button className="btn btn--ghost btn--sm" onClick={togglePause}>
-                  {paused ? t("run.resume") : t("run.pause")}
-                </button>
                 <button
                   className="btn btn--ghost btn--sm"
                   onClick={() => setSidebarOpen((v) => !v)}
@@ -839,7 +891,7 @@ export function RunView({
                 </>
               )}
             </h2>
-            {humanTurn && (
+            {humanTurn && !compact && (
               <span className="hint">
                 {humanTurn.myTurn ? t("turn.keyHints") : t("turn.spaceHint")}
               </span>
@@ -903,14 +955,14 @@ export function RunView({
                     humanTurn.resolve(pass ? { action: pass } : { ai: true });
                   }}
                 >
-                  {t("turn.pass")}
+                  {compact ? t("turn.passShort") : t("turn.pass")}
                 </button>
                 {humanTurn.myTurn && (
                   <button
                     className="btn"
                     onClick={() => beginPassTurn(humanTurn)}
                   >
-                    {t("turn.passTurn")}
+                    {compact ? t("turn.passTurnShort") : t("turn.passTurn")}
                   </button>
                 )}
                 <button
@@ -1235,12 +1287,46 @@ function MulliganModal({
 }) {
   const { t } = useI18n();
   const bottoming = prompt.stage === "bottom";
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  // Move focus into the dialog, trap Tab within it, and restore focus on close.
+  useEffect(() => {
+    const node = modalRef.current;
+    if (!node) return;
+    const prev = document.activeElement as HTMLElement | null;
+    const focusable = () =>
+      [
+        ...node.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        ),
+      ];
+    focusable()[0]?.focus();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Tab") return;
+      const els = focusable();
+      if (els.length === 0) return;
+      const first = els[0];
+      const last = els[els.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+    node.addEventListener("keydown", onKey);
+    return () => {
+      node.removeEventListener("keydown", onKey);
+      prev?.focus?.();
+    };
+  }, []);
 
   return (
-    <div className="mull-overlay" role="dialog" aria-modal="true">
-      <div className="mull-modal">
+    <div className="mull-overlay" role="dialog" aria-modal="true" aria-labelledby="mull-title">
+      <div className="mull-modal" ref={modalRef}>
         <div className="mull-modal__head">
-          <h2>{bottoming ? t("mulligan.bottomTitle") : t("mulligan.title")}</h2>
+          <h2 id="mull-title">{bottoming ? t("mulligan.bottomTitle") : t("mulligan.title")}</h2>
           <p className="hint">
             {bottoming
               ? t("mulligan.bottomInstruction", { n: prompt.bottomCount })


### PR DESCRIPTION
Bumps the app to **0.3.0** — a mobile-focused experience update driven by a design critique + WCAG 2.1 AA audit of the play board at phone width.

## Mobile board
- **Hand** is now a horizontal strip of larger, more readable cards instead of a cramped wrap.
- **Multi-opponent pods** render as a swipeable gallery that auto-follows whose turn it is, and holds on the last-shown opponent while you're playing.
- The page **no longer scrolls sideways** (toolbar wraps, log drawer is contained) — only the hand and opponents gallery scroll horizontally.
- On mobile, keyboard hints (space/enter) are dropped, the pass buttons lose their key labels, and the **stack & log drawer starts closed** so it never covers the board on entry.

## Accessibility (WCAG 2.1 AA)
- Visible keyboard **focus ring** across the app.
- **44px** minimum touch targets on mobile.
- **Selected state** exposed on the nav tabs and the pod-size / mode / difficulty / speed toggles (`aria-pressed` / `aria-current`).
- The **mulligan popup** behaves as a dialog — focus moves in, stays trapped, and returns on close — and now fits within a phone screen.

## Playback controls
- Redrawn as **icons**: a pause icon that stays lit while paused (pressing a speed resumes — that's the practical resume action), then **Slow / Normal / Fast** as one, two, and three play triangles.
- Each control carries a text accessible name and a **desktop hover tooltip**.

## Game log
- Now reads **newest-first** — the latest entry is on top, with each turn heading above its own group.

## Checks
- `typecheck`, `lint`, `test` (93 passed / 2 skipped), and `domainbook check` all clean.
- Docs updated: new `read-the-board-on-a-phone` feature, plus `follow-the-game` and `configure-a-run`; changelog cut for 0.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)