### PR TITLE
0.4.2: place scry & surveil cards in a floating window

### DIFF
--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,6 +12,15 @@ depth live there. A purely-internal PR that touches no product or architecture m
 skip its version with a `Skip-Docs: <reason>` trailer instead. There are no
 per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
+## [0.4.2] - 2026-08-21
+
+### Added
+
+- Scry and surveil open a floating window that shows the looked-at cards one at a
+  time, letting you place each — keep on top, or to the bottom (scry) / graveyard
+  (surveil) — instead of the AI resolving them unseen
+  (`domains/simulation/features/place-scry-and-surveil-cards.md`).
+
 ## [0.4.1] - 2026-08-21
 
 ### Added

--- a/domainbook/domains/simulation/features/place-scry-and-surveil-cards.md
+++ b/domainbook/domains/simulation/features/place-scry-and-surveil-cards.md
@@ -1,0 +1,69 @@
+---
+id: place-scry-and-surveil-cards
+name: Place scry and surveil cards
+status: implemented
+---
+
+## Story
+
+As a player piloting my seat
+I want to see the cards I scry or surveil and place each one myself
+So that I decide what stays on top rather than letting the AI resolve it unseen
+
+## Rule: Scrying or surveilling opens a window on the human's seat
+
+When the engine asks the human to resolve a `ScryChoice` or `SurveilChoice`
+`decision request`, a floating window (the same style as the graveyard inspector)
+shows the looked-at cards, top of library first. Other seats resolve it by
+`AI action proposal` as before.
+
+```gherkin
+Example: The window appears when I scry
+  Given a play-mode match where I control seat 0
+  When an effect makes me scry
+  Then a window shows the top cards I am looking at
+  And the opponents' scries are still decided by the AI
+```
+
+## Rule: I place each card one at a time
+
+The window shows one card at a time with two destination buttons. Scry offers
+Keep on top / Put on bottom; surveil offers Keep on top / Put into graveyard.
+After the last card is placed the decision is submitted: the kept cards stay on
+top in the order shown (topmost first), and the rest go to the bottom of the
+library (scry) or to the graveyard (surveil).
+
+```gherkin
+Example: Keeping a scried card on top
+  Given the scry window shows a card
+  When I choose Keep on top
+  Then that card stays on top of my library
+
+Example: Bottoming a scried card
+  Given the scry window shows a card
+  When I choose Put on bottom
+  Then that card moves to the bottom of my library
+
+Example: Binning a surveilled card
+  Given the surveil window shows a card
+  When I choose Put into graveyard
+  Then that card goes to my graveyard
+```
+
+## Rule: The placement can be handed to the AI
+
+Closing the window (its close button or Escape) or choosing let the AI decide
+hands the whole scry/surveil back to the engine's own AI, so the decision is
+never stuck.
+
+```gherkin
+Example: Letting the AI decide
+  Given the scry or surveil window is shown
+  When I choose let the AI decide
+  Then the engine's AI resolves the placement
+```
+
+## Open Questions
+
+- None. Kept cards are submitted topmost-first, and the engine keeps that order —
+  confirmed against a live Scry 2 (both cards land on top in the submitted order).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",

--- a/src/App.css
+++ b/src/App.css
@@ -1255,6 +1255,38 @@ th {
   font-size: 0.7rem;
 }
 
+/* ── Scry / Surveil window ─────────────────────────────────────── */
+.scry-window {
+  width: min(84vw, 260px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.7rem;
+}
+.scry-window__card {
+  width: 150px;
+  height: 209px;
+}
+.scry-window__card .card__img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.scry-window__card.card--text {
+  max-width: none;
+  padding: 0.5rem;
+  white-space: normal;
+  text-align: center;
+  justify-content: center;
+  font-size: 0.78rem;
+}
+.scry-window__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.4rem;
+}
+
 /* ── XP dropdown (select) ──────────────────────────────────────── */
 .xp-select {
   position: relative;

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -287,6 +287,14 @@ export const messages = {
   "discard.progress": { pt: "Selecionadas: {n} / {max}", en: "Selected: {n} / {max}" },
   "discard.confirm": { pt: "Descartar", en: "Discard" },
 
+  "scry.title": { pt: "Vidência", en: "Scry" },
+  "surveil.title": { pt: "Vigília", en: "Surveil" },
+  "scry.progress": { pt: "Carta {n} de {max}", en: "Card {n} of {max}" },
+  "scry.keepTop": { pt: "Manter no topo", en: "Keep on top" },
+  "scry.toBottom": { pt: "Enviar ao fundo", en: "Put on bottom" },
+  "surveil.toGrave": { pt: "Enviar ao cemitério", en: "Put into graveyard" },
+  "scry.letAi": { pt: "IA decide", en: "Let the AI decide" },
+
   "select.noResults": { pt: "Nenhum resultado", en: "No matches" },
 
   "sidebar.title": { pt: "Pilha e registro", en: "Stack & log" },

--- a/src/match/RunView.tsx
+++ b/src/match/RunView.tsx
@@ -28,6 +28,8 @@ import {
   discardCardsAction,
   type DiscardPrompt,
 } from "../sim/decisions/discard";
+import { scryAction, type ScryPrompt } from "../sim/decisions/scry";
+import { XpWindow } from "../components/XpWindow";
 import {
   declareAttackersAction,
   type AttackersPrompt,
@@ -184,6 +186,11 @@ interface DiscardTurn {
   resolve: (choice: HumanChoice) => void;
 }
 
+interface ScryTurn {
+  prompt: ScryPrompt;
+  resolve: (choice: HumanChoice) => void;
+}
+
 /** Runs a configured series of matches and renders the live board + results. */
 export function RunView({
   config,
@@ -225,6 +232,7 @@ export function RunView({
   const [bottomPick, setBottomPick] = useState<Set<number>>(new Set());
   const [discardTurn, setDiscardTurn] = useState<DiscardTurn | null>(null);
   const [discardPick, setDiscardPick] = useState<Set<number>>(new Set());
+  const [scryTurn, setScryTurn] = useState<ScryTurn | null>(null);
   const [passingTurn, setPassingTurn] = useState(false);
   const [logEntries, setLogEntries] = useState<LoggedEntry[]>([]);
   // On mobile the log is a full-screen drawer, so it always starts closed and
@@ -450,6 +458,20 @@ export function RunView({
                   },
                 });
               }),
+            requestHumanScry: (_env, prompt) =>
+              new Promise<HumanChoice>((resolve) => {
+                if (cancelled) {
+                  resolve({ ai: true });
+                  return;
+                }
+                setScryTurn({
+                  prompt,
+                  resolve: (choice) => {
+                    setScryTurn(null);
+                    resolve(choice);
+                  },
+                });
+              }),
           },
         );
         runnerRef.current = runner;
@@ -574,10 +596,13 @@ export function RunView({
 
   // Any other decision that needs the human pauses the pass-turn flow.
   useEffect(() => {
-    if (passingTurn && (targeting || manaTurn || blockingTurn || creatureTypeTurn)) {
+    if (
+      passingTurn &&
+      (targeting || manaTurn || blockingTurn || creatureTypeTurn || scryTurn)
+    ) {
       setPassingTurn(false);
     }
-  }, [passingTurn, targeting, manaTurn, blockingTurn, creatureTypeTurn]);
+  }, [passingTurn, targeting, manaTurn, blockingTurn, creatureTypeTurn, scryTurn]);
 
   // Map draggable hand cards to their play actions for the current window.
   const play: PlayInteraction | undefined = useMemo(() => {
@@ -1301,6 +1326,17 @@ export function RunView({
         />
       )}
 
+      {scryTurn && (
+        <ScryWindow
+          prompt={scryTurn.prompt}
+          images={images}
+          onSubmit={(keptOnTop) =>
+            scryTurn.resolve({ action: scryAction(keptOnTop) })
+          }
+          onLetAi={() => scryTurn.resolve({ ai: true })}
+        />
+      )}
+
       {phase === "done" && (
         <RunReport
           stats={stats}
@@ -1578,6 +1614,74 @@ function DiscardModal({
 
       {overlay}
     </div>
+  );
+}
+
+/** Scry/Surveil floating window: place each looked-at card, top of library first. */
+function ScryWindow({
+  prompt,
+  images,
+  onSubmit,
+  onLetAi,
+}: {
+  prompt: ScryPrompt;
+  images: Record<string, string>;
+  onSubmit: (keptOnTop: number[]) => void;
+  onLetAi: () => void;
+}) {
+  const { t } = useI18n();
+  const [index, setIndex] = useState(0);
+  const [kept, setKept] = useState<number[]>([]);
+
+  const card = prompt.cards[index];
+  const url = card?.name ? images[card.name.toLowerCase()] : undefined;
+
+  const advance = (keepOnTop: boolean) => {
+    const nextKept = keepOnTop ? [...kept, card.id] : kept;
+    const nextIndex = index + 1;
+    if (nextIndex >= prompt.cards.length) {
+      onSubmit(nextKept);
+    } else {
+      setKept(nextKept);
+      setIndex(nextIndex);
+    }
+  };
+
+  const awayLabel =
+    prompt.mode === "scry" ? t("scry.toBottom") : t("surveil.toGrave");
+
+  return (
+    <XpWindow
+      title={prompt.mode === "scry" ? t("scry.title") : t("surveil.title")}
+      onClose={onLetAi}
+    >
+      <div className="scry-window">
+        <p className="hint">
+          {t("scry.progress", { n: index + 1, max: prompt.cards.length })}
+        </p>
+        {card &&
+          (url ? (
+            <div className="card scry-window__card">
+              <img className="card__img" src={url} alt={card.name} />
+            </div>
+          ) : (
+            <div className="card card--text scry-window__card">
+              <span className="card__name">{card.name || "?"}</span>
+            </div>
+          ))}
+        <div className="scry-window__actions">
+          <button className="btn" onClick={() => advance(true)}>
+            {t("scry.keepTop")}
+          </button>
+          <button className="btn" onClick={() => advance(false)}>
+            {awayLabel}
+          </button>
+          <button className="btn btn--ghost" onClick={onLetAi}>
+            {t("scry.letAi")}
+          </button>
+        </div>
+      </div>
+    </XpWindow>
   );
 }
 

--- a/src/sim/decisions/scry.test.ts
+++ b/src/sim/decisions/scry.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { parseScryPrompt, scryAction } from "./scry";
+import type { GameState, WaitingFor } from "../../engine/types";
+
+function stateWithLibrary(): GameState {
+  const objects: GameState["objects"] = {};
+  for (const id of [13, 67, 81]) {
+    objects[id] = { id, zone: "Library", name: `Card ${id}` };
+  }
+  return {
+    turn_number: 3,
+    phase: "Upkeep",
+    active_player: 0,
+    waiting_for: { type: "ScryChoice" },
+    players: [
+      { id: 0, life: 40, hand: [], library: [13, 67, 81], graveyard: [] },
+      { id: 1, life: 40, hand: [], library: [], graveyard: [] },
+    ],
+    objects,
+    battlefield: [],
+    command_zone: [],
+    stack: [],
+    eliminated_players: [],
+  } as unknown as GameState;
+}
+
+// Shapes captured from the vendored phase-rs WASM by headless introspection.
+const SCRY: WaitingFor = { type: "ScryChoice", data: { cards: [13, 67], player: 0 } };
+const SURVEIL: WaitingFor = { type: "SurveilChoice", data: { cards: [13], player: 0 } };
+
+describe("parseScryPrompt", () => {
+  it("reads scry cards, top of library first", () => {
+    const prompt = parseScryPrompt(SCRY, stateWithLibrary(), 0);
+    expect(prompt).not.toBeNull();
+    expect(prompt!.mode).toBe("scry");
+    expect(prompt!.player).toBe(0);
+    expect(prompt!.cards.map((c) => c.id)).toEqual([13, 67]);
+    expect(prompt!.cards[0].name).toBe("Card 13");
+  });
+
+  it("tags a SurveilChoice as surveil", () => {
+    expect(parseScryPrompt(SURVEIL, stateWithLibrary(), 0)!.mode).toBe("surveil");
+  });
+
+  it("returns null when the decision targets another seat", () => {
+    expect(parseScryPrompt(SCRY, stateWithLibrary(), 1)).toBeNull();
+  });
+
+  it("returns null for an unrelated waiting_for", () => {
+    expect(parseScryPrompt({ type: "DiscardChoice" }, stateWithLibrary(), 0)).toBeNull();
+  });
+
+  it("returns null when no cards are looked at", () => {
+    const wf: WaitingFor = { type: "ScryChoice", data: { cards: [], player: 0 } };
+    expect(parseScryPrompt(wf, stateWithLibrary(), 0)).toBeNull();
+  });
+});
+
+describe("scryAction", () => {
+  it("submits the kept ids as a SelectCards action, topmost first", () => {
+    expect(scryAction([67, 13])).toEqual({
+      type: "SelectCards",
+      data: { cards: [67, 13] },
+    });
+  });
+
+  it("keeps nothing on top with an empty selection", () => {
+    expect(scryAction([])).toEqual({ type: "SelectCards", data: { cards: [] } });
+  });
+});

--- a/src/sim/decisions/scry.ts
+++ b/src/sim/decisions/scry.ts
@@ -1,0 +1,60 @@
+// Scry and Surveil. When the human scries or surveils, the engine surfaces a
+// `ScryChoice` / `SurveilChoice` waiting_for whose `data` carries the acting
+// `player` and `cards` — the ids looked at, ordered top-of-library first. The
+// seat answers by submitting `SelectCards` with the ids to KEEP ON TOP (in the
+// order they should sit, topmost first). The engine sends the rest to the
+// bottom of the library (scry) or to the graveyard (surveil). Shapes captured
+// from the vendored WASM by headless introspection.
+
+import type { GameState, WaitingFor } from "../../engine/types";
+
+/** Scry sends the unkept cards to the library bottom; surveil to the graveyard. */
+export type ScryMode = "scry" | "surveil";
+
+/** One card being looked at during a scry/surveil. */
+export interface ScryCard {
+  id: number;
+  name: string;
+}
+
+export interface ScryPrompt {
+  player: number;
+  mode: ScryMode;
+  /** The looked-at cards, top of library first. */
+  cards: ScryCard[];
+}
+
+const MODE_BY_TYPE: Record<string, ScryMode> = {
+  ScryChoice: "scry",
+  SurveilChoice: "surveil",
+};
+
+/**
+ * Read a scry/surveil decision for `seat`, or null if this waiting_for is not
+ * one aimed at that seat (or reveals no cards).
+ */
+export function parseScryPrompt(
+  wf: WaitingFor | undefined,
+  state: GameState,
+  seat: number,
+): ScryPrompt | null {
+  if (!wf) return null;
+  const mode = MODE_BY_TYPE[wf.type];
+  if (!mode) return null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const d: any = wf.data ?? {};
+  if (d.player !== seat) return null;
+
+  const ids: number[] = Array.isArray(d.cards) ? d.cards : [];
+  if (ids.length === 0) return null;
+  const cards = ids.map((id) => ({ id, name: state.objects?.[id]?.name ?? "" }));
+  return { player: seat, mode, cards };
+}
+
+/** Keep `keptOnTop` on top of the library, topmost first; the rest go away. */
+export function scryAction(keptOnTop: number[]): {
+  type: string;
+  data: { cards: number[] };
+} {
+  return { type: "SelectCards", data: { cards: keptOnTop } };
+}

--- a/src/sim/driver.ts
+++ b/src/sim/driver.ts
@@ -25,6 +25,7 @@ import {
   type MulliganPrompt,
 } from "./decisions/mulligan";
 import { parseDiscardPrompt, type DiscardPrompt } from "./decisions/discard";
+import { parseScryPrompt, type ScryPrompt } from "./decisions/scry";
 
 export interface MatchResult {
   matchIndex: number;
@@ -203,6 +204,11 @@ export interface DriverCallbacks {
   requestHumanDiscard?: (
     env: GameStateEnvelope,
     prompt: DiscardPrompt,
+  ) => Promise<HumanChoice>;
+  /** Called when the human scries or surveils and must place the looked-at cards. */
+  requestHumanScry?: (
+    env: GameStateEnvelope,
+    prompt: ScryPrompt,
   ) => Promise<HumanChoice>;
 }
 
@@ -417,6 +423,10 @@ export class MatchRunner {
         humanNonPriority && cb.requestHumanDiscard
           ? parseDiscardPrompt(wf, env.state, humanSeat)
           : null;
+      const humanScry =
+        humanNonPriority && cb.requestHumanScry
+          ? parseScryPrompt(wf, env.state, humanSeat)
+          : null;
 
       // Run the human's choice: play their action, or hand this decision to the AI.
       const applyChoice = async (choice: HumanChoice): Promise<void> => {
@@ -484,6 +494,13 @@ export class MatchRunner {
         await applyChoice(choice);
       } else if (humanDiscard) {
         const choice = await cb.requestHumanDiscard!(env, humanDiscard);
+        if (this.aborted) {
+          stopped = true;
+          break;
+        }
+        await applyChoice(choice);
+      } else if (humanScry) {
+        const choice = await cb.requestHumanScry!(env, humanScry);
         if (this.aborted) {
           stopped = true;
           break;


### PR DESCRIPTION
Closes #25

## Summary

Manual play never surfaced scries or surveils — the engine's `ScryChoice` / `SurveilChoice` fell through to the AI heuristic and the cards were never shown. This adds a per-seat floating window (the same `XpWindow` as the graveyard inspector) that reveals the looked-at cards one at a time and lets the player place each:

- **Scry:** Keep on top / Put on bottom
- **Surveil:** Keep on top / Put into graveyard

Closing the window (X / Escape) or "Let the AI decide" hands the whole decision back to the engine, so the player is never stuck.

## Engine shapes (captured, not guessed)

The vendored engine is opaque WASM, so the decision shapes were learned by headless introspection and verified against the live engine:

- `ScryChoice` / `SurveilChoice` → `data.cards` are the top cards (library index 0 = top).
- Submit `SelectCards` with the ids to **keep on top**, topmost first (submitted array order becomes the new top order — confirmed against a live Scry 2).
- Unselected cards go to the **bottom** (scry) vs **graveyard** (surveil); the engine picks which by decision type, so one action serves both.

## Changes

- New decision module `src/sim/decisions/scry.ts` (+ tests) — parses the two `waiting_for` kinds and builds the `SelectCards` action.
- `src/sim/driver.ts` — `requestHumanScry` callback + routing, mirroring the discard path.
- `src/match/RunView.tsx` — `ScryWindow` UI and wiring; pauses the pass-turn flow like the other decisions.
- `src/i18n/messages.ts` — pt/en strings.
- `src/App.css` — `.scry-window` styling.
- Domainbook feature doc + changelog + version bump to 0.4.2.

## Verification

- Unit tests for the parser/action; full suite green (107 passed).
- Live-engine integration check using the real modules through the same submit path the driver uses (driver-gate catches the `ScryChoice`, parser reads it, keep-on-top keeps the card on top).
- `tsc`, `eslint`, production `vite build`, and `domainbook validate` + `check` all pass.
- Verified visually in the browser: playing Temple of Enlightenment fires Scry 1 and the window shows the revealed card with the two placement buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)