### PR TITLE
0.4.1: inspect a seat's graveyard in a floating window

### DIFF
--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -17,8 +17,8 @@ per-domain changelogs; this file is the single timeline (`ADR-0007`).
 ### Added
 
 - Click a seat's graveyard count to open a floating, draggable, closable window
-  that lists that graveyard's cards in one row, shown untapped
-  (`domains/board/features/inspect-a-graveyard.md`).
+  that lists that graveyard's cards in one row, shown untapped, each enlarging on
+  hover (`domains/board/features/inspect-a-graveyard.md`).
 
 ## [0.4.0] - 2026-08-20
 

--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,6 +12,14 @@ depth live there. A purely-internal PR that touches no product or architecture m
 skip its version with a `Skip-Docs: <reason>` trailer instead. There are no
 per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
+## [0.4.1] - 2026-08-21
+
+### Added
+
+- Click a seat's graveyard count to open a floating, draggable, closable window
+  that lists that graveyard's cards in one row, shown untapped
+  (`domains/board/features/inspect-a-graveyard.md`).
+
 ## [0.4.0] - 2026-08-20
 
 ### Changed

--- a/domainbook/domains/board/features/inspect-a-graveyard.md
+++ b/domainbook/domains/board/features/inspect-a-graveyard.md
@@ -1,0 +1,58 @@
+---
+id: inspect-a-graveyard
+name: Inspect a graveyard
+status: implemented
+---
+
+## Story
+
+As a player
+I want to open any seat's graveyard and read the cards in it
+So that I can check what has died or been discarded without leaving the board
+
+## Rule: The graveyard count is a button when the graveyard is not empty
+
+```gherkin
+Example: A filled graveyard invites a click
+  Given a seat whose graveyard has at least one card
+  When I look at that seat's zone counts
+  Then the graveyard count is a button
+  And clicking it opens that seat's graveyard
+
+Example: An empty graveyard is just a number
+  Given a seat with an empty graveyard
+  Then its graveyard count is plain text, not a button
+```
+
+## Rule: The graveyard opens in a floating window
+
+```gherkin
+Example: One row of cards, titled by owner
+  Given I open a seat's graveyard
+  Then a floating window shows the graveyard's cards in a single row
+  And the window is titled with the seat's name
+  And a row wider than the window scrolls sideways
+
+Example: Move it out of the way
+  Given the graveyard window is open
+  When I hold its title bar and drag
+  Then the window follows the pointer and stays within the screen
+
+Example: Dismiss it
+  Given the graveyard window is open
+  When I click its close button or press Escape
+  Then the window disappears
+```
+
+## Rule: Graveyard cards are shown untapped
+
+```gherkin
+Example: A creature that died tapped lies flat in the graveyard
+  Given a card that was tapped when it left the battlefield
+  When I view it in the graveyard window
+  Then it is drawn upright, not rotated
+```
+
+## Open Questions
+
+None.

--- a/domainbook/domains/board/features/inspect-a-graveyard.md
+++ b/domainbook/domains/board/features/inspect-a-graveyard.md
@@ -42,6 +42,11 @@ Example: Dismiss it
   Given the graveyard window is open
   When I click its close button or press Escape
   Then the window disappears
+
+Example: Read a card up close
+  Given the graveyard window is open
+  When I hover a card in it
+  Then an enlarged preview of that card is shown, above the window
 ```
 
 ## Rule: Graveyard cards are shown untapped

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",

--- a/src/App.css
+++ b/src/App.css
@@ -819,6 +819,27 @@ th {
   align-items: center;
   gap: 0.25rem;
 }
+.seat__zone-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 1px 5px;
+  font: inherit;
+  color: var(--accent-bright);
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  box-shadow: var(--bevel-raised);
+}
+.seat__zone-btn:hover {
+  color: var(--accent-ink);
+  background: var(--accent);
+  border-color: var(--accent-2);
+}
+.seat__zone-btn:active {
+  box-shadow: var(--bevel-pressed);
+}
 .seat__cmd {
   display: flex;
   gap: 0.3rem;
@@ -1141,6 +1162,97 @@ th {
   color: var(--accent);
   font-weight: 700;
   margin-top: 0.35rem;
+}
+
+/* ── XpWindow: draggable floating window (graveyard, …) ─────────── */
+.xpwin {
+  position: fixed;
+  z-index: 75;
+  display: flex;
+  flex-direction: column;
+  max-width: min(92vw, 760px);
+  border: 1px solid var(--accent);
+  background: var(--winbg);
+  box-shadow: 0 14px 44px -8px rgba(0, 0, 0, 0.75);
+}
+.xpwin--center {
+  left: 50%;
+  top: 12vh;
+  transform: translateX(-50%);
+}
+.xpwin__bar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 28px;
+  padding: 0 4px 0 9px;
+  background: linear-gradient(var(--accent), var(--accent-2));
+  cursor: move;
+  user-select: none;
+}
+.xpwin__title {
+  flex: 1;
+  min-width: 0;
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 13px;
+  color: var(--accent-ink);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.xpwin__close {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 18px;
+  padding: 0;
+  color: var(--accent-ink);
+  background: var(--accent-bright);
+  border: 1px solid var(--accent-edge);
+  box-shadow: var(--bevel-raised);
+  cursor: pointer;
+}
+.xpwin__close:hover {
+  background: var(--warn);
+}
+.xpwin__close:active {
+  box-shadow: var(--bevel-pressed);
+}
+.xpwin__body {
+  min-width: 0;
+  padding: 8px;
+  background: var(--inset);
+  box-shadow: var(--bevel-well);
+}
+.gy-window {
+  width: min(88vw, 604px);
+}
+.gy-window__row {
+  display: flex;
+  gap: 0.4rem;
+  align-items: flex-start;
+}
+.gy-window__row .card {
+  flex: 0 0 auto;
+  width: 92px;
+  height: 128px;
+}
+.gy-window__row .card__img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.gy-window__row .card--text {
+  max-width: none;
+  padding: 0.35rem;
+  white-space: normal;
+  text-align: center;
+  justify-content: center;
+  font-size: 0.7rem;
 }
 
 /* ── XP dropdown (select) ──────────────────────────────────────── */

--- a/src/App.css
+++ b/src/App.css
@@ -1137,7 +1137,7 @@ th {
 /* ── Hover card preview ────────────────────────────────────────── */
 .card-preview {
   position: fixed;
-  z-index: 50;
+  z-index: 78;
   pointer-events: none;
   border-radius: var(--radius);
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.55);

--- a/src/board/Board.tsx
+++ b/src/board/Board.tsx
@@ -22,6 +22,7 @@ import { CardPreview, type Preview } from "./CardPreview";
 import { useI18n } from "../i18n/I18nContext";
 import { categoryLabel } from "../i18n/messages";
 import { XpScroll } from "../components/XpScroll";
+import { XpWindow } from "../components/XpWindow";
 
 /** Play-mode interaction for the human's seat: drag a hand card to a slot, or
  * click the commander in the command zone to cast it. */
@@ -291,10 +292,12 @@ export function Board({
 }) {
   const { t } = useI18n();
   const [preview, setPreview] = useState<Preview | null>(null);
+  const [graveSeat, setGraveSeat] = useState<number | null>(null);
   const oppScrollRef = useRef<HTMLDivElement | null>(null);
 
   const you = view.seats.find((s) => s.seat === 0);
   const opponents = view.seats.filter((s) => s.seat !== 0);
+  const graveView = view.seats.find((s) => s.seat === graveSeat);
 
   // In the mobile opponents gallery, follow the active opponent into view. When
   // the human (seat 0) is active, leave the gallery on the last-shown opponent.
@@ -335,6 +338,7 @@ export function Board({
             winner={view.winner}
             images={images}
             onHover={onHover}
+            onOpenGraveyard={setGraveSeat}
             target={target}
             attack={attack}
             block={block}
@@ -352,6 +356,7 @@ export function Board({
             winner={view.winner}
             images={images}
             onHover={onHover}
+            onOpenGraveyard={setGraveSeat}
             play={play}
             target={target}
             ability={ability}
@@ -361,6 +366,23 @@ export function Board({
             mana={mana}
           />
         </div>
+      )}
+
+      {graveView && graveView.graveyard.length > 0 && (
+        <XpWindow
+          title={t("board.graveyardOf", { name: seatName(graveView) })}
+          onClose={() => setGraveSeat(null)}
+        >
+          <XpScroll
+            axis="x"
+            wrapperClassName="gy-window"
+            className="gy-window__row"
+          >
+            {graveView.graveyard.map((o) => (
+              <Card key={o.id} obj={o} images={images} />
+            ))}
+          </XpScroll>
+        </XpWindow>
       )}
 
       {preview && play?.dragging == null && <CardPreview preview={preview} />}
@@ -376,6 +398,7 @@ function Seat({
   winner,
   images,
   onHover,
+  onOpenGraveyard,
   play,
   target,
   ability,
@@ -391,6 +414,7 @@ function Seat({
   winner: number | null;
   images?: Record<string, string>;
   onHover?: (p: Preview | null) => void;
+  onOpenGraveyard?: (seat: number) => void;
   play?: PlayInteraction;
   target?: TargetInteraction;
   ability?: AbilityInteraction;
@@ -466,9 +490,23 @@ function Seat({
         <span>
           <Layers size={13} /> {seat.librarySize}
         </span>
-        <span>
-          <Skull size={13} /> {seat.graveyardSize}
-        </span>
+        {seat.graveyardSize > 0 && onOpenGraveyard ? (
+          <button
+            type="button"
+            className="seat__zone-btn"
+            onClick={(e) => {
+              e.stopPropagation();
+              onOpenGraveyard(seat.seat);
+            }}
+            title={t("board.graveyardOpen")}
+          >
+            <Skull size={13} /> {seat.graveyardSize}
+          </button>
+        ) : (
+          <span>
+            <Skull size={13} /> {seat.graveyardSize}
+          </span>
+        )}
         {seat.poison > 0 && (
           <span>
             <Biohazard size={13} /> {seat.poison}

--- a/src/board/Board.tsx
+++ b/src/board/Board.tsx
@@ -379,7 +379,7 @@ export function Board({
             className="gy-window__row"
           >
             {graveView.graveyard.map((o) => (
-              <Card key={o.id} obj={o} images={images} />
+              <Card key={o.id} obj={o} images={images} onHover={onHover} />
             ))}
           </XpScroll>
         </XpWindow>

--- a/src/board/boardView.test.ts
+++ b/src/board/boardView.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { toBoardView } from "./boardView";
+import type { GameStateEnvelope } from "../engine/types";
+
+function envelope(): GameStateEnvelope {
+  return {
+    state: {
+      turn_number: 1,
+      phase: "Main1",
+      active_player: 0,
+      waiting_for: { type: "Priority" },
+      players: [{ id: 0, life: 40, hand: [], library: [], graveyard: [1, 2] }],
+      objects: {
+        1: {
+          id: 1,
+          name: "Tapped Attacker",
+          zone: "Graveyard",
+          owner: 0,
+          tapped: true,
+          card_types: { core_types: ["Creature"] },
+        },
+        2: {
+          id: 2,
+          name: "Dead Spell",
+          zone: "Graveyard",
+          owner: 0,
+          tapped: false,
+          card_types: { core_types: ["Instant"] },
+        },
+      },
+      battlefield: [],
+      command_zone: [],
+      stack: [],
+      eliminated_players: [],
+    },
+    derived: {},
+  } as GameStateEnvelope;
+}
+
+describe("toBoardView graveyard", () => {
+  it("projects the graveyard cards in order with the right count", () => {
+    const view = toBoardView(envelope(), [{ name: "You", commander: "" }]);
+    const gy = view.seats[0].graveyard;
+    expect(view.seats[0].graveyardSize).toBe(2);
+    expect(gy.map((o) => o.name)).toEqual(["Tapped Attacker", "Dead Spell"]);
+  });
+
+  it("renders every graveyard card untapped without mutating the source", () => {
+    const env = envelope();
+    const gy = toBoardView(env, [{ name: "You", commander: "" }]).seats[0].graveyard;
+    expect(gy.every((o) => o.tapped === false)).toBe(true);
+    expect(env.state.objects[1].tapped).toBe(true);
+  });
+});

--- a/src/board/boardView.ts
+++ b/src/board/boardView.ts
@@ -14,6 +14,8 @@ export interface SeatView {
   hand: GameObject[];
   librarySize: number;
   graveyardSize: number;
+  /** Cards in this player's graveyard, in the engine's order. */
+  graveyard: GameObject[];
   lands: GameObject[];
   creatures: GameObject[];
   others: GameObject[];
@@ -71,6 +73,10 @@ export function toBoardView(
     );
     const handZone = all.filter((o) => o.zone === "Hand" && o.owner === seat);
     const hand = handZone.filter((o) => !o.face_down);
+    const graveyard = (p.graveyard ?? [])
+      .map((id) => objects[id])
+      .filter((o): o is GameObject => !!o)
+      .map((o) => (o.tapped ? { ...o, tapped: false } : o));
 
     return {
       seat,
@@ -83,6 +89,7 @@ export function toBoardView(
       hand,
       librarySize: p.library?.length ?? 0,
       graveyardSize: p.graveyard?.length ?? 0,
+      graveyard,
       lands,
       creatures,
       others,

--- a/src/components/XpWindow.tsx
+++ b/src/components/XpWindow.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { X } from "lucide-react";
+import { useI18n } from "../i18n/I18nContext";
+
+interface XpWindowProps {
+  title: string;
+  onClose: () => void;
+  children: ReactNode;
+}
+
+/**
+ * A floating Windows XP window: copper title bar, a close button, and a body.
+ * Drag it anywhere by holding the title bar; Escape or the close button shuts it.
+ */
+export function XpWindow({ title, onClose, children }: XpWindowProps) {
+  const { t } = useI18n();
+  const ref = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  function onBarDown(e: React.MouseEvent) {
+    const el = ref.current;
+    if (!el || (e.target as HTMLElement).closest(".xpwin__close")) return;
+    e.preventDefault();
+    const rect = el.getBoundingClientRect();
+    const offX = e.clientX - rect.left;
+    const offY = e.clientY - rect.top;
+    const maxX = Math.max(0, window.innerWidth - rect.width);
+    const maxY = Math.max(0, window.innerHeight - rect.height);
+    function move(ev: MouseEvent) {
+      setPos({
+        x: Math.min(Math.max(0, ev.clientX - offX), maxX),
+        y: Math.min(Math.max(0, ev.clientY - offY), maxY),
+      });
+    }
+    function up() {
+      document.removeEventListener("mousemove", move);
+      document.removeEventListener("mouseup", up);
+      document.body.classList.remove("xpscroll-dragging");
+    }
+    document.addEventListener("mousemove", move);
+    document.addEventListener("mouseup", up);
+    document.body.classList.add("xpscroll-dragging");
+  }
+
+  return createPortal(
+    <div
+      ref={ref}
+      className={`xpwin${pos ? "" : " xpwin--center"}`}
+      style={pos ? { left: pos.x, top: pos.y } : undefined}
+      role="dialog"
+      aria-label={title}
+    >
+      <div className="xpwin__bar" onMouseDown={onBarDown}>
+        <span className="xpwin__title">{title}</span>
+        <button
+          type="button"
+          className="xpwin__close"
+          onClick={onClose}
+          aria-label={t("common.close")}
+        >
+          <X size={13} strokeWidth={3} />
+        </button>
+      </div>
+      <div className="xpwin__body">{children}</div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -324,6 +324,12 @@ export const messages = {
   "board.rowOthers": { pt: "Outros", en: "Other" },
   "board.rowLands": { pt: "Terrenos", en: "Lands" },
   "board.rowHand": { pt: "Mão", en: "Hand" },
+  "board.graveyardOpen": { pt: "Abrir cemitério", en: "Open graveyard" },
+  "board.graveyardOf": {
+    pt: "Cemitério de {name}",
+    en: "{name}'s graveyard",
+  },
+  "common.close": { pt: "Fechar", en: "Close" },
 
   "goldfish.title": { pt: "Consistência (goldfishing)", en: "Consistency (goldfishing)" },
   "goldfish.subtitle": {


### PR DESCRIPTION
## What

Turn each seat's graveyard count into a button (when the graveyard is non-empty). Clicking it opens a floating **Windows XP window** titled with the seat's name, listing that graveyard's cards in a single horizontal row.

- **Draggable** by the title bar (clamped to the viewport), **closable** via the × button or Escape.
- A row wider than the window scrolls with the XP horizontal scrollbar.
- Graveyard cards render **untapped** — the engine keeps a leftover `tapped` flag on cards that died tapped, so it's cleared in the graveyard projection.

New reusable [`XpWindow`](../blob/feat/graveyard-window/src/components/XpWindow.tsx) component (rendered via a portal).

## Verification

- `typecheck`, `lint`, `build`, and the full test suite pass (100 passed / 2 skipped).
- New unit test `boardView.test.ts`: a `tapped: true` graveyard object is projected `tapped: false`, source object not mutated.
- Live match: opened a 7-card graveyard — all cards upright (creatures included) while battlefield lands/tokens render rotated; drag, close, and horizontal scroll confirmed.
- Docs: `domainbook validate` + `check` pass; new feature `domains/board/features/inspect-a-graveyard.md`, changelog `0.4.1`, package.json bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)