### PR TITLE
0.4.3: never offer defender creatures as attackers

### DIFF
--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -18,7 +18,8 @@ per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
 - Creatures with defender (walls, tokens, and printed cards alike) are no longer
   offered as attackers when declaring attackers — the vendored engine lists them
-  regardless of the keyword (`domains/simulation/features/step-through-a-turn.md`).
+  regardless of the keyword (`domains/simulation/features/step-through-a-turn.md`,
+  `TDR-0003`).
 
 ## [0.4.2] - 2026-08-21
 

--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,6 +12,14 @@ depth live there. A purely-internal PR that touches no product or architecture m
 skip its version with a `Skip-Docs: <reason>` trailer instead. There are no
 per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
+## [0.4.3] - 2026-08-21
+
+### Fixed
+
+- Creatures with defender (walls, tokens, and printed cards alike) are no longer
+  offered as attackers when declaring attackers — the vendored engine lists them
+  regardless of the keyword (`domains/simulation/features/step-through-a-turn.md`).
+
 ## [0.4.2] - 2026-08-21
 
 ### Added

--- a/domainbook/debt/0003-creatures-with-defender-granted-the-ability-to-attack-cannot-be-declared.md
+++ b/domainbook/debt/0003-creatures-with-defender-granted-the-ability-to-attack-cannot-be-declared.md
@@ -1,0 +1,43 @@
+---
+status: open
+date: 2026-08-21
+severity: low
+quadrant: deliberate-prudent
+decisions: [ADR-0006]
+---
+
+# Creatures with defender granted the ability to attack cannot be declared
+
+## Debt
+
+The engine lists every creature with the Defender keyword in a `DeclareAttackers`
+decision's `valid_attacker_ids`, regardless of the keyword and regardless of any
+effect — so it cannot be trusted to say when a defender may attack (`TDR-0001`, the
+churning alpha ABI, is the wider version of this). We work around it by dropping
+every creature whose effective keywords include `Defender` when building the
+declare-attackers prompt (`src/sim/decisions/attackers.ts`,
+`domains/simulation/features/step-through-a-turn.md`). That is correct for the
+overwhelmingly common case, but it also removes the rare *legal* one: a defender
+granted "can attack as though it didn't have defender" (Assault Formation,
+Wakestone Gargoyle, High Alert, …) — the grant does not clear the keyword, so our
+filter still hides it. This is the one combat scenario the app does not cover.
+
+## Impact
+
+Low. It only bites a defenders-matter deck that has actually activated such a grant
+(the bundled Abzan Armor deck can), and even then only costs the ability to swing
+with a wall that turn — the board state stays correct. No wrong life totals, no
+silent mis-scoring. The far more common bug — defenders attacking when they never
+should — is what the filter fixes.
+
+## Remedy
+
+Prefer an upstream fix: the engine should exclude defenders from
+`valid_attacker_ids` unless a grant is active (filed as
+[phase-rs/phase#7587](https://github.com/phase-rs/phase/issues/7587)). We expect a
+future engine version to eventually honor the keyword; when it does, delete the
+client-side filter and this debt in the same pass — the prompt can then trust
+`valid_attacker_ids` directly. Until then, a grant-aware filter is possible locally
+(scan `transient_continuous_effects` for an active `CanAttackWithDefender` on the
+object), but it adds real complexity for a niche case and is not worth carrying
+ahead of the upstream fix.

--- a/domainbook/domains/simulation/features/step-through-a-turn.md
+++ b/domainbook/domains/simulation/features/step-through-a-turn.md
@@ -66,6 +66,16 @@ Example: Choosing which cards to discard
   And you pick exactly the required number to discard, or let the AI choose
 ```
 
+## Rule: Creatures with defender are never offered as attackers
+
+```gherkin
+Example: A defender wall is not declarable as an attacker
+  Given it is your combat and you control a creature with defender
+  When the engine asks you to declare attackers
+  Then that creature is not offered as an attacker
+  And only creatures without defender can be declared
+```
+
 ## Rule: You put cards into play by dragging or tapping from hand, or clicking the commander in its zone
 
 ```gherkin

--- a/domainbook/domains/simulation/features/step-through-a-turn.md
+++ b/domainbook/domains/simulation/features/step-through-a-turn.md
@@ -68,6 +68,10 @@ Example: Choosing which cards to discard
 
 ## Rule: Creatures with defender are never offered as attackers
 
+The engine lists creatures with defender as legal attackers regardless of the
+keyword, so we drop them when building the prompt. This also hides the rare case
+of a defender granted the ability to attack (`TDR-0003`).
+
 ```gherkin
 Example: A defender wall is not declarable as an attacker
   Given it is your combat and you control a creature with defender

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -51,6 +51,8 @@ export interface GameObject {
   power?: number | null;
   toughness?: number | null;
   card_types?: CardTypes;
+  /** Effective keywords after continuous effects (e.g. "Defender", "Flying"). */
+  keywords?: string[];
   is_commander?: boolean;
   is_token?: boolean;
   face_down?: boolean;

--- a/src/sim/decisions/attackers.test.ts
+++ b/src/sim/decisions/attackers.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { parseAttackersPrompt, declareAttackersAction } from "./attackers";
-import type { WaitingFor } from "../../engine/types";
+import type { GameObject, WaitingFor } from "../../engine/types";
 
 // A real DeclareAttackers waiting_for captured from the phase-rs WASM build.
 const REAL: WaitingFor = {
@@ -22,6 +22,28 @@ describe("parseAttackersPrompt", () => {
     expect(p.player).toBe(0);
     expect(p.attackers.map((a) => a.attackerId)).toEqual([53, 81]);
     expect(p.attackers[0].targets).toEqual([{ type: "Player", data: 1 }]);
+  });
+
+  it("drops creatures with the Defender keyword the engine wrongly offers", () => {
+    const objects: Record<string, GameObject> = {
+      "53": { id: 53, zone: "Battlefield", keywords: ["Defender"] },
+      "81": { id: 81, zone: "Battlefield", keywords: ["Flying"] },
+    };
+    const p = parseAttackersPrompt(REAL, objects)!;
+    expect(p.attackers.map((a) => a.attackerId)).toEqual([81]);
+  });
+
+  it("returns null when every offered attacker has Defender", () => {
+    const objects: Record<string, GameObject> = {
+      "53": { id: 53, zone: "Battlefield", keywords: ["Defender"] },
+      "81": { id: 81, zone: "Battlefield", keywords: ["Defender", "Reach"] },
+    };
+    expect(parseAttackersPrompt(REAL, objects)).toBeNull();
+  });
+
+  it("keeps all attackers when object data is unavailable", () => {
+    const p = parseAttackersPrompt(REAL)!;
+    expect(p.attackers.map((a) => a.attackerId)).toEqual([53, 81]);
   });
 
   it("returns null for non-attack waiting_for and empty attacker lists", () => {

--- a/src/sim/decisions/attackers.ts
+++ b/src/sim/decisions/attackers.ts
@@ -3,9 +3,17 @@
 // (a player, planeswalker, or battle). We echo those target refs straight back
 // in the submitted action, so we never have to construct them ourselves.
 
-import type { WaitingFor } from "../../engine/types";
+import type { GameObject, WaitingFor } from "../../engine/types";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
+
+// The vendored engine lists creatures with Defender in `valid_attacker_ids`
+// regardless of the keyword, so we drop them here — a Defender creature is
+// never a legal attacker. (A temporary "can attack as though it had no
+// defender" grant does not clear the keyword, so those stay filtered too.)
+function hasDefender(o: GameObject | undefined): boolean {
+  return Array.isArray(o?.keywords) && o.keywords.includes("Defender");
+}
 
 /** An attack target ref as the engine phrases it, e.g. `{type:"Player",data:1}`. */
 export type AttackTargetRef = any;
@@ -24,6 +32,7 @@ export interface AttackersPrompt {
 /** Read a DeclareAttackers waiting_for, or null if it isn't one / has no attackers. */
 export function parseAttackersPrompt(
   wf: WaitingFor | undefined,
+  objects?: Record<string, GameObject>,
 ): AttackersPrompt | null {
   if (!wf || wf.type !== "DeclareAttackers") return null;
   const d = wf.data ?? {};
@@ -32,6 +41,7 @@ export function parseAttackersPrompt(
   const byAttacker = d.valid_attack_targets_by_attacker ?? {};
   const attackers: AttackerOption[] = ids
     .filter((id): id is number => typeof id === "number")
+    .filter((id) => !hasDefender(objects?.[id]))
     .map((id) => ({
       attackerId: id,
       targets: Array.isArray(byAttacker[id]) ? byAttacker[id] : [],

--- a/src/sim/driver.ts
+++ b/src/sim/driver.ts
@@ -403,7 +403,7 @@ export class MatchRunner {
         humanNonPriority && cb.requestHumanTargets ? parseTargetPrompt(wf) : null;
       const humanAttackers =
         humanNonPriority && cb.requestHumanAttackers
-          ? parseAttackersPrompt(wf)
+          ? parseAttackersPrompt(wf, env.state.objects)
           : null;
       const humanBlockers =
         humanNonPriority && cb.requestHumanBlockers


### PR DESCRIPTION
## What

Creatures with the **Defender** keyword are no longer offered as attackers when declaring attackers — for tokens and printed cards alike.

Closes #26.

## Root cause

The vendored phase-rs engine lists creatures with Defender in `waiting_for.data.valid_attacker_ids` regardless of the keyword. Verified headless against the **Abzan Armor** deck: `Jaddi Offshoot`, `Wall of Blossoms`, `Sylvan Caryatid`, and wall tokens were all offered as attackers with **no** attack-granting effect on the battlefield. The creatures' effective `keywords` still contain `"Defender"` in those states, so this is the engine's legal-attacker computation, not our parsing.

Confirmed still present in the latest engine (**v0.59.0**), so an engine bump doesn't resolve it. Filed upstream: https://github.com/phase-rs/phase/issues/7587.

## Fix

Since the WASM can't be patched here, `parseAttackersPrompt` now takes the objects map and drops any offered attacker whose effective `keywords` include `Defender`, so a defender is never declarable. Wired through `driver.ts` (`env.state.objects`).

Verified against 30 live attack windows from the Abzan deck: 0 defenders leaked through, non-defender attackers preserved on mixed boards, all-defender turns collapse to "no attackers."

## Deliberate tradeoff

The filter drops **all** effective-defenders. The deck's **Assault Formation** / **Wakestone Gargoyle** can grant "defenders may attack this turn"; that grant doesn't clear the keyword, so a granted wall also won't be offered. This matches the issue's stated rule ("a creature with defender is never a legal attacker"), and the engine wasn't gating that grant correctly anyway. A grant-aware version (scanning `transient_continuous_effects`) is possible as a follow-up if desired.

## Checks

- `npx vitest run` — 110 passed (added 3 cases covering the defender filter)
- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — clean
- `npx domainbook validate` — valid; changelog + `step-through-a-turn.md` updated; version bumped to 0.4.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)