### PR TITLE
0.3.2: preview cards during the opening mulligan

### DIFF
--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,6 +12,14 @@ depth live there. A purely-internal PR that touches no product or architecture m
 skip its version with a `Skip-Docs: <reason>` trailer instead. There are no
 per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
+## [0.3.2] - 2026-08-19
+
+### Added
+
+- Cards in the opening-hand mulligan popup can be enlarged to read: hover or focus
+  on a pointer device, tap on touch, and long-press while bottoming so a tap still
+  picks cards (`domains/simulation/features/decide-the-opening-mulligan.md`).
+
 ## [0.3.1] - 2026-08-19
 
 ### Changed

--- a/domainbook/domains/simulation/features/decide-the-opening-mulligan.md
+++ b/domainbook/domains/simulation/features/decide-the-opening-mulligan.md
@@ -52,6 +52,32 @@ Example: Bottoming the owed cards
   And confirming puts them on the bottom of my library and keeps the rest
 ```
 
+## Rule: Mulligan cards can be enlarged to read them
+
+Every card in the popup previews at full size, the same way the hand does during
+play. On a pointer device, hovering or focusing a card shows an enlarged copy
+beside it; on touch, tapping a card opens it as a centred overlay that dismisses
+on tap. During bottom-selection a tap already picks a card, so there a long press
+opens the enlarged overlay instead, without selecting the card.
+
+```gherkin
+Example: Hovering enlarges a card on a pointer device
+  Given the opening-hand popup on a pointer device
+  When I hover a card
+  Then an enlarged copy appears beside it so I can read it
+
+Example: Tapping enlarges a card while deciding on touch
+  Given the opening-hand popup on a touch device, deciding keep or mulligan
+  When I tap a card
+  Then it opens enlarged as an overlay I can dismiss by tapping
+
+Example: Long-press enlarges while bottoming on touch
+  Given the bottom-selection stage on a touch device
+  When I long-press a card
+  Then it opens enlarged without being picked for the bottom
+  And a plain tap still picks a card for the bottom
+```
+
 ## Rule: The mulligan can be handed to the AI
 
 ```gherkin

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",

--- a/src/App.css
+++ b/src/App.css
@@ -1454,3 +1454,30 @@ th {
 .mull-actions .hint {
   margin-right: auto;
 }
+.mull-zoom {
+  position: fixed;
+  inset: 0;
+  z-index: 90;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  background: color-mix(in srgb, var(--bg) 88%, transparent);
+}
+.mull-zoom__img {
+  width: auto;
+  max-width: min(88vw, 360px);
+  max-height: 88vh;
+  border-radius: var(--radius);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.6);
+}
+.mull-zoom__text {
+  max-width: min(88vw, 360px);
+  padding: 1.25rem 1.4rem;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-weight: 700;
+  text-align: center;
+}

--- a/src/board/Board.tsx
+++ b/src/board/Board.tsx
@@ -18,6 +18,7 @@ import {
 } from "lucide-react";
 import type { GameObject } from "../engine/types";
 import type { BoardView, SeatView } from "./boardView";
+import { CardPreview, type Preview } from "./CardPreview";
 import { useI18n } from "../i18n/I18nContext";
 import { categoryLabel } from "../i18n/messages";
 
@@ -263,15 +264,6 @@ function slotsFor(o: GameObject): string[] {
 function slotAccepts(cat: string, o: GameObject): boolean {
   if (cat === "Spell") return !isPermanent(o);
   return coreTypes(o).includes(cat);
-}
-
-interface Preview {
-  url?: string;
-  name: string;
-  power?: number | null;
-  toughness?: number | null;
-  isCreature: boolean;
-  rect: DOMRect;
 }
 
 /** Render opponents (top) with the human seat centered and larger at the bottom. */
@@ -816,37 +808,3 @@ function Card({
   );
 }
 
-/** Fixed-position enlarged card shown beside the hovered card. */
-function CardPreview({ preview }: { preview: Preview }) {
-  const width = 312;
-  const height = Math.round(width / 0.716);
-  const { rect } = preview;
-  const vw = typeof window !== "undefined" ? window.innerWidth : 1280;
-  const vh = typeof window !== "undefined" ? window.innerHeight : 800;
-  const gap = 12;
-  const fitsRight = rect.right + gap + width <= vw;
-  const left = fitsRight
-    ? rect.right + gap
-    : Math.max(8, rect.left - gap - width);
-  const top = Math.min(Math.max(8, rect.top - 20), Math.max(8, vh - height - 8));
-
-  return (
-    <div
-      className="card-preview"
-      style={{ left, top, width }}
-    >
-      {preview.url ? (
-        <img src={preview.url} alt={preview.name} className="card-preview__img" />
-      ) : (
-        <div className="card-preview__text">
-          <div className="card-preview__name">{preview.name}</div>
-          {preview.isCreature && (
-            <div className="card-preview__pt">
-              {preview.power ?? 0}/{preview.toughness ?? 0}
-            </div>
-          )}
-        </div>
-      )}
-    </div>
-  );
-}

--- a/src/board/CardPreview.tsx
+++ b/src/board/CardPreview.tsx
@@ -1,0 +1,40 @@
+export interface Preview {
+  url?: string;
+  name: string;
+  power?: number | null;
+  toughness?: number | null;
+  isCreature: boolean;
+  rect: DOMRect;
+}
+
+/** Fixed-position enlarged card shown beside the hovered card. */
+export function CardPreview({ preview }: { preview: Preview }) {
+  const width = 312;
+  const height = Math.round(width / 0.716);
+  const { rect } = preview;
+  const vw = typeof window !== "undefined" ? window.innerWidth : 1280;
+  const vh = typeof window !== "undefined" ? window.innerHeight : 800;
+  const gap = 12;
+  const fitsRight = rect.right + gap + width <= vw;
+  const left = fitsRight
+    ? rect.right + gap
+    : Math.max(8, rect.left - gap - width);
+  const top = Math.min(Math.max(8, rect.top - 20), Math.max(8, vh - height - 8));
+
+  return (
+    <div className="card-preview" style={{ left, top, width }}>
+      {preview.url ? (
+        <img src={preview.url} alt={preview.name} className="card-preview__img" />
+      ) : (
+        <div className="card-preview__text">
+          <div className="card-preview__name">{preview.name}</div>
+          {preview.isCreature && (
+            <div className="card-preview__pt">
+              {preview.power ?? 0}/{preview.toughness ?? 0}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/match/RunView.tsx
+++ b/src/match/RunView.tsx
@@ -23,6 +23,7 @@ import {
   type BlockInteraction,
   type ManaInteraction,
 } from "../board/Board";
+import { CardPreview, type Preview } from "../board/CardPreview";
 import {
   declareAttackersAction,
   type AttackersPrompt,
@@ -46,6 +47,7 @@ import {
   mulliganTakeAction,
   bottomCardsAction,
   type MulliganPrompt,
+  type MulliganCard,
 } from "../sim/decisions/mulligan";
 import { toBoardView, type BoardView, type SeatMeta } from "../board/boardView";
 import { GameSidebar, type LoggedEntry } from "../board/GameSidebar";
@@ -1322,6 +1324,48 @@ function MulliganModal({
     };
   }, []);
 
+  const canHover =
+    typeof window !== "undefined" &&
+    !!window.matchMedia?.("(hover: hover) and (pointer: fine)").matches;
+
+  const [preview, setPreview] = useState<Preview | null>(null);
+  const [zoomed, setZoomed] = useState<MulliganCard | null>(null);
+  const longPressTimer = useRef<number | null>(null);
+  const longPressFired = useRef(false);
+
+  const previewFor = (c: MulliganCard, rect: DOMRect): Preview => ({
+    url: c.name ? images[c.name.toLowerCase()] : undefined,
+    name: c.name || "?",
+    isCreature: false,
+    rect,
+  });
+
+  const cancelLongPress = () => {
+    if (longPressTimer.current != null) {
+      window.clearTimeout(longPressTimer.current);
+      longPressTimer.current = null;
+    }
+  };
+  useEffect(() => cancelLongPress, []);
+
+  const startLongPress = (c: MulliganCard) => {
+    longPressFired.current = false;
+    cancelLongPress();
+    longPressTimer.current = window.setTimeout(() => {
+      longPressFired.current = true;
+      setZoomed(c);
+    }, 500);
+  };
+
+  const onCardClick = (c: MulliganCard) => {
+    if (longPressFired.current) {
+      longPressFired.current = false;
+      return;
+    }
+    if (bottoming) onToggleBottom(c.id);
+    else if (!canHover) setZoomed(c);
+  };
+
   return (
     <div className="mull-overlay" role="dialog" aria-modal="true" aria-labelledby="mull-title">
       <div className="mull-modal" ref={modalRef}>
@@ -1350,8 +1394,23 @@ function MulliganModal({
                 className={`mull-card${bottoming ? " mull-card--selectable" : ""}${
                   picked ? " mull-card--picked" : ""
                 }`}
-                disabled={!bottoming}
-                onClick={() => bottoming && onToggleBottom(c.id)}
+                onClick={() => onCardClick(c)}
+                onMouseEnter={
+                  canHover
+                    ? (e) => setPreview(previewFor(c, e.currentTarget.getBoundingClientRect()))
+                    : undefined
+                }
+                onMouseLeave={canHover ? () => setPreview(null) : undefined}
+                onFocus={
+                  canHover
+                    ? (e) => setPreview(previewFor(c, e.currentTarget.getBoundingClientRect()))
+                    : undefined
+                }
+                onBlur={canHover ? () => setPreview(null) : undefined}
+                onTouchStart={canHover ? undefined : () => startLongPress(c)}
+                onTouchEnd={canHover ? undefined : cancelLongPress}
+                onTouchMove={canHover ? undefined : cancelLongPress}
+                onContextMenu={canHover ? undefined : (e) => e.preventDefault()}
                 title={c.name}
               >
                 {url ? (
@@ -1404,6 +1463,28 @@ function MulliganModal({
           )}
         </div>
       </div>
+
+      {preview && <CardPreview preview={preview} />}
+
+      {zoomed && (
+        <div
+          className="mull-zoom"
+          onClick={() => setZoomed(null)}
+          role="dialog"
+          aria-modal="true"
+        >
+          {(() => {
+            const url = zoomed.name
+              ? images[zoomed.name.toLowerCase()]
+              : undefined;
+            return url ? (
+              <img src={url} alt={zoomed.name} className="mull-zoom__img" />
+            ) : (
+              <div className="mull-zoom__text">{zoomed.name || "?"}</div>
+            );
+          })()}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## What

During the opening-hand mulligan, cards can now be previewed at full size — the same reading affordance the hand already has during play.

- **Pointer devices:** hovering (or keyboard-focusing) a mulligan card shows the enlarged copy beside it, reusing the board's existing preview.
- **Touch, deciding keep/mulligan:** tapping a card opens it as a centred overlay, dismissed by tapping anywhere.
- **Touch, bottom-selection:** a tap still picks a card to bottom (unchanged); a **long-press** opens the enlarged overlay without selecting. The trailing click that ends the long-press is suppressed so it never selects by accident.

## How

- Extracted the board's inline `CardPreview` + `Preview` type into `src/board/CardPreview.tsx` and reused it in both `Board` and `MulliganModal` (no behavior change on the board).
- The mulligan hover preview renders inside the modal overlay's stacking context so it layers above the popup.
- Interaction is gated on `(hover: hover) and (pointer: fine)`: hover/focus handlers on pointer devices, touch + long-press timer on touch.

## Docs

- `domains/simulation/features/decide-the-opening-mulligan.md` — new rule + examples for the three interactions.
- Changelog `[0.3.2]` + `package.json` bump. `domainbook check --staged` passes.

## Verification

Driven end-to-end in the live app against a starter deck in play mode:
- Desktop: hover updates the preview per card and hides on leave; it renders above the modal.
- Mobile (touch-emulated): tap in the keep stage opens the full-size lightbox; backdrop tap dismisses.
- Mobile bottom stage: quick tap selects a card (no preview); long-press opens the preview with the card left unselected, and the follow-up click does not select.
- `npm run build` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)