### PR TITLE
0.3.3: let the player choose cards to discard when playing by hand

### DIFF
--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,6 +12,14 @@ depth live there. A purely-internal PR that touches no product or architecture m
 skip its version with a `Skip-Docs: <reason>` trailer instead. There are no
 per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
+## [0.3.3] - 2026-08-20
+
+### Fixed
+
+- When playing by hand, a forced discard now prompts you to choose which cards to
+  discard (with the same card preview as the mulligan), instead of the AI picking
+  for you (`domains/simulation/features/step-through-a-turn.md`).
+
 ## [0.3.2] - 2026-08-19
 
 ### Added

--- a/domainbook/domains/simulation/features/step-through-a-turn.md
+++ b/domainbook/domains/simulation/features/step-through-a-turn.md
@@ -58,6 +58,12 @@ Example: Naming a creature type
   When the engine asks for the type
   Then you pick one from the valid types, pre-selected with the AI's suggestion
   And you may instead let the AI choose for you
+
+Example: Choosing which cards to discard
+  Given an effect (or the end-of-turn hand-size rule) makes you discard
+  When the engine asks you to discard
+  Then a popup shows the eligible cards, previewable like your hand
+  And you pick exactly the required number to discard, or let the AI choose
 ```
 
 ## Rule: You put cards into play by dragging or tapping from hand, or clicking the commander in its zone

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -275,6 +275,14 @@ export const messages = {
   "mulligan.bottomConfirm": { pt: "Devolver e ficar", en: "Bottom & keep" },
   "mulligan.letAi": { pt: "IA decide o mulligan", en: "Let the AI decide" },
 
+  "discard.title": { pt: "Descartar cartas", en: "Discard cards" },
+  "discard.instruction": {
+    pt: "Escolha {n} carta(s) para descartar.",
+    en: "Choose {n} card(s) to discard.",
+  },
+  "discard.progress": { pt: "Selecionadas: {n} / {max}", en: "Selected: {n} / {max}" },
+  "discard.confirm": { pt: "Descartar", en: "Discard" },
+
   "select.noResults": { pt: "Nenhum resultado", en: "No matches" },
 
   "sidebar.title": { pt: "Pilha e registro", en: "Stack & log" },

--- a/src/match/RunView.tsx
+++ b/src/match/RunView.tsx
@@ -23,7 +23,11 @@ import {
   type BlockInteraction,
   type ManaInteraction,
 } from "../board/Board";
-import { CardPreview, type Preview } from "../board/CardPreview";
+import { useCardPreview } from "./useCardPreview";
+import {
+  discardCardsAction,
+  type DiscardPrompt,
+} from "../sim/decisions/discard";
 import {
   declareAttackersAction,
   type AttackersPrompt,
@@ -47,7 +51,6 @@ import {
   mulliganTakeAction,
   bottomCardsAction,
   type MulliganPrompt,
-  type MulliganCard,
 } from "../sim/decisions/mulligan";
 import { toBoardView, type BoardView, type SeatMeta } from "../board/boardView";
 import { GameSidebar, type LoggedEntry } from "../board/GameSidebar";
@@ -176,6 +179,11 @@ interface MulliganTurn {
   resolve: (choice: HumanChoice) => void;
 }
 
+interface DiscardTurn {
+  prompt: DiscardPrompt;
+  resolve: (choice: HumanChoice) => void;
+}
+
 /** Runs a configured series of matches and renders the live board + results. */
 export function RunView({
   config,
@@ -215,6 +223,8 @@ export function RunView({
   const [creatureTypePick, setCreatureTypePick] = useState("");
   const [mulliganTurn, setMulliganTurn] = useState<MulliganTurn | null>(null);
   const [bottomPick, setBottomPick] = useState<Set<number>>(new Set());
+  const [discardTurn, setDiscardTurn] = useState<DiscardTurn | null>(null);
+  const [discardPick, setDiscardPick] = useState<Set<number>>(new Set());
   const [passingTurn, setPassingTurn] = useState(false);
   const [logEntries, setLogEntries] = useState<LoggedEntry[]>([]);
   // On mobile the log is a full-screen drawer, so it always starts closed and
@@ -420,6 +430,22 @@ export function RunView({
                   resolve: (choice) => {
                     setMulliganTurn(null);
                     setBottomPick(new Set());
+                    resolve(choice);
+                  },
+                });
+              }),
+            requestHumanDiscard: (_env, prompt) =>
+              new Promise<HumanChoice>((resolve) => {
+                if (cancelled) {
+                  resolve({ ai: true });
+                  return;
+                }
+                setDiscardPick(new Set());
+                setDiscardTurn({
+                  prompt,
+                  resolve: (choice) => {
+                    setDiscardTurn(null);
+                    setDiscardPick(new Set());
                     resolve(choice);
                   },
                 });
@@ -1255,6 +1281,26 @@ export function RunView({
         />
       )}
 
+      {discardTurn && (
+        <DiscardModal
+          prompt={discardTurn.prompt}
+          images={images}
+          pick={discardPick}
+          onTogglePick={(id) =>
+            setDiscardPick((prev) => {
+              const next = new Set(prev);
+              if (next.has(id)) next.delete(id);
+              else if (next.size < discardTurn.prompt.count) next.add(id);
+              return next;
+            })
+          }
+          onConfirm={() =>
+            discardTurn.resolve({ action: discardCardsAction([...discardPick]) })
+          }
+          onLetAi={() => discardTurn.resolve({ ai: true })}
+        />
+      )}
+
       {phase === "done" && (
         <RunReport
           stats={stats}
@@ -1324,47 +1370,11 @@ function MulliganModal({
     };
   }, []);
 
-  const canHover =
-    typeof window !== "undefined" &&
-    !!window.matchMedia?.("(hover: hover) and (pointer: fine)").matches;
-
-  const [preview, setPreview] = useState<Preview | null>(null);
-  const [zoomed, setZoomed] = useState<MulliganCard | null>(null);
-  const longPressTimer = useRef<number | null>(null);
-  const longPressFired = useRef(false);
-
-  const previewFor = (c: MulliganCard, rect: DOMRect): Preview => ({
-    url: c.name ? images[c.name.toLowerCase()] : undefined,
-    name: c.name || "?",
-    isCreature: false,
-    rect,
+  const { cardProps, overlay } = useCardPreview({
+    images,
+    selectable: bottoming,
+    onToggle: onToggleBottom,
   });
-
-  const cancelLongPress = () => {
-    if (longPressTimer.current != null) {
-      window.clearTimeout(longPressTimer.current);
-      longPressTimer.current = null;
-    }
-  };
-  useEffect(() => cancelLongPress, []);
-
-  const startLongPress = (c: MulliganCard) => {
-    longPressFired.current = false;
-    cancelLongPress();
-    longPressTimer.current = window.setTimeout(() => {
-      longPressFired.current = true;
-      setZoomed(c);
-    }, 500);
-  };
-
-  const onCardClick = (c: MulliganCard) => {
-    if (longPressFired.current) {
-      longPressFired.current = false;
-      return;
-    }
-    if (bottoming) onToggleBottom(c.id);
-    else if (!canHover) setZoomed(c);
-  };
 
   return (
     <div className="mull-overlay" role="dialog" aria-modal="true" aria-labelledby="mull-title">
@@ -1394,23 +1404,7 @@ function MulliganModal({
                 className={`mull-card${bottoming ? " mull-card--selectable" : ""}${
                   picked ? " mull-card--picked" : ""
                 }`}
-                onClick={() => onCardClick(c)}
-                onMouseEnter={
-                  canHover
-                    ? (e) => setPreview(previewFor(c, e.currentTarget.getBoundingClientRect()))
-                    : undefined
-                }
-                onMouseLeave={canHover ? () => setPreview(null) : undefined}
-                onFocus={
-                  canHover
-                    ? (e) => setPreview(previewFor(c, e.currentTarget.getBoundingClientRect()))
-                    : undefined
-                }
-                onBlur={canHover ? () => setPreview(null) : undefined}
-                onTouchStart={canHover ? undefined : () => startLongPress(c)}
-                onTouchEnd={canHover ? undefined : cancelLongPress}
-                onTouchMove={canHover ? undefined : cancelLongPress}
-                onContextMenu={canHover ? undefined : (e) => e.preventDefault()}
+                {...cardProps(c)}
                 title={c.name}
               >
                 {url ? (
@@ -1464,27 +1458,125 @@ function MulliganModal({
         </div>
       </div>
 
-      {preview && <CardPreview preview={preview} />}
+      {overlay}
+    </div>
+  );
+}
 
-      {zoomed && (
-        <div
-          className="mull-zoom"
-          onClick={() => setZoomed(null)}
-          role="dialog"
-          aria-modal="true"
-        >
-          {(() => {
-            const url = zoomed.name
-              ? images[zoomed.name.toLowerCase()]
-              : undefined;
-            return url ? (
-              <img src={url} alt={zoomed.name} className="mull-zoom__img" />
-            ) : (
-              <div className="mull-zoom__text">{zoomed.name || "?"}</div>
-            );
-          })()}
+/** Forced-discard popup: pick exactly `count` cards to discard. */
+function DiscardModal({
+  prompt,
+  images,
+  pick,
+  onTogglePick,
+  onConfirm,
+  onLetAi,
+}: {
+  prompt: DiscardPrompt;
+  images: Record<string, string>;
+  pick: Set<number>;
+  onTogglePick: (id: number) => void;
+  onConfirm: () => void;
+  onLetAi: () => void;
+}) {
+  const { t } = useI18n();
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  // Move focus into the dialog, trap Tab within it, and restore focus on close.
+  useEffect(() => {
+    const node = modalRef.current;
+    if (!node) return;
+    const prev = document.activeElement as HTMLElement | null;
+    const focusable = () =>
+      [
+        ...node.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        ),
+      ];
+    focusable()[0]?.focus();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Tab") return;
+      const els = focusable();
+      if (els.length === 0) return;
+      const first = els[0];
+      const last = els[els.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+    node.addEventListener("keydown", onKey);
+    return () => {
+      node.removeEventListener("keydown", onKey);
+      prev?.focus?.();
+    };
+  }, []);
+
+  const { cardProps, overlay } = useCardPreview({
+    images,
+    selectable: true,
+    onToggle: onTogglePick,
+  });
+
+  return (
+    <div
+      className="mull-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="discard-title"
+    >
+      <div className="mull-modal" ref={modalRef}>
+        <div className="mull-modal__head">
+          <h2 id="discard-title">{t("discard.title")}</h2>
+          <p className="hint">{t("discard.instruction", { n: prompt.count })}</p>
         </div>
-      )}
+
+        <div className="mull-hand">
+          {prompt.cards.map((c) => {
+            const url = c.name ? images[c.name.toLowerCase()] : undefined;
+            const picked = pick.has(c.id);
+            return (
+              <button
+                key={c.id}
+                type="button"
+                className={`mull-card mull-card--selectable${
+                  picked ? " mull-card--picked" : ""
+                }`}
+                {...cardProps(c)}
+                title={c.name}
+              >
+                {url ? (
+                  <img src={url} alt={c.name} loading="lazy" />
+                ) : (
+                  <span className="mull-card__name">{c.name || "?"}</span>
+                )}
+                {picked && <span className="mull-card__badge">✕</span>}
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="mull-actions">
+          <span className="hint">
+            {t("discard.progress", { n: pick.size, max: prompt.count })}
+          </span>
+          <button
+            className="btn"
+            disabled={pick.size !== prompt.count}
+            onClick={onConfirm}
+          >
+            {t("discard.confirm")}
+          </button>
+          <button className="btn btn--ghost" onClick={onLetAi}>
+            {t("mulligan.letAi")}
+          </button>
+        </div>
+      </div>
+
+      {overlay}
     </div>
   );
 }

--- a/src/match/useCardPreview.tsx
+++ b/src/match/useCardPreview.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useRef, useState } from "react";
+import type { FocusEvent, MouseEvent } from "react";
+import { CardPreview, type Preview } from "../board/CardPreview";
+
+interface PickCard {
+  id: number;
+  name: string;
+}
+
+/**
+ * Shared card-preview interaction for the mulligan and discard popups. A pointer
+ * device previews a card on hover or focus (an enlarged copy beside it); touch
+ * opens a centred overlay — on tap when the card has no other action, or on
+ * long-press when a tap already selects the card, so selection still works.
+ *
+ * Returns `cardProps(card)` to spread onto each card button, and `overlay` to
+ * render at the popup-overlay level (above the modal).
+ */
+export function useCardPreview({
+  images,
+  selectable,
+  onToggle,
+}: {
+  images: Record<string, string>;
+  selectable: boolean;
+  onToggle?: (id: number) => void;
+}) {
+  const canHover =
+    typeof window !== "undefined" &&
+    !!window.matchMedia?.("(hover: hover) and (pointer: fine)").matches;
+
+  const [preview, setPreview] = useState<Preview | null>(null);
+  const [zoomed, setZoomed] = useState<PickCard | null>(null);
+  const longPressTimer = useRef<number | null>(null);
+  const longPressFired = useRef(false);
+
+  const previewFor = (c: PickCard, rect: DOMRect): Preview => ({
+    url: c.name ? images[c.name.toLowerCase()] : undefined,
+    name: c.name || "?",
+    isCreature: false,
+    rect,
+  });
+
+  const cancelLongPress = () => {
+    if (longPressTimer.current != null) {
+      window.clearTimeout(longPressTimer.current);
+      longPressTimer.current = null;
+    }
+  };
+  useEffect(() => cancelLongPress, []);
+
+  const startLongPress = (c: PickCard) => {
+    longPressFired.current = false;
+    cancelLongPress();
+    longPressTimer.current = window.setTimeout(() => {
+      longPressFired.current = true;
+      setZoomed(c);
+    }, 500);
+  };
+
+  const onCardClick = (c: PickCard) => {
+    if (longPressFired.current) {
+      longPressFired.current = false;
+      return;
+    }
+    if (selectable) onToggle?.(c.id);
+    else if (!canHover) setZoomed(c);
+  };
+
+  const cardProps = (c: PickCard) => ({
+    onClick: () => onCardClick(c),
+    onMouseEnter: canHover
+      ? (e: MouseEvent) =>
+          setPreview(previewFor(c, e.currentTarget.getBoundingClientRect()))
+      : undefined,
+    onMouseLeave: canHover ? () => setPreview(null) : undefined,
+    onFocus: canHover
+      ? (e: FocusEvent) =>
+          setPreview(previewFor(c, e.currentTarget.getBoundingClientRect()))
+      : undefined,
+    onBlur: canHover ? () => setPreview(null) : undefined,
+    onTouchStart: canHover ? undefined : () => startLongPress(c),
+    onTouchEnd: canHover ? undefined : cancelLongPress,
+    onTouchMove: canHover ? undefined : cancelLongPress,
+    onContextMenu: canHover ? undefined : (e: MouseEvent) => e.preventDefault(),
+  });
+
+  const overlay = (
+    <>
+      {preview && <CardPreview preview={preview} />}
+      {zoomed && (
+        <div
+          className="mull-zoom"
+          onClick={() => setZoomed(null)}
+          role="dialog"
+          aria-modal="true"
+        >
+          {(() => {
+            const url = zoomed.name
+              ? images[zoomed.name.toLowerCase()]
+              : undefined;
+            return url ? (
+              <img src={url} alt={zoomed.name} className="mull-zoom__img" />
+            ) : (
+              <div className="mull-zoom__text">{zoomed.name || "?"}</div>
+            );
+          })()}
+        </div>
+      )}
+    </>
+  );
+
+  return { cardProps, overlay };
+}

--- a/src/sim/decisions/discard.test.ts
+++ b/src/sim/decisions/discard.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { parseDiscardPrompt, discardCardsAction } from "./discard";
+import type { GameState, WaitingFor } from "../../engine/types";
+
+// Names the popup renders for the discard candidates.
+function stateWithHand(): GameState {
+  const objects: GameState["objects"] = {};
+  for (const id of [45, 65, 87, 86, 69, 91]) {
+    objects[id] = { id, zone: "Hand", name: `Card ${id}` };
+  }
+  return {
+    turn_number: 5,
+    phase: "Cleanup",
+    active_player: 0,
+    waiting_for: { type: "DiscardChoice" },
+    players: [
+      { id: 0, life: 40, hand: [45, 65, 87, 86, 69, 91], library: [], graveyard: [] },
+      { id: 1, life: 40, hand: [], library: [], graveyard: [] },
+    ],
+    objects,
+    battlefield: [],
+    command_zone: [],
+    stack: [],
+    eliminated_players: [],
+  } as unknown as GameState;
+}
+
+// Forced discard captured from the phase-rs WASM build (v0.55.0): seat 0 must
+// discard two of the six eligible cards.
+const DISCARD: WaitingFor = {
+  type: "DiscardChoice",
+  data: {
+    cards: [45, 65, 87, 86, 69, 91],
+    count: 2,
+    effect_kind: "Discard",
+    player: 0,
+    source_id: 127,
+  },
+};
+
+describe("parseDiscardPrompt", () => {
+  it("reads the count and the eligible cards for the acting seat", () => {
+    const prompt = parseDiscardPrompt(DISCARD, stateWithHand(), 0);
+    expect(prompt).not.toBeNull();
+    expect(prompt!.player).toBe(0);
+    expect(prompt!.count).toBe(2);
+    expect(prompt!.cards.map((c) => c.id)).toEqual([45, 65, 87, 86, 69, 91]);
+    expect(prompt!.cards[0].name).toBe("Card 45");
+  });
+
+  it("returns null when the decision targets another seat", () => {
+    expect(parseDiscardPrompt(DISCARD, stateWithHand(), 1)).toBeNull();
+  });
+
+  it("returns null for a non-discard waiting_for", () => {
+    const wf: WaitingFor = { type: "MulliganDecision" };
+    expect(parseDiscardPrompt(wf, stateWithHand(), 0)).toBeNull();
+  });
+
+  it("defaults count to 1 when the engine omits it", () => {
+    const wf: WaitingFor = {
+      type: "DiscardChoice",
+      data: { cards: [45, 65], player: 0 },
+    };
+    expect(parseDiscardPrompt(wf, stateWithHand(), 0)!.count).toBe(1);
+  });
+});
+
+describe("discardCardsAction", () => {
+  it("submits the chosen ids as a SelectCards action", () => {
+    expect(discardCardsAction([45, 69])).toEqual({
+      type: "SelectCards",
+      data: { cards: [45, 69] },
+    });
+  });
+});

--- a/src/sim/decisions/discard.ts
+++ b/src/sim/decisions/discard.ts
@@ -1,0 +1,51 @@
+// A forced discard. When an effect (or the cleanup hand-size rule) makes the
+// human discard, the engine surfaces a `DiscardChoice` waiting_for whose `data`
+// carries the acting `player`, the `count` to discard, and `cards` — the ids
+// eligible to discard (normally the whole hand). The seat answers by submitting
+// `SelectCards` with exactly `count` of those ids, the same action the London
+// mulligan uses to bottom cards.
+
+import type { GameState, WaitingFor } from "../../engine/types";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/** A card eligible for a forced discard. */
+export interface DiscardCard {
+  id: number;
+  name: string;
+}
+
+export interface DiscardPrompt {
+  player: number;
+  /** How many cards must be discarded now. */
+  count: number;
+  /** The cards this seat may choose from. */
+  cards: DiscardCard[];
+}
+
+/**
+ * Read a forced-discard decision for `seat`, or null if this waiting_for is not
+ * a `DiscardChoice` aimed at that seat.
+ */
+export function parseDiscardPrompt(
+  wf: WaitingFor | undefined,
+  state: GameState,
+  seat: number,
+): DiscardPrompt | null {
+  if (!wf || wf.type !== "DiscardChoice") return null;
+  const d: any = wf.data ?? {};
+  if (d.player !== seat) return null;
+
+  const ids: number[] = Array.isArray(d.cards) ? d.cards : [];
+  const count: number = typeof d.count === "number" ? d.count : 1;
+  const cards = ids.map((id) => ({ id, name: state.objects?.[id]?.name ?? "" }));
+  return { player: seat, count, cards };
+}
+
+/** Discard the chosen cards. */
+export function discardCardsAction(cards: number[]): {
+  type: string;
+  data: { cards: number[] };
+} {
+  return { type: "SelectCards", data: { cards } };
+}

--- a/src/sim/driver.ts
+++ b/src/sim/driver.ts
@@ -24,6 +24,7 @@ import {
   parseMulliganPrompt,
   type MulliganPrompt,
 } from "./decisions/mulligan";
+import { parseDiscardPrompt, type DiscardPrompt } from "./decisions/discard";
 
 export interface MatchResult {
   matchIndex: number;
@@ -197,6 +198,11 @@ export interface DriverCallbacks {
   requestHumanMulligan?: (
     env: GameStateEnvelope,
     prompt: MulliganPrompt,
+  ) => Promise<HumanChoice>;
+  /** Called when an effect forces the human to choose cards to discard. */
+  requestHumanDiscard?: (
+    env: GameStateEnvelope,
+    prompt: DiscardPrompt,
   ) => Promise<HumanChoice>;
 }
 
@@ -407,6 +413,10 @@ export class MatchRunner {
         humanNonPriority && cb.requestHumanMulligan
           ? parseMulliganPrompt(wf, env.state, humanSeat)
           : null;
+      const humanDiscard =
+        humanNonPriority && cb.requestHumanDiscard
+          ? parseDiscardPrompt(wf, env.state, humanSeat)
+          : null;
 
       // Run the human's choice: play their action, or hand this decision to the AI.
       const applyChoice = async (choice: HumanChoice): Promise<void> => {
@@ -467,6 +477,13 @@ export class MatchRunner {
         await applyChoice(choice);
       } else if (humanMulligan) {
         const choice = await cb.requestHumanMulligan!(env, humanMulligan);
+        if (this.aborted) {
+          stopped = true;
+          break;
+        }
+        await applyChoice(choice);
+      } else if (humanDiscard) {
+        const choice = await cb.requestHumanDiscard!(env, humanDiscard);
         if (this.aborted) {
           stopped = true;
           break;


### PR DESCRIPTION
## Bug

When playing a match by hand, a forced discard was resolved by the AI — the player never got to choose which cards to pitch. Confirmed against the live engine: the `DiscardChoice` decision was not among the driver's human-routed decisions, so it fell through to the AI branch.

## Fix

Route `DiscardChoice` to the human, mirroring the mulligan:

- **`src/sim/decisions/discard.ts`** — `parseDiscardPrompt` (reads the acting seat, the `count` to discard, and the eligible `cards`) + `discardCardsAction` (submits `SelectCards`). Wire shape captured from the live v0.55.0 WASM.
- **`src/sim/driver.ts`** — new `requestHumanDiscard` callback + routing branch (with the standard "let the AI decide" escape).
- **`src/match/RunView.tsx`** — a `DiscardModal` that reuses the mulligan's card selection UI.
- **`src/match/useCardPreview.tsx`** — extracted the mulligan's card selection + preview interaction (hover / tap / long-press + the zoom lightbox) into a shared hook so both popups behave identically. MulliganModal now uses it too.

## Verification

- **Engine boundary (real WASM, headless):** drove AI matches to a real `DiscardChoice` for seat 0, then submitted `discardCardsAction` exactly as the driver would. The engine accepted it — no panic, hand shrank by the required `count` (7→5 for a count-2 discard), and the decision advanced to Priority. This proves the parser, action shape, and routing against the actual engine.
- **Unit tests:** `discard.test.ts` covers the parser (count, eligible cards, wrong-seat/other-type null, count default) and the action shape.
- **Mulligan regression (browser, after the hook extraction):** the opening-hand popup still renders, the hover preview still appears above the modal, and bottom-stage selection still toggles ("Selected: 1 / 1"). The `DiscardModal` shares that exact verified hook + CSS.
- Full suite (98 passed), `eslint`, and `npm run build` all clean. `domainbook check` passes.

## Docs

- `domains/simulation/features/step-through-a-turn.md` — new example under "You decide only where the engine asks."
- Changelog `[0.3.3]` + `package.json` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)