### PR TITLE
0.3.1: match-setup deck picker and stronger defaults

### DIFF
--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,6 +12,18 @@ depth live there. A purely-internal PR that touches no product or architecture m
 skip its version with a `Skip-Docs: <reason>` trailer instead. There are no
 per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
+## [0.3.1] - 2026-08-19
+
+### Changed
+
+- The Play tab opens match setup directly on your last-played deck (a dropdown over
+  every saved deck), instead of requiring a deck to be picked from the library first
+  (`domains/match-setup/features/configure-a-run.md`).
+- Setup now defaults to one match against Very Hard AI
+  (`domains/match-setup/features/configure-a-run.md`).
+- Opponent decks are listed one per line, numbered in seat order
+  (`domains/match-setup/features/configure-a-run.md`).
+
 ## [0.3.0] - 2026-08-19
 
 ### Added

--- a/domainbook/domains/match-setup/features/configure-a-run.md
+++ b/domainbook/domains/match-setup/features/configure-a-run.md
@@ -22,6 +22,37 @@ Example: A watch run is configured and started
   Then simulation begins a 20-match run with all seats piloted by the AI
 ```
 
+## Rule: Opening Play lands on setup with your last-played deck chosen
+
+The Play tab opens the setup form directly whenever the library holds at least
+one deck; only an empty library shows the "create a deck first" prompt. Your deck
+is a dropdown over every saved deck, defaulting to the one you last started a run
+with (or the first deck the first time). Opponents are chosen from the remaining
+decks and are listed one per line, numbered in seat order.
+
+```gherkin
+Example: Setup opens on the last-played deck
+  Given a run was last started with a given deck
+  When I open the Play tab again
+  Then setup opens with that deck chosen as my deck
+
+Example: My deck can be swapped at setup
+  Given the setup form is open
+  When I pick a different deck from the your-deck list
+  Then that deck becomes mine and the opponent choices exclude it
+```
+
+## Rule: Setup defaults to a single Very Hard match
+
+An unconfigured run defaults to one match against Very Hard AI, so pressing start
+without touching the form plays a single strong game.
+
+```gherkin
+Example: The defaults are one Very Hard match
+  Given the setup form opened without changes
+  Then the match count is 1 and the difficulty is Very Hard
+```
+
 ## Rule: The match count cannot exceed 50
 
 ```gherkin
@@ -67,4 +98,4 @@ Example: The opening-hand dialog keeps focus
 
 ## Open Questions
 
-- The default match count, given each match is slow.
+None.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",

--- a/src/App.css
+++ b/src/App.css
@@ -372,10 +372,32 @@ th {
   }
 }
 
-.opponent-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+.opponent-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
   gap: 0.5rem;
+}
+
+.opponent-list__item {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.opponent-list__num {
+  flex: 0 0 auto;
+  min-width: 1.25rem;
+  text-align: right;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.opponent-list__item .input {
+  flex: 1;
+  min-width: 0;
 }
 
 .field-row {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import "./App.css";
 import { DeckLibrary } from "./deck/DeckLibrary";
 import { DeckDetail } from "./deck/DeckDetail";
 import { useDecks } from "./deck/useDecks";
+import { getLastPlayedDeckId, setLastPlayedDeckId } from "./deck/storage";
 import type { SavedDeck } from "./deck/model";
 import { MatchSetup } from "./match/MatchSetup";
 import { RunView } from "./match/RunView";
@@ -20,7 +21,12 @@ export function App() {
   const [playDeck, setPlayDeck] = useState<SavedDeck | null>(null);
   const [runConfig, setRunConfig] = useState<RunConfig | null>(null);
 
-  const wide = view === "play" && !!playDeck && !!runConfig;
+  const wide = view === "play" && !!runConfig;
+
+  const preferredDeckId =
+    (playDeck && decks.some((d) => d.id === playDeck.id) && playDeck.id) ||
+    getLastPlayedDeckId() ||
+    undefined;
 
   return (
     <div className={`app${wide ? " app--wide" : ""}`}>
@@ -70,7 +76,7 @@ export function App() {
         ))}
 
       {view === "play" &&
-        (!playDeck ? (
+        (decks.length === 0 ? (
           <section className="panel">
             <h2>{t("play.empty.title")}</h2>
             <p className="hint">{t("play.empty.body")}</p>
@@ -85,9 +91,12 @@ export function App() {
           />
         ) : (
           <MatchSetup
-            yourDeck={playDeck}
-            decks={decks.filter((d) => d.id !== playDeck.id)}
-            onStart={setRunConfig}
+            decks={decks}
+            initialDeckId={preferredDeckId}
+            onStart={(config) => {
+              setLastPlayedDeckId(config.seatDeckIds[0]);
+              setRunConfig(config);
+            }}
           />
         ))}
     </div>

--- a/src/deck/storage.ts
+++ b/src/deck/storage.ts
@@ -1,6 +1,7 @@
 import type { SavedDeck } from "./model";
 
 const STORAGE_KEY = "commander-playtester/decks/v1";
+const LAST_PLAYED_KEY = "commander-playtester/last-played-deck/v1";
 
 function readAll(): SavedDeck[] {
   try {
@@ -42,4 +43,21 @@ export function saveDeck(deck: SavedDeck): SavedDeck {
 
 export function deleteDeck(id: string): void {
   writeAll(readAll().filter((d) => d.id !== id));
+}
+
+/** The deck id the user last started a run with, if any. */
+export function getLastPlayedDeckId(): string | null {
+  try {
+    return localStorage.getItem(LAST_PLAYED_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function setLastPlayedDeckId(id: string): void {
+  try {
+    localStorage.setItem(LAST_PLAYED_KEY, id);
+  } catch {
+    return;
+  }
 }

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -18,8 +18,8 @@ export const messages = {
 
   "play.empty.title": { pt: "Testar deck em partida", en: "Test a deck in a match" },
   "play.empty.body": {
-    pt: "Escolha um deck na aba Decks e clique em Testar em partida.",
-    en: "Pick a deck in the Decks tab and click Test in a match.",
+    pt: "Crie um deck na aba Decks para começar uma partida.",
+    en: "Create a deck in the Decks tab to start a match.",
   },
 
   "library.title": { pt: "Meus decks", en: "My decks" },
@@ -109,6 +109,7 @@ export const messages = {
   "setup.podSize": { pt: "Jogadores no pod", en: "Players in the pod" },
   "setup.players": { pt: "{n} jogadores", en: "{n} players" },
   "setup.opponents": { pt: "Oponentes (IA)", en: "Opponents (AI)" },
+  "setup.opponentN": { pt: "Oponente {n}", en: "Opponent {n}" },
   "setup.needOpponent": { pt: "Crie outro deck para usar como oponente.", en: "Create another deck to use as an opponent." },
   "setup.mode": { pt: "Modo", en: "Mode" },
   "setup.modePlay": { pt: "Jogar (você pilota)", en: "Play (you pilot)" },

--- a/src/match/MatchSetup.tsx
+++ b/src/match/MatchSetup.tsx
@@ -16,27 +16,35 @@ const DIFFICULTY_LABEL: Record<AiDifficulty, Record<Lang, string>> = {
   CEDH: { pt: "cEDH", en: "cEDH" },
 };
 
-/** Pre-game configuration: opponents, pod size, play/watch, match count. */
+/** Pre-game configuration: your deck, opponents, pod size, play/watch, match count. */
 export function MatchSetup({
-  yourDeck,
   decks,
+  initialDeckId,
   onStart,
 }: {
-  yourDeck: SavedDeck;
   decks: SavedDeck[];
+  initialDeckId?: string;
   onStart: (config: RunConfig) => void;
 }) {
   const { t, lang } = useI18n();
   const [seatCount, setSeatCount] = useState<SeatCount>(4);
   const [mode, setMode] = useState<PlayMode>("watch");
-  const [matchCount, setMatchCount] = useState(3);
+  const [matchCount, setMatchCount] = useState(1);
   const [seed, setSeed] = useState(1);
   const [revealHands, setRevealHands] = useState(false);
-  const [difficulty, setDifficulty] = useState<AiDifficulty>("Medium");
+  const [difficulty, setDifficulty] = useState<AiDifficulty>("VeryHard");
+  const [yourDeckId, setYourDeckId] = useState(
+    decks.find((d) => d.id === initialDeckId)?.id ?? decks[0].id,
+  );
   const [opponentIds, setOpponentIds] = useState<string[]>([]);
 
+  const yourDeck = decks.find((d) => d.id === yourDeckId) ?? decks[0];
+  const opponentDecks = decks.filter((d) => d.id !== yourDeck.id);
+
   function opponentAt(index: number): string {
-    return opponentIds[index] ?? decks[0]?.id ?? "";
+    const chosen = opponentIds[index];
+    if (chosen && opponentDecks.some((d) => d.id === chosen)) return chosen;
+    return opponentDecks[0]?.id ?? "";
   }
 
   function setOpponentAt(index: number, id: string) {
@@ -47,7 +55,7 @@ export function MatchSetup({
 
   const opponentSeats = seatCount - 1;
   const allChosen =
-    decks.length > 0 &&
+    opponentDecks.length > 0 &&
     Array.from({ length: opponentSeats }, (_, i) => opponentAt(i)).every(
       Boolean,
     );
@@ -73,7 +81,17 @@ export function MatchSetup({
 
       <div className="field">
         <span className="field__label">{t("setup.yourDeck")}</span>
-        <div className="chip">{yourDeck.name}</div>
+        <select
+          className="input"
+          value={yourDeck.id}
+          onChange={(e) => setYourDeckId(e.target.value)}
+        >
+          {decks.map((deck) => (
+            <option key={deck.id} value={deck.id}>
+              {deck.name}
+            </option>
+          ))}
+        </select>
       </div>
 
       <div className="field">
@@ -95,25 +113,30 @@ export function MatchSetup({
       {opponentSeats > 0 && (
         <div className="field">
           <span className="field__label">{t("setup.opponents")}</span>
-          {decks.length === 0 ? (
+          {opponentDecks.length === 0 ? (
             <p className="hint">{t("setup.needOpponent")}</p>
           ) : (
-            <div className="opponent-grid">
+            <ol className="opponent-list">
               {Array.from({ length: opponentSeats }, (_, i) => (
-                <select
-                  key={i}
-                  className="input"
-                  value={opponentAt(i)}
-                  onChange={(e) => setOpponentAt(i, e.target.value)}
-                >
-                  {decks.map((deck) => (
-                    <option key={deck.id} value={deck.id}>
-                      {deck.name}
-                    </option>
-                  ))}
-                </select>
+                <li key={i} className="opponent-list__item">
+                  <span className="opponent-list__num" aria-hidden="true">
+                    {i + 1}
+                  </span>
+                  <select
+                    className="input"
+                    value={opponentAt(i)}
+                    onChange={(e) => setOpponentAt(i, e.target.value)}
+                    aria-label={t("setup.opponentN", { n: i + 1 })}
+                  >
+                    {opponentDecks.map((deck) => (
+                      <option key={deck.id} value={deck.id}>
+                        {deck.name}
+                      </option>
+                    ))}
+                  </select>
+                </li>
               ))}
-            </div>
+            </ol>
           )}
         </div>
       )}


### PR DESCRIPTION
## What

Three match-setup changes for 0.3.1:

1. **Play opens setup on your last-played deck.** The Play tab now opens the setup form directly whenever the library holds at least one deck (only an empty library shows the "create a deck first" prompt). Your deck is a dropdown over every saved deck, defaulting to the one you last started a run with, persisted in a new `commander-playtester/last-played-deck/v1` localStorage key. Switching your deck excludes it from the opponent lists, and any opponent set to the newly-chosen deck falls back cleanly.
2. **Stronger defaults:** an unconfigured run defaults to **1 match** against **Very Hard** AI.
3. **Opponents are numbered and vertically aligned:** the opponent selects are now an `<ol>`, one per line with a seat number, replacing the old auto-fit grid.

## Docs

- `domainbook/domains/match-setup/features/configure-a-run.md` — new rules for the last-played default, deck swapping, and the Very Hard / 1-match defaults; resolved the "default match count" open question.
- Changelog `[0.3.1]` + `package.json` bump to 0.3.1. `domainbook check --staged` passes.

## Verification

- `npm run build` green.
- Live in the browser: Play opens on the last-played deck, difficulty = Very hard, match count = 1, opponents listed 1/2/3, and swapping your deck to one an opponent used excludes it with no stale selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)