### PR TITLE
0.4.4: aim each attacker at its own defender, with per-opponent colors

### DIFF
--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,6 +12,16 @@ depth live there. A purely-internal PR that touches no product or architecture m
 skip its version with a `Skip-Docs: <reason>` trailer instead. There are no
 per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
+## [0.4.4] - 2026-08-21
+
+### Added
+
+- Declaring attackers in a pod now aims each attacker at its own opponent: focus a
+  creature and click a defender to aim it, see the target on each attacker and in a
+  summary, and confirm a split attack before passing priority
+  (`domains/board/features/aim-attackers-at-defenders.md`,
+  `domains/simulation/features/step-through-a-turn.md`).
+
 ## [0.4.3] - 2026-08-21
 
 ### Fixed

--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -18,8 +18,9 @@ per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
 - Declaring attackers in a pod now aims each attacker at its own opponent: focus a
   creature and click a defender to aim it, see the target on each attacker and in a
-  summary, and confirm a split attack before passing priority
-  (`domains/board/features/aim-attackers-at-defenders.md`,
+  summary, and confirm a split attack before passing priority. Each opponent has an
+  identity color on its board name, badge, and summary row so same-named seats stay
+  distinct (`domains/board/features/aim-attackers-at-defenders.md`,
   `domains/simulation/features/step-through-a-turn.md`).
 
 ## [0.4.3] - 2026-08-21

--- a/domainbook/domains/board/features/aim-attackers-at-defenders.md
+++ b/domainbook/domains/board/features/aim-attackers-at-defenders.md
@@ -20,6 +20,20 @@ Example: Focusing an attacker to aim it
   And clicking the focused attacker again removes it from combat
 ```
 
+## Rule: Each opponent has an identity color, so same-named seats stay distinct
+
+Opponents in a pod are often the same deck and commander, so their names read
+identically. Each seat carries a fixed identity color on its board name, and the
+attacker's target badge and the summary reuse that same color — so "who is this
+attacker aimed at" is answered by color, not by a name that repeats.
+
+```gherkin
+Example: Telling three identically-named opponents apart
+  Given a pod where every opponent shows the same deck name
+  Then each opponent's name is drawn in its own identity color
+  And an attacker aimed at one shows that opponent's color on its badge and summary row
+```
+
 ## Rule: Each declared attacker shows the opponent it is aimed at
 
 ```gherkin

--- a/domainbook/domains/board/features/aim-attackers-at-defenders.md
+++ b/domainbook/domains/board/features/aim-attackers-at-defenders.md
@@ -1,0 +1,61 @@
+---
+id: aim-attackers-at-defenders
+name: Aim attackers at defenders
+status: implemented
+---
+
+## Story
+
+As a player declaring attackers in a pod
+I want to see, per attacker, which opponent it is aimed at before I commit
+So that I can split my attack across players without guessing who gets hit
+
+## Rule: Declared attackers are highlighted, and the focused one stands out
+
+```gherkin
+Example: Focusing an attacker to aim it
+  Given it is your combat with more than one opponent to attack
+  When you click one of your highlighted creatures
+  Then it is declared as an attacker and focused for aiming
+  And clicking the focused attacker again removes it from combat
+```
+
+## Rule: Each declared attacker shows the opponent it is aimed at
+
+```gherkin
+Example: A target badge on the attacker
+  Given you have declared an attacker in a pod
+  When you look at that creature on the board
+  Then a badge on the card names the opponent it will attack
+
+Example: Re-aiming the focused attacker
+  Given a focused attacker and more than one opponent to attack
+  When you click a highlighted opponent
+  Then only the focused attacker is re-aimed at that opponent
+  And the other attackers keep their own targets
+```
+
+## Rule: A summary lists every attacker and its defender before you confirm
+
+```gherkin
+Example: Reviewing the assignments
+  Given you have declared attackers across two opponents
+  When you look at the attack controls
+  Then each attacker is listed with the opponent it is aimed at
+  And the focused attacker's row is marked
+  And you can confirm once the assignments read as you intend
+```
+
+## Rule: A single-defender game shows no aiming, only the plain toggle
+
+```gherkin
+Example: A duel keeps the simple flow
+  Given it is your combat with a single opponent
+  Then declared attackers carry no target badge or summary
+  And clicking a creature just toggles it as an attacker
+```
+
+## Open Questions
+
+- Whether attackers aimed at a planeswalker or battle (not a player) should carry
+  their own badge, once those become attackable targets in play mode.

--- a/domainbook/domains/simulation/features/step-through-a-turn.md
+++ b/domainbook/domains/simulation/features/step-through-a-turn.md
@@ -80,27 +80,18 @@ Example: A defender wall is not declarable as an attacker
   And only creatures without defender can be declared
 ```
 
-## Rule: Each attacker is aimed independently, so a pod attack can be split across opponents
+## Rule: The engine gives each attacker its own legal targets, so an attack can be split
 
-The engine lists, per attacker, the legal things it may attack, and we echo the
-chosen ref straight back. A declared attacker defaults to its first legal target;
-when more than one opponent could be attacked, you focus one attacker and pick its
-defender, so different attackers can be sent at different players. With a single
-possible defender there is nothing to aim and declaring is a plain toggle.
+The engine reports the legal targets per attacker, not one shared list, and we echo
+the chosen ref straight back per attacker — so different attackers can be declared
+against different opponents in a pod. Choosing and reviewing those targets is the
+board's job (`domains/board/features/aim-attackers-at-defenders.md`).
 
 ```gherkin
-Example: Splitting attackers between two opponents in a pod
+Example: Two attackers declared at two different opponents
   Given it is your combat with two opponents you could attack
-  And you have declared two attackers
-  When you focus the first attacker and choose one opponent
-  And you focus the second attacker and choose the other opponent
-  Then each attacker is aimed at the opponent you chose for it
-  And confirming declares them against their separate defenders
-
-Example: A duel needs no aiming
-  Given it is your combat with a single opponent to attack
-  When you declare an attacker
-  Then it is aimed at that opponent with no further choice
+  When you declare two attackers, one aimed at each opponent
+  Then the submitted declaration pairs each attacker with its own defender
 ```
 
 ## Rule: You put cards into play by dragging or tapping from hand, or clicking the commander in its zone

--- a/domainbook/domains/simulation/features/step-through-a-turn.md
+++ b/domainbook/domains/simulation/features/step-through-a-turn.md
@@ -80,6 +80,29 @@ Example: A defender wall is not declarable as an attacker
   And only creatures without defender can be declared
 ```
 
+## Rule: Each attacker is aimed independently, so a pod attack can be split across opponents
+
+The engine lists, per attacker, the legal things it may attack, and we echo the
+chosen ref straight back. A declared attacker defaults to its first legal target;
+when more than one opponent could be attacked, you focus one attacker and pick its
+defender, so different attackers can be sent at different players. With a single
+possible defender there is nothing to aim and declaring is a plain toggle.
+
+```gherkin
+Example: Splitting attackers between two opponents in a pod
+  Given it is your combat with two opponents you could attack
+  And you have declared two attackers
+  When you focus the first attacker and choose one opponent
+  And you focus the second attacker and choose the other opponent
+  Then each attacker is aimed at the opponent you chose for it
+  And confirming declares them against their separate defenders
+
+Example: A duel needs no aiming
+  Given it is your combat with a single opponent to attack
+  When you declare an attacker
+  Then it is aimed at that opponent with no further choice
+```
+
 ## Rule: You put cards into play by dragging or tapping from hand, or clicking the commander in its zone
 
 ```gherkin

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",

--- a/src/App.css
+++ b/src/App.css
@@ -1033,12 +1033,72 @@ th {
   cursor: pointer;
   box-shadow: 0 0 0 3px var(--good);
 }
+.card--attacker-selected {
+  box-shadow: 0 0 0 3px var(--accent);
+}
+.card__attack-target {
+  position: absolute;
+  top: 1px;
+  left: 1px;
+  max-width: calc(100% - 4px);
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  font-size: 0.58rem;
+  font-weight: 700;
+  line-height: 1.3;
+  color: var(--text);
+  background: color-mix(in srgb, var(--good) 82%, black);
+  border-radius: 3px;
+  padding: 0 3px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .seat--defender {
   cursor: pointer;
   box-shadow: 0 0 0 2px var(--warn) inset;
 }
 .seat--defender:hover {
   box-shadow: 0 0 0 3px var(--warn) inset;
+}
+.attack-summary {
+  list-style: none;
+  margin: 0.25rem 0 0.5rem;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+.attack-summary__row {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.72rem;
+  padding: 0.1rem 0.3rem;
+  border-radius: 4px;
+  border: 1px solid transparent;
+}
+.attack-summary__row--sel {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+}
+.attack-summary__from {
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.attack-summary__arrow {
+  color: var(--muted);
+  flex-shrink: 0;
+}
+.attack-summary__to {
+  color: var(--good);
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* ── Combat: declare blockers ──────────────────────────────────── */

--- a/src/board/Board.tsx
+++ b/src/board/Board.tsx
@@ -18,6 +18,7 @@ import {
 } from "lucide-react";
 import type { GameObject } from "../engine/types";
 import type { BoardView, SeatView } from "./boardView";
+import { seatColor } from "./seatColor";
 import { CardPreview, type Preview } from "./CardPreview";
 import { useI18n } from "../i18n/I18nContext";
 import { categoryLabel } from "../i18n/messages";
@@ -152,19 +153,19 @@ function attackProps(
   attacking?: boolean;
   attackerSelected?: boolean;
   attackTarget?: string;
+  attackTargetColor?: string;
   onToggleAttack?: () => void;
 } {
   if (!attack || !attack.attackerIds.has(o.id)) return {};
   const declared = attack.declaredIds.has(o.id);
   const seat = attack.assignments.get(o.id);
+  const aimed = attack.multiDefender && declared && seat !== undefined;
   return {
     attacker: true,
     attacking: declared,
     attackerSelected: attack.multiDefender && attack.selectedAttackerId === o.id,
-    attackTarget:
-      attack.multiDefender && declared && seat !== undefined
-        ? attack.defenderNames.get(seat)
-        : undefined,
+    attackTarget: aimed ? attack.defenderNames.get(seat!) : undefined,
+    attackTargetColor: aimed ? seatColor(seat!) : undefined,
     onToggleAttack: () => attack.onAttackerClick(o.id),
   };
 }
@@ -477,7 +478,10 @@ function Seat({
     <div className={cls} onClick={seatClick} data-seat={seat.seat}>
       <div className="seat__head">
         <div className="seat__id">
-          <span className="seat__name">
+          <span
+            className="seat__name"
+            style={you ? undefined : { color: seatColor(seat.seat) }}
+          >
             {name}
             {you && <span className="seat__tag">{t("board.you")}</span>}
           </span>
@@ -736,6 +740,7 @@ function Card({
   attacking,
   attackerSelected,
   attackTarget,
+  attackTargetColor,
   onToggleAttack,
   blocker,
   blocking,
@@ -771,6 +776,7 @@ function Card({
   attacking?: boolean;
   attackerSelected?: boolean;
   attackTarget?: string;
+  attackTargetColor?: string;
   onToggleAttack?: () => void;
   blocker?: boolean;
   blocking?: boolean;
@@ -828,7 +834,15 @@ function Card({
   ) : null;
 
   const targetBadge = attackTarget ? (
-    <span className="card__attack-target" title={attackTarget}>
+    <span
+      className="card__attack-target"
+      title={attackTarget}
+      style={
+        attackTargetColor
+          ? { background: attackTargetColor, color: "#1b1206" }
+          : undefined
+      }
+    >
       ⚔ {attackTarget}
     </span>
   ) : null;

--- a/src/board/Board.tsx
+++ b/src/board/Board.tsx
@@ -123,14 +123,23 @@ function ninjutsuReturnProps(
   };
 }
 
-/** Declare-attackers interaction: toggle your creatures, aim at a defender. */
+/** Declare-attackers interaction: toggle your creatures, aim each at a defender. */
 export interface AttackInteraction {
   /** Your creatures that may attack (click to toggle). */
   attackerIds: Set<number>;
   /** Attackers currently declared (highlighted). */
   declaredIds: Set<number>;
-  onToggleAttacker: (id: number) => void;
-  /** Opponent seats you may aim declared attackers at (multiplayer choice). */
+  /** Whether multiple defenders make per-attacker aiming meaningful. */
+  multiDefender: boolean;
+  /** The declared attacker focused for re-aiming (multiplayer), or null. */
+  selectedAttackerId: number | null;
+  /** attackerId -> the seat it is aimed at. */
+  assignments: Map<number, number>;
+  /** seat -> short display name, for the on-card target badge. */
+  defenderNames: Map<number, string>;
+  /** Click one of your creatures (toggles it, or focuses it for aiming). */
+  onAttackerClick: (id: number) => void;
+  /** Opponent seats you may aim the focused attacker at (multiplayer choice). */
   defenderSeats: Set<number>;
   onChooseDefender: (seat: number) => void;
 }
@@ -138,12 +147,25 @@ export interface AttackInteraction {
 function attackProps(
   o: GameObject,
   attack?: AttackInteraction,
-): { attacker?: boolean; attacking?: boolean; onToggleAttack?: () => void } {
+): {
+  attacker?: boolean;
+  attacking?: boolean;
+  attackerSelected?: boolean;
+  attackTarget?: string;
+  onToggleAttack?: () => void;
+} {
   if (!attack || !attack.attackerIds.has(o.id)) return {};
+  const declared = attack.declaredIds.has(o.id);
+  const seat = attack.assignments.get(o.id);
   return {
     attacker: true,
-    attacking: attack.declaredIds.has(o.id),
-    onToggleAttack: () => attack.onToggleAttacker(o.id),
+    attacking: declared,
+    attackerSelected: attack.multiDefender && attack.selectedAttackerId === o.id,
+    attackTarget:
+      attack.multiDefender && declared && seat !== undefined
+        ? attack.defenderNames.get(seat)
+        : undefined,
+    onToggleAttack: () => attack.onAttackerClick(o.id),
   };
 }
 
@@ -712,6 +734,8 @@ function Card({
   onNinjutsuReturn,
   attacker,
   attacking,
+  attackerSelected,
+  attackTarget,
   onToggleAttack,
   blocker,
   blocking,
@@ -745,6 +769,8 @@ function Card({
   onNinjutsuReturn?: () => void;
   attacker?: boolean;
   attacking?: boolean;
+  attackerSelected?: boolean;
+  attackTarget?: string;
   onToggleAttack?: () => void;
   blocker?: boolean;
   blocking?: boolean;
@@ -773,6 +799,7 @@ function Card({
     ninjutsuReturn ? "card--ninjutsu-return" : "",
     attacker ? "card--attacker" : "",
     attacking ? "card--attacking" : "",
+    attackerSelected ? "card--attacker-selected" : "",
     blocker ? "card--blocker" : "",
     blocking ? "card--blocking" : "",
     blockSelected ? "card--block-selected" : "",
@@ -797,6 +824,12 @@ function Card({
   const pt = isCreature ? (
     <span className="card__pt">
       {obj.power ?? 0}/{obj.toughness ?? 0}
+    </span>
+  ) : null;
+
+  const targetBadge = attackTarget ? (
+    <span className="card__attack-target" title={attackTarget}>
+      ⚔ {attackTarget}
     </span>
   ) : null;
 
@@ -838,6 +871,7 @@ function Card({
       <div {...common}>
         <img className="card__img" src={url} alt={obj.name ?? ""} loading="lazy" />
         {pt}
+        {targetBadge}
       </div>
     );
   }
@@ -845,6 +879,7 @@ function Card({
     <div {...common}>
       <span className="card__name">{obj.name ?? "?"}</span>
       {pt}
+      {targetBadge}
     </div>
   );
 }

--- a/src/board/seatColor.ts
+++ b/src/board/seatColor.ts
@@ -1,0 +1,12 @@
+// A stable identity color per seat, used to tell opponents apart at a glance —
+// especially when several share a deck name or commander. Seat 0 is the human.
+const SEAT_COLORS = [
+  "#c9a26b", // you — muted copper
+  "#5cb3ff", // sky blue
+  "#f47fb5", // pink
+  "#b98cff", // violet
+];
+
+export function seatColor(seat: number): string {
+  return SEAT_COLORS[seat % SEAT_COLORS.length];
+}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -206,9 +206,10 @@ export const messages = {
     en: "Click your highlighted creatures to attack.",
   },
   "attack.defenderHint": {
-    pt: "Clique em um oponente destacado para direcionar os atacantes.",
-    en: "Click a highlighted opponent to aim your attackers.",
+    pt: "Selecione um atacante e clique em um oponente destacado para direcioná-lo.",
+    en: "Select an attacker, then click a highlighted opponent to aim it.",
   },
+  "attack.noTarget": { pt: "sem alvo", en: "no target" },
   "attack.confirm": { pt: "Confirmar ataque", en: "Confirm attack" },
   "attack.none": { pt: "Sem ataque", en: "No attack" },
   "attack.letAi": { pt: "IA decide o combate", en: "Let the AI attack" },

--- a/src/match/RunView.tsx
+++ b/src/match/RunView.tsx
@@ -58,6 +58,7 @@ import {
   type MulliganPrompt,
 } from "../sim/decisions/mulligan";
 import { toBoardView, type BoardView, type SeatMeta } from "../board/boardView";
+import { seatColor } from "../board/seatColor";
 import { GameSidebar, type LoggedEntry } from "../board/GameSidebar";
 import type { LogEntry } from "../engine/types";
 import { abilitiesBySource } from "../sim/decisions/abilities";
@@ -1129,7 +1130,14 @@ export function RunView({
                           {attackerName(id)}
                         </span>
                         <span className="attack-summary__arrow">→</span>
-                        <span className="attack-summary__to">
+                        <span
+                          className="attack-summary__to"
+                          style={
+                            seat !== undefined
+                              ? { color: seatColor(seat) }
+                              : undefined
+                          }
+                        >
                           {def ?? t("attack.noTarget")}
                         </span>
                       </li>

--- a/src/match/RunView.tsx
+++ b/src/match/RunView.tsx
@@ -32,6 +32,9 @@ import { scryAction, type ScryPrompt } from "../sim/decisions/scry";
 import { XpWindow } from "../components/XpWindow";
 import {
   declareAttackersAction,
+  clickAttacker,
+  aimAtDefender,
+  type AttackDraft,
   type AttackersPrompt,
   type AttackTargetRef,
 } from "../sim/decisions/attackers";
@@ -221,6 +224,7 @@ export function RunView({
   const [attacks, setAttacks] = useState<Map<number, AttackTargetRef>>(
     new Map(),
   );
+  const [selectedAttacker, setSelectedAttacker] = useState<number | null>(null);
   const [blockingTurn, setBlockingTurn] = useState<BlockTurn | null>(null);
   const [blockAssign, setBlockAssign] = useState<Map<number, number>>(new Map());
   const [selectedBlocker, setSelectedBlocker] = useState<number | null>(null);
@@ -370,11 +374,13 @@ export function RunView({
                   return;
                 }
                 setAttacks(new Map());
+                setSelectedAttacker(null);
                 setAttacking({
                   prompt,
                   resolve: (choice) => {
                     setAttacking(null);
                     setAttacks(new Map());
+                    setSelectedAttacker(null);
                     resolve(choice);
                   },
                 });
@@ -731,7 +737,8 @@ export function RunView({
   const canConfirmMulti =
     !!targeting && targeting.prompt.multi && chosen.length >= targeting.prompt.min;
 
-  // Toggle attackers and (in multiplayer) aim them at a defending player.
+  // Toggle attackers and, in multiplayer, aim each one at its own defender:
+  // focus a declared attacker, then click a defending player to assign it.
   const attack: AttackInteraction | undefined = useMemo(() => {
     if (!attacking) return undefined;
     const { prompt } = attacking;
@@ -743,41 +750,44 @@ export function RunView({
         if (tgt?.type === "Player") allDefenders.add(tgt.data);
       }
     }
+    const multiDefender = allDefenders.size > 1;
+
+    const assignments = new Map<number, number>();
+    for (const [id, ref] of attacks) {
+      if (ref?.type === "Player") assignments.set(id, ref.data);
+    }
+    const defenderNames = new Map<number, string>();
+    for (const seat of allDefenders) {
+      defenderNames.set(
+        seat,
+        seatMeta[seat]?.name || t("board.player", { n: seat + 1 }),
+      );
+    }
+
+    const apply = (draft: AttackDraft) => {
+      setAttacks(draft.attacks);
+      setSelectedAttacker(draft.selected);
+    };
+    const draft: AttackDraft = { attacks, selected: selectedAttacker };
+
     return {
       attackerIds,
       declaredIds,
-      onToggleAttacker: (id: number) => {
-        setAttacks((prev) => {
-          const next = new Map(prev);
-          if (next.has(id)) {
-            next.delete(id);
-          } else {
-            const opt = prompt.attackers.find((a) => a.attackerId === id);
-            if (opt?.targets[0] !== undefined) next.set(id, opt.targets[0]);
-          }
-          return next;
-        });
-      },
-      // Only offer a defender choice when there's a real one to make.
+      multiDefender,
+      selectedAttackerId: multiDefender ? selectedAttacker : null,
+      assignments,
+      defenderNames,
+      onAttackerClick: (id: number) =>
+        apply(clickAttacker(draft, id, prompt, multiDefender)),
+      // A defender is clickable only once an attacker is focused to receive it.
       defenderSeats:
-        declaredIds.size > 0 && allDefenders.size > 1
+        multiDefender && selectedAttacker != null && attacks.has(selectedAttacker)
           ? allDefenders
           : new Set<number>(),
-      onChooseDefender: (seat: number) => {
-        setAttacks((prev) => {
-          const next = new Map(prev);
-          for (const id of next.keys()) {
-            const opt = prompt.attackers.find((a) => a.attackerId === id);
-            const t = opt?.targets.find(
-              (x) => x?.type === "Player" && x?.data === seat,
-            );
-            if (t !== undefined) next.set(id, t);
-          }
-          return next;
-        });
-      },
+      onChooseDefender: (seat: number) =>
+        apply(aimAtDefender(draft, seat, prompt)),
     };
-  }, [attacking, attacks]);
+  }, [attacking, attacks, selectedAttacker, seatMeta, t]);
 
   // Pick a blocker, then click the attacker it should block.
   const block: BlockInteraction | undefined = useMemo(() => {
@@ -823,6 +833,15 @@ export function RunView({
       },
     };
   }, [manaTurn]);
+
+  // Name a declared attacker (always one of the human seat's permanents).
+  const attackerName = (id: number): string => {
+    const you = board?.seats.find((s) => s.seat === 0);
+    const owned = you
+      ? [...you.creatures, ...you.commanders, ...you.others, ...you.lands]
+      : [];
+    return owned.find((o) => o.id === id)?.name ?? `#${id}`;
+  };
 
   return (
     <div>
@@ -1086,8 +1105,37 @@ export function RunView({
                 </span>
               </div>
               <p className="hint">{t("attack.instruction")}</p>
-              {attack && attack.defenderSeats.size > 0 && (
+              {attack?.multiDefender && (
                 <p className="hint">{t("attack.defenderHint")}</p>
+              )}
+              {attack?.multiDefender && attacks.size > 0 && (
+                <ul className="attack-summary">
+                  {[...attacks.entries()].map(([id, ref]) => {
+                    const seat = ref?.type === "Player" ? ref.data : undefined;
+                    const def =
+                      seat !== undefined
+                        ? attack.defenderNames.get(seat)
+                        : undefined;
+                    return (
+                      <li
+                        key={id}
+                        className={
+                          selectedAttacker === id
+                            ? "attack-summary__row attack-summary__row--sel"
+                            : "attack-summary__row"
+                        }
+                      >
+                        <span className="attack-summary__from">
+                          {attackerName(id)}
+                        </span>
+                        <span className="attack-summary__arrow">→</span>
+                        <span className="attack-summary__to">
+                          {def ?? t("attack.noTarget")}
+                        </span>
+                      </li>
+                    );
+                  })}
+                </ul>
               )}
               <div className="import__row">
                 <button

--- a/src/sim/decisions/attackers.test.ts
+++ b/src/sim/decisions/attackers.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { parseAttackersPrompt, declareAttackersAction } from "./attackers";
+import {
+  parseAttackersPrompt,
+  declareAttackersAction,
+  clickAttacker,
+  aimAtDefender,
+  type AttackDraft,
+  type AttackersPrompt,
+} from "./attackers";
 import type { GameObject, WaitingFor } from "../../engine/types";
 
 // A real DeclareAttackers waiting_for captured from the phase-rs WASM build.
@@ -78,5 +85,100 @@ describe("declareAttackersAction", () => {
 
   it("represents no attackers as an empty attacks list", () => {
     expect(declareAttackersAction([]).data.attacks).toEqual([]);
+  });
+});
+
+// Two attackers (7, 9), two defending players (1, 2). Each attacker may aim at
+// either player — the shape the split-attack UI operates on.
+const MULTI: AttackersPrompt = {
+  player: 0,
+  attackers: [
+    {
+      attackerId: 7,
+      targets: [
+        { type: "Player", data: 1 },
+        { type: "Player", data: 2 },
+      ],
+    },
+    {
+      attackerId: 9,
+      targets: [
+        { type: "Player", data: 1 },
+        { type: "Player", data: 2 },
+      ],
+    },
+  ],
+};
+
+const empty = (): AttackDraft => ({ attacks: new Map(), selected: null });
+
+describe("clickAttacker (single defender)", () => {
+  const prompt: AttackersPrompt = {
+    player: 0,
+    attackers: [{ attackerId: 7, targets: [{ type: "Player", data: 1 }] }],
+  };
+
+  it("toggles an attacker on with its only legal target", () => {
+    const r = clickAttacker(empty(), 7, prompt, false);
+    expect([...r.attacks.entries()]).toEqual([[7, { type: "Player", data: 1 }]]);
+    expect(r.selected).toBeNull();
+  });
+
+  it("toggles an already-declared attacker back off", () => {
+    const on = clickAttacker(empty(), 7, prompt, false);
+    const off = clickAttacker(on, 7, prompt, false);
+    expect(off.attacks.size).toBe(0);
+  });
+});
+
+describe("clickAttacker (multiple defenders)", () => {
+  it("declares and focuses an attacker on first click", () => {
+    const r = clickAttacker(empty(), 7, MULTI, true);
+    expect(r.attacks.get(7)).toEqual({ type: "Player", data: 1 });
+    expect(r.selected).toBe(7);
+  });
+
+  it("focuses a second attacker without dropping the first", () => {
+    const a = clickAttacker(empty(), 7, MULTI, true);
+    const b = clickAttacker(a, 9, MULTI, true);
+    expect([...b.attacks.keys()]).toEqual([7, 9]);
+    expect(b.selected).toBe(9);
+  });
+
+  it("re-focuses an already-declared attacker instead of removing it", () => {
+    const a = clickAttacker(empty(), 7, MULTI, true);
+    const b = clickAttacker(a, 9, MULTI, true); // 9 focused, 7 still declared
+    const c = clickAttacker(b, 7, MULTI, true); // clicking unfocused 7 focuses it
+    expect(c.attacks.has(7)).toBe(true);
+    expect(c.selected).toBe(7);
+  });
+
+  it("removes an attacker when its focused card is clicked again", () => {
+    const a = clickAttacker(empty(), 7, MULTI, true); // 7 focused
+    const b = clickAttacker(a, 7, MULTI, true); // focused again -> remove
+    expect(b.attacks.has(7)).toBe(false);
+    expect(b.selected).toBeNull();
+  });
+});
+
+describe("aimAtDefender", () => {
+  it("re-aims only the focused attacker, leaving others untouched", () => {
+    let d = clickAttacker(empty(), 7, MULTI, true); // 7 -> player 1, focused
+    d = clickAttacker(d, 9, MULTI, true); // 9 -> player 1, focused
+    d = aimAtDefender(d, 2, MULTI); // aim focused (9) at player 2
+    expect(d.attacks.get(7)).toEqual({ type: "Player", data: 1 });
+    expect(d.attacks.get(9)).toEqual({ type: "Player", data: 2 });
+  });
+
+  it("is a no-op when nothing is focused", () => {
+    const d = aimAtDefender(empty(), 2, MULTI);
+    expect(d.attacks.size).toBe(0);
+    expect(d.selected).toBeNull();
+  });
+
+  it("ignores a seat the focused attacker cannot attack", () => {
+    const focused = clickAttacker(empty(), 7, MULTI, true);
+    const r = aimAtDefender(focused, 3, MULTI); // player 3 not a legal target
+    expect(r.attacks.get(7)).toEqual({ type: "Player", data: 1 });
   });
 });

--- a/src/sim/decisions/attackers.ts
+++ b/src/sim/decisions/attackers.ts
@@ -60,3 +60,67 @@ export function declareAttackersAction(attacks: [number, AttackTargetRef][]): {
 } {
   return { type: "DeclareAttackers", data: { attacks, bands: [] } };
 }
+
+/** In-progress attacker declaration: who attacks (and what each aims at), plus
+ *  the attacker currently focused for re-aiming (multiplayer only). */
+export interface AttackDraft {
+  attacks: Map<number, AttackTargetRef>;
+  selected: number | null;
+}
+
+function defaultTarget(
+  prompt: AttackersPrompt,
+  id: number,
+): AttackTargetRef | undefined {
+  return prompt.attackers.find((a) => a.attackerId === id)?.targets[0];
+}
+
+/**
+ * Click one of your creatures during declare-attackers.
+ * Single-defender games plain-toggle the attacker. With multiple defenders,
+ * a click focuses the attacker for aiming (declaring it first if needed);
+ * clicking the already-focused attacker removes it from combat.
+ */
+export function clickAttacker(
+  draft: AttackDraft,
+  id: number,
+  prompt: AttackersPrompt,
+  multiDefender: boolean,
+): AttackDraft {
+  const attacks = new Map(draft.attacks);
+  if (!multiDefender) {
+    if (attacks.has(id)) {
+      attacks.delete(id);
+    } else {
+      const tgt = defaultTarget(prompt, id);
+      if (tgt !== undefined) attacks.set(id, tgt);
+    }
+    return { attacks, selected: null };
+  }
+  if (draft.selected === id) {
+    attacks.delete(id);
+    return { attacks, selected: null };
+  }
+  if (!attacks.has(id)) {
+    const tgt = defaultTarget(prompt, id);
+    if (tgt === undefined) return draft;
+    attacks.set(id, tgt);
+  }
+  return { attacks, selected: id };
+}
+
+/** Aim the focused attacker at a defending seat; no-op if it can't attack there. */
+export function aimAtDefender(
+  draft: AttackDraft,
+  seat: number,
+  prompt: AttackersPrompt,
+): AttackDraft {
+  if (draft.selected == null) return draft;
+  const tgt = prompt.attackers
+    .find((a) => a.attackerId === draft.selected)
+    ?.targets.find((x) => x?.type === "Player" && x?.data === seat);
+  if (tgt === undefined) return draft;
+  const attacks = new Map(draft.attacks);
+  attacks.set(draft.selected, tgt);
+  return { attacks, selected: draft.selected };
+}


### PR DESCRIPTION
Resolves #27.

## What

During declare-attackers in a pod, you can now aim each attacker at its **own** defender and see every assignment before committing.

- **Per-attacker split aiming.** Previously, choosing a defender re-aimed *all* declared attackers at once, so you couldn't split an attack across players. Now (when more than one opponent can be attacked) you focus a declared attacker, then click a defending opponent to aim just that one. Single-defender games keep the plain toggle.
- **Visible targets.** Each declared attacker shows a ⚔ target badge naming its defender, and a summary above the Confirm button lists every attacker → defender with the focused row marked.
- **Per-opponent identity colors.** Pod opponents are often the same deck and commander, so a summary that read "→ Counter Intelligence" three times was ambiguous. Each seat now has a fixed identity color on its board name, and the badge and summary row reuse that color — so the target is told apart by color, not by a repeating name.

## How

- The interaction is extracted to pure helpers in `src/sim/decisions/attackers.ts` (`clickAttacker` / `aimAtDefender`), each fully unit-tested.
- Presentation lives in `Board.tsx` (badge, focus highlight, colored names) and `RunView.tsx` (summary). One shared `seatColor(seat)` drives every color.

## Verification

- New unit tests for the aim/focus/remove/no-op logic; full suite green.
- `tsc`, ESLint, and `vite build` all clean.
- Confirmed on a live board (computed styles): seats 1/2/3 render distinct colors (blue/pink/violet) and the human seat stays default; badge and summary reuse the same mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)