### PR TITLE
Render tokens as cards on the board (#28)

### DIFF
--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,6 +12,14 @@ depth live there. A purely-internal PR that touches no product or architecture m
 skip its version with a `Skip-Docs: <reason>` trailer instead. There are no
 per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
+## [0.4.5] - 2026-08-21
+
+### Added
+
+- Token permanents render as cards on the board, with real token art pulled from the
+  Scryfall printing the engine picks (`token_image_ref`) and the text face as the
+  fallback when a token has no printing (`domains/board/index.md`).
+
 ## [0.4.4] - 2026-08-21
 
 ### Added

--- a/domainbook/domains/board/index.md
+++ b/domainbook/domains/board/index.md
@@ -56,7 +56,9 @@ way whether they are playing or watching.
 - The engine's per-seat view already filters hidden information, so the board can
   render exactly what it is handed without leaking.
 - Card images are fetched from Scryfall at runtime and cached locally (`ADR-0003`);
-  the board does not bundle images.
+  the board does not bundle images. Minted tokens have no deck printing, so their
+  art comes from the Scryfall id the engine picks (`token_image_ref`); a token with
+  no printing falls back to the text face like any imageless card.
 - A four-seat pod fits the fixed layout, and so do one and two seats.
 
 ## Verification Metrics

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",

--- a/src/board/Board.tsx
+++ b/src/board/Board.tsx
@@ -20,6 +20,7 @@ import type { GameObject } from "../engine/types";
 import type { BoardView, SeatView } from "./boardView";
 import { seatColor } from "./seatColor";
 import { CardPreview, type Preview } from "./CardPreview";
+import { tokenImageUrl } from "./tokenArt";
 import { useI18n } from "../i18n/I18nContext";
 import { categoryLabel } from "../i18n/messages";
 import { XpScroll } from "../components/XpScroll";
@@ -789,7 +790,9 @@ function Card({
   castable?: boolean;
   onCast?: () => void;
 }) {
-  const url = obj.name ? images?.[obj.name.toLowerCase()] : undefined;
+  const url =
+    (obj.name ? images?.[obj.name.toLowerCase()] : undefined) ??
+    tokenImageUrl(obj);
   const isCreature = obj.card_types?.core_types?.includes("Creature") ?? false;
   const cls = [
     "card",

--- a/src/board/tokenArt.test.ts
+++ b/src/board/tokenArt.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { tokenImageUrl } from "./tokenArt";
+import type { GameObject } from "../engine/types";
+
+function token(overrides: Partial<GameObject> = {}): GameObject {
+  return {
+    id: 1,
+    name: "Wall",
+    zone: "Battlefield",
+    is_token: true,
+    token_image_ref: {
+      scryfall_id: "9b154f90-cc26-4e45-b751-854e2017cd40",
+    },
+    ...overrides,
+  };
+}
+
+describe("tokenImageUrl", () => {
+  it("builds a CDN url sharded by the first two id digits", () => {
+    expect(tokenImageUrl(token())).toBe(
+      "https://cards.scryfall.io/normal/front/9/b/9b154f90-cc26-4e45-b751-854e2017cd40.jpg",
+    );
+  });
+
+  it("returns undefined for non-token objects", () => {
+    expect(tokenImageUrl(token({ is_token: false }))).toBeUndefined();
+  });
+
+  it("returns undefined when the token carries no printing", () => {
+    expect(tokenImageUrl(token({ token_image_ref: null }))).toBeUndefined();
+  });
+});

--- a/src/board/tokenArt.ts
+++ b/src/board/tokenArt.ts
@@ -1,0 +1,12 @@
+import type { GameObject } from "../engine/types";
+
+/**
+ * Scryfall's image CDN lays cards out by the first two hex digits of the
+ * printing id, matching the `image_uris` URLs the deck path already uses.
+ */
+export function tokenImageUrl(obj: GameObject): string | undefined {
+  if (!obj.is_token) return undefined;
+  const id = obj.token_image_ref?.scryfall_id;
+  if (!id) return undefined;
+  return `https://cards.scryfall.io/normal/front/${id[0]}/${id[1]}/${id}.jpg`;
+}

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -55,6 +55,12 @@ export interface GameObject {
   keywords?: string[];
   is_commander?: boolean;
   is_token?: boolean;
+  /** For minted tokens: the Scryfall printing the engine picked for its art. */
+  token_image_ref?: {
+    scryfall_id?: string;
+    scryfall_oracle_id?: string;
+    preset_id?: string;
+  } | null;
   face_down?: boolean;
   summoning_sick?: boolean;
   damage_marked?: number;


### PR DESCRIPTION
## What

Token permanents (e.g. the Wall tokens the Abzan Armor deck mints) now render as real cards on the board instead of a bare text tile.

Tokens already reached the per-seat battlefield lists in `boardView`, and the `Card` component already renders an `<img>` when it has a URL — the gap was the URL. Tokens have no deck printing, so the name→image map never had an entry for them and they fell through to the `card--text` fallback.

Each minted token carries the Scryfall printing the engine picked, at `token_image_ref.scryfall_id`. `tokenImageUrl` builds the CDN URL from that id, sharded by its first two hex digits — the same `cards.scryfall.io` path the deck images already use — so no extra API call is needed. The text face stays as the fallback for any token without a printing.

## Changes

- `src/board/tokenArt.ts` — new `tokenImageUrl(obj)` helper (+ unit tests)
- `src/board/Board.tsx` — `Card` prefers the deck image, then the token art
- `src/engine/types.ts` — type the `token_image_ref` field on `GameObject`
- domainbook: board index assumption + changelog `0.4.5`, `package.json` bump

## Verification

- Unit tests for the helper (URL shape, non-token, missing printing)
- Full suite: 122 passing; typecheck, `eslint .`, `domainbook check --staged`, and `vite build` all clean
- Headless capture of a real engine-minted Wall token confirmed it lands on a seat's battlefield list with `is_token` + `token_image_ref.scryfall_id`, and the real helper produces `https://cards.scryfall.io/normal/front/9/b/9b154f90-…jpg`, which returns `200 image/jpeg`

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)