### PR TITLE
Manual mana tapping: pool mana by hand, then cast from the reserve (#24)

### DIFF
--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,6 +12,22 @@ depth live there. A purely-internal PR that touches no product or architecture m
 skip its version with a `Skip-Docs: <reason>` trailer instead. There are no
 per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
+## [0.4.6] - 2026-08-21
+
+### Added
+
+- A taskbar Settings menu with a persisted "tap mana manually" toggle; when on,
+  the player taps their own sources (any mana permanent, not just lands) to pool
+  mana, and a spell is castable only once the reserve covers it — casting then
+  spends the reserve and goes straight to targeting, with no auto-tapping
+  (`domains/simulation/features/pay-mana-by-hand.md`).
+
+### Fixed
+
+- The floating-mana reserve beside a player's life now reads the engine's
+  `mana_pool.mana` (it looked at a field that never populated), so pooled mana
+  shows.
+
 ## [0.4.5] - 2026-08-21
 
 ### Added

--- a/domainbook/domains/simulation/features/pay-mana-by-hand.md
+++ b/domainbook/domains/simulation/features/pay-mana-by-hand.md
@@ -1,0 +1,82 @@
+---
+id: pay-mana-by-hand
+name: Pay for spells by tapping mana yourself
+status: implemented
+---
+
+## Story
+
+As a player
+I want to tap my own lands for mana and then cast from that reserve
+So that I decide which sources pay, and hold up exactly the mana I mean to
+
+## Rule: A global setting turns manual mana on; off, mana auto-pays as before
+
+The "tap mana manually" toggle lives in the taskbar Settings menu and is
+remembered across sessions. It is off by default. When off, casting a spell pays
+for it automatically, and the engine only asks the human where a payment has a
+genuine choice (see `step-through-a-turn.md`, "Paying with a specific source").
+
+```gherkin
+Example: The setting is off by default and mana auto-pays
+  Given a new player has not opened Settings
+  When they cast a spell they can afford
+  Then the engine pays for it automatically
+
+Example: Turning the setting on requires pooling mana before casting
+  Given the player has enabled "tap mana manually"
+  Then casting no longer auto-taps their lands
+  And they must first tap sources to make the mana
+```
+
+## Rule: With the setting on, tap your own sources at priority to pool mana
+
+While the setting is on and the player has priority, every permanent that can
+make mana — land, rock, or creature — is tappable. Tapping one adds its mana to
+the player's reserve, shown beside their life. A source that makes more than one
+color asks which to make before it is tapped.
+
+```gherkin
+Example: Tapping a land to pool its mana
+  Given manual mana is on and it is the player's main phase
+  When they tap one of their lands
+  Then that land's mana is added to their reserve
+
+Example: A non-land source pools mana too
+  Given the player controls a mana rock or a creature that makes mana
+  When they tap it
+  Then its mana is added to their reserve like a land's
+
+Example: Choosing a color from a dual source
+  Given the player taps a source that can make more than one color
+  When they are asked which color to make
+  Then they pick one, and that color is added to their reserve
+```
+
+## Rule: A spell is castable only when the reserve already covers its cost
+
+With the setting on, a spell can be cast only when the floating reserve pays its
+whole cost — each colored pip from its own color, the generic part from whatever
+is left. Spells the reserve cannot cover are not offered, so casting never taps a
+land the player did not choose. Casting spends the reserve and goes straight to
+choosing targets — there is no separate payment step to confirm.
+
+```gherkin
+Example: Casting once the reserve covers the cost
+  Given manual mana is on and the player has pooled enough mana for a spell
+  When they cast that spell
+  Then its cost is paid from the reserve
+  And no additional land is tapped
+  And they go straight to choosing its targets
+
+Example: A spell you cannot yet pay for is not castable
+  Given manual mana is on and the reserve does not cover a spell's cost
+  Then that spell is not offered to cast
+  And the player must pool more mana first
+```
+
+## Open Questions
+
+- Colored pips are matched to floating mana of the same color; hybrid and
+  Phyrexian pips are not modeled, so such spells read as not-yet-payable until
+  their plain-color mana is floating.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",

--- a/src/App.css
+++ b/src/App.css
@@ -253,6 +253,52 @@ body.xpscroll-dragging {
   color: var(--accent-ink);
 }
 
+/* Settings popup: sits just left of the language switch, opens upward. */
+.xp-settings {
+  margin-left: auto;
+}
+.xp-settings ~ .xp-lang {
+  margin-left: 4px;
+}
+.xp-settings__menu {
+  min-width: 244px;
+  padding: 0;
+}
+.xp-settings__item {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  width: 100%;
+  padding: 9px 12px;
+  text-align: left;
+  background: var(--winbg);
+  border: none;
+  cursor: pointer;
+  color: var(--text);
+}
+.xp-settings__item:hover {
+  background: var(--accent-2);
+  color: var(--accent-ink);
+}
+.xp-settings__check {
+  font-size: 15px;
+  line-height: 1.2;
+  flex: 0 0 auto;
+}
+.xp-settings__text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.xp-settings__label {
+  font-size: 13px;
+  font-weight: 700;
+}
+.xp-settings__desc {
+  font-size: 11px;
+  opacity: 0.75;
+}
+
 /* View width: narrow forms cap and left-align; report/board go full-bleed. */
 .xp-content--narrow .panel {
   max-width: 780px;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { RunView } from "./match/RunView";
 import type { RunConfig } from "./match/config";
 import { useI18n } from "./i18n/I18nContext";
 import { LangToggle } from "./i18n/LangToggle";
+import { SettingsMenu } from "./settings/SettingsMenu";
 import { XpScroll } from "./components/XpScroll";
 import iconDecks from "./assets/icon-decks.png";
 import iconPlay from "./assets/icon-play.png";
@@ -138,6 +139,7 @@ export function App() {
           <img className="xp-taskbtn__icon" src={iconPlay} alt="" />
           {t("nav.play")}
         </button>
+        <SettingsMenu />
         <LangToggle />
       </div>
     </div>

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -15,6 +15,15 @@ export const messages = {
   "nav.decks": { pt: "Decks", en: "Decks" },
   "nav.play": { pt: "Testar", en: "Play" },
   "lang.aria": { pt: "Idioma", en: "Language" },
+  "settings.title": { pt: "Configurações", en: "Settings" },
+  "settings.manualMana": {
+    pt: "Tocar mana manualmente",
+    en: "Tap mana manually",
+  },
+  "settings.manualManaDesc": {
+    pt: "Escolha quais permanentes tocar ao pagar mágicas.",
+    en: "Choose which permanents to tap when paying for spells.",
+  },
   "win.reportTitle": {
     pt: "{name} — consistência",
     en: "{name} — consistency",
@@ -168,6 +177,10 @@ export const messages = {
     en: "Click a highlighted permanent to activate an ability.",
   },
   "turn.abilityN": { pt: "Habilidade {n}", en: "Ability {n}" },
+  "turn.floatManaHint": {
+    pt: "Toque suas fontes para gerar mana; depois lance uma mágica que você já pode pagar.",
+    en: "Tap your sources to make mana, then cast a spell you can already pay for.",
+  },
   "turn.ninjutsuHint": {
     pt: "Clique em um ninja destacado (na mão ou na zona de comando) para usar ninjutsu.",
     en: "Click a highlighted ninja (in hand or the command zone) to use ninjutsu.",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,12 +2,15 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
 import { I18nProvider } from "./i18n/I18nContext";
+import { SettingsProvider } from "./settings/SettingsContext";
 import "./index.css";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <I18nProvider>
-      <App />
+      <SettingsProvider>
+        <App />
+      </SettingsProvider>
     </I18nProvider>
   </StrictMode>,
 );

--- a/src/match/RunView.tsx
+++ b/src/match/RunView.tsx
@@ -45,7 +45,12 @@ import {
 import {
   chooseManaColorAction,
   tapManaSourceAction,
+  priorityManaSources,
+  canPayFromPool,
+  readManaPool,
   type ManaPrompt,
+  type ManaPip,
+  type ManaSourceOption,
 } from "../sim/decisions/mana";
 import {
   chooseOptionAction,
@@ -60,13 +65,14 @@ import {
 import { toBoardView, type BoardView, type SeatMeta } from "../board/boardView";
 import { seatColor } from "../board/seatColor";
 import { GameSidebar, type LoggedEntry } from "../board/GameSidebar";
-import type { LogEntry } from "../engine/types";
+import type { GameObject, LogEntry } from "../engine/types";
 import { abilitiesBySource } from "../sim/decisions/abilities";
 import { ninjutsuBySource } from "../sim/decisions/ninjutsu";
 import { aggregate } from "../analysis/matchStats";
 import { fetchCardsCached } from "../lib/scryfallCache";
 import { SearchableSelect } from "../components/SearchableSelect";
 import { useI18n } from "../i18n/I18nContext";
+import { useSettings } from "../settings/SettingsContext";
 import { phaseLabel, type Lang } from "../i18n/messages";
 
 type Phase = "loading" | "running" | "done" | "error";
@@ -152,6 +158,10 @@ interface HumanTurn {
   myTurn: boolean;
   /** True when an opponent has something on the stack awaiting the human. */
   opponentActed: boolean;
+  /** Your floating mana this window (manual-mana gating + reserve display). */
+  manaPool: ManaPip[];
+  /** This frame's objects, for reading a castable spell's mana cost. */
+  objects: Record<string, GameObject>;
   resolve: (choice: HumanChoice) => void;
 }
 
@@ -206,6 +216,7 @@ export function RunView({
   onExit: () => void;
 }) {
   const { t, lang } = useI18n();
+  const { settings } = useSettings();
   const [phase, setPhase] = useState<Phase>("loading");
   const [message, setMessage] = useState(t("run.preparing"));
   const [board, setBoard] = useState<BoardView | null>(null);
@@ -218,6 +229,11 @@ export function RunView({
   const [dragging, setDragging] = useState<number | null>(null);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [abilityPick, setAbilityPick] = useState<{ objId: number; actions: any[] } | null>(null);
+  // Which colour to make when a tapped mana source produces more than one.
+  const [manaSourcePick, setManaSourcePick] = useState<{
+    objId: number;
+    options: ManaSourceOption[];
+  } | null>(null);
   const [ninjutsuSource, setNinjutsuSource] = useState<number | null>(null);
   const [targeting, setTargeting] = useState<TargetTurn | null>(null);
   const [chosen, setChosen] = useState<TargetRef[]>([]);
@@ -346,6 +362,8 @@ export function RunView({
                   opponentActed: stack.some(
                     (id) => (st.objects?.[id]?.controller ?? -1) !== 0,
                   ),
+                  manaPool: readManaPool(st.players?.[0]),
+                  objects: st.objects ?? {},
                   resolve: (choice) => {
                     setHumanTurn(null);
                     resolve(choice);
@@ -530,6 +548,7 @@ export function RunView({
   useEffect(() => {
     setDragging(null);
     setAbilityPick(null);
+    setManaSourcePick(null);
     setNinjutsuSource(null);
   }, [humanTurn]);
 
@@ -612,6 +631,9 @@ export function RunView({
   }, [passingTurn, targeting, manaTurn, blockingTurn, creatureTypeTurn, scryTurn]);
 
   // Map draggable hand cards to their play actions for the current window.
+  // With manual mana on, a normal cast is offered only when the floating reserve
+  // already covers it, so casting never taps extra lands (the player floats mana
+  // by tapping sources first).
   const play: PlayInteraction | undefined = useMemo(() => {
     if (!humanTurn) return undefined;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -619,7 +641,15 @@ export function RunView({
     for (const a of humanTurn.legal.actions ?? []) {
       if (!PLAYABLE_TYPES.has(a?.type)) continue;
       const id = actionObjectId(a);
-      if (id != null && !map.has(id)) map.set(id, a);
+      if (id == null || map.has(id)) continue;
+      if (
+        settings.manualMana &&
+        a.type === "CastSpell" &&
+        !canPayFromPool(humanTurn.manaPool, humanTurn.objects[id]?.mana_cost)
+      ) {
+        continue;
+      }
+      map.set(id, a);
     }
     return {
       playableIds: new Set(map.keys()),
@@ -630,7 +660,7 @@ export function RunView({
         if (a) humanTurn.resolve({ action: a });
       },
     };
-  }, [humanTurn, dragging]);
+  }, [humanTurn, dragging, settings.manualMana]);
 
   const hasPlayable = (play?.playableIds.size ?? 0) > 0;
 
@@ -822,18 +852,39 @@ export function RunView({
     };
   }, [blockingTurn, blockAssign, selectedBlocker]);
 
-  // Tap one of your sources when the engine asks which to use for a payment.
+  // Two ways a source gets tapped: the engine asking which source to use for a
+  // payment (ManaSourceSelection), or — with manual mana on — the player pooling
+  // mana at their own priority before casting. A source that makes more than one
+  // color opens a small color picker first.
   const mana: ManaInteraction | undefined = useMemo(() => {
-    if (!manaTurn || manaTurn.prompt.kind !== "source") return undefined;
-    const { prompt } = manaTurn;
-    return {
-      sourceIds: new Set(prompt.sources.map((s) => s.objectId)),
-      onTapSource: (objId: number) => {
-        const src = prompt.sources.find((s) => s.objectId === objId);
-        if (src) manaTurn.resolve({ action: tapManaSourceAction(src) });
-      },
-    };
-  }, [manaTurn]);
+    if (manaTurn?.prompt.kind === "source") {
+      const { prompt } = manaTurn;
+      return {
+        sourceIds: new Set(prompt.sources.map((s) => s.objectId)),
+        onTapSource: (objId: number) => {
+          const src = prompt.sources.find((s) => s.objectId === objId);
+          if (src) manaTurn.resolve({ action: tapManaSourceAction(src) });
+        },
+      };
+    }
+    if (settings.manualMana && humanTurn) {
+      const sources = priorityManaSources(humanTurn.legal);
+      if (sources.size === 0) return undefined;
+      return {
+        sourceIds: new Set(sources.keys()),
+        onTapSource: (objId: number) => {
+          const options = sources.get(objId);
+          if (!options || options.length === 0) return;
+          if (options.length === 1) {
+            humanTurn.resolve({ action: options[0].action });
+          } else {
+            setManaSourcePick({ objId, options });
+          }
+        },
+      };
+    }
+    return undefined;
+  }, [manaTurn, humanTurn, settings.manualMana]);
 
   // Name a declared attacker (always one of the human seat's permanents).
   const attackerName = (id: number): string => {
@@ -996,9 +1047,15 @@ export function RunView({
                     : t("turn.ninjutsuHint")}
                 </p>
               )}
-              {!hasPlayable && !ability && !ninjutsu && (
-                <p className="hint">{t("turn.nothingToPlay")}</p>
+              {settings.manualMana && mana && (
+                <p className="hint">{t("turn.floatManaHint")}</p>
               )}
+              {!hasPlayable &&
+                !ability &&
+                !ninjutsu &&
+                !(settings.manualMana && mana) && (
+                  <p className="hint">{t("turn.nothingToPlay")}</p>
+                )}
               {abilityPick && (
                 <div className="import__row">
                   {abilityPick.actions.map((a, i) => (
@@ -1015,6 +1072,25 @@ export function RunView({
                   <button
                     className="btn btn--ghost"
                     onClick={() => setAbilityPick(null)}
+                  >
+                    {t("turn.cancel")}
+                  </button>
+                </div>
+              )}
+              {manaSourcePick && (
+                <div className="import__row">
+                  {manaSourcePick.options.map((opt, i) => (
+                    <button
+                      key={i}
+                      className="btn"
+                      onClick={() => humanTurn.resolve({ action: opt.action })}
+                    >
+                      {t(`mana.color.${opt.manaType}` as Parameters<typeof t>[0])}
+                    </button>
+                  ))}
+                  <button
+                    className="btn btn--ghost"
+                    onClick={() => setManaSourcePick(null)}
                   >
                     {t("turn.cancel")}
                   </button>

--- a/src/settings/SettingsContext.tsx
+++ b/src/settings/SettingsContext.tsx
@@ -1,0 +1,59 @@
+import { createContext, useCallback, useContext, useMemo, useState } from "react";
+import type { ReactNode } from "react";
+
+const STORAGE_KEY = "commander-playtester/settings/v1";
+
+export interface Settings {
+  /** Pay for spells by tapping sources yourself instead of auto-paying. */
+  manualMana: boolean;
+}
+
+const DEFAULTS: Settings = { manualMana: false };
+
+function initialSettings(): Settings {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved) return { ...DEFAULTS, ...JSON.parse(saved) };
+  } catch {
+    // ignore storage/parse errors (private mode, corrupt value)
+  }
+  return DEFAULTS;
+}
+
+interface SettingsApi {
+  settings: Settings;
+  setManualMana: (on: boolean) => void;
+}
+
+const Ctx = createContext<SettingsApi | null>(null);
+
+export function SettingsProvider({ children }: { children: ReactNode }) {
+  const [settings, setSettings] = useState<Settings>(initialSettings);
+
+  const persist = useCallback((next: Settings) => {
+    setSettings(next);
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+    } catch {
+      // ignore storage errors
+    }
+  }, []);
+
+  const setManualMana = useCallback(
+    (on: boolean) => persist({ ...settings, manualMana: on }),
+    [persist, settings],
+  );
+
+  const value = useMemo<SettingsApi>(
+    () => ({ settings, setManualMana }),
+    [settings, setManualMana],
+  );
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useSettings(): SettingsApi {
+  const ctx = useContext(Ctx);
+  if (!ctx) throw new Error("useSettings must be used within SettingsProvider");
+  return ctx;
+}

--- a/src/settings/SettingsMenu.tsx
+++ b/src/settings/SettingsMenu.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useRef, useState } from "react";
+import { useI18n } from "../i18n/I18nContext";
+import { useSettings } from "./SettingsContext";
+
+function GearGlyph({ size = 14 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M12 8a4 4 0 100 8 4 4 0 000-8zm0 2.4a1.6 1.6 0 110 3.2 1.6 1.6 0 010-3.2z" />
+      <path d="M10.6 2h2.8l.5 2.3a7.6 7.6 0 011.8.75l2-1.2 2 2-1.2 2c.32.56.57 1.16.75 1.8L23 12v.8l-2.3.5c-.18.64-.43 1.24-.75 1.8l1.2 2-2 2-2-1.2c-.56.32-1.16.57-1.8.75L13.4 22h-2.8l-.5-2.3a7.6 7.6 0 01-1.8-.75l-2 1.2-2-2 1.2-2a7.6 7.6 0 01-.75-1.8L1 12.8V12l2.3-.5c.18-.64.43-1.24.75-1.8l-1.2-2 2-2 2 1.2c.56-.32 1.16-.57 1.8-.75L10.6 2z" opacity="0.55" />
+    </svg>
+  );
+}
+
+/** XP taskbar settings popup: beveled button opening a small menu upward. */
+export function SettingsMenu() {
+  const { t } = useI18n();
+  const { settings, setManualMana } = useSettings();
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onDown(e: MouseEvent) {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  return (
+    <div className="xp-lang xp-settings" ref={rootRef}>
+      <button
+        type="button"
+        className="xp-lang__btn"
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={t("settings.title")}
+      >
+        <GearGlyph />
+        {t("settings.title")}
+        <span className="xp-lang__caret" aria-hidden>
+          {open ? "▾" : "▴"}
+        </span>
+      </button>
+      {open && (
+        <div className="xp-lang__menu xp-settings__menu" role="menu" aria-label={t("settings.title")}>
+          <button
+            type="button"
+            role="menuitemcheckbox"
+            aria-checked={settings.manualMana}
+            className="xp-settings__item"
+            onClick={() => setManualMana(!settings.manualMana)}
+          >
+            <span className="xp-settings__check" aria-hidden>
+              {settings.manualMana ? "☑" : "☐"}
+            </span>
+            <span className="xp-settings__text">
+              <span className="xp-settings__label">{t("settings.manualMana")}</span>
+              <span className="xp-settings__desc">{t("settings.manualManaDesc")}</span>
+            </span>
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/sim/decisions/mana.test.ts
+++ b/src/sim/decisions/mana.test.ts
@@ -3,6 +3,8 @@ import {
   parseManaPrompt,
   chooseManaColorAction,
   tapManaSourceAction,
+  priorityManaSources,
+  canPayFromPool,
   readManaPool,
 } from "./mana";
 import type { WaitingFor } from "../../engine/types";
@@ -88,15 +90,116 @@ describe("mana action builders", () => {
   });
 });
 
+// A real legalActionsByObject slice for manual-mana priority: a basic taps for
+// one color, a dual offers two, a rock defers its color. Captured live (trimmed).
+const LEGAL_BY_OBJECT = {
+  legalActionsByObject: {
+    "48": [
+      {
+        type: "TapLandForMana",
+        data: {
+          selection: {
+            source: { object_id: 48, incarnation: 2 },
+            mana_type: "Green",
+            output: { type: "Concrete", data: "Green" },
+          },
+        },
+        interactionActionId: "abc123",
+      },
+    ],
+    "77": [
+      {
+        type: "TapLandForMana",
+        data: { selection: { source: { object_id: 77 }, mana_type: "White" } },
+      },
+      {
+        type: "TapLandForMana",
+        data: { selection: { source: { object_id: 77 }, mana_type: "Black" } },
+      },
+    ],
+    "90": [
+      {
+        type: "ActivateManaSource",
+        data: {
+          selection: {
+            source: { object_id: 90 },
+            output: { type: "DeferredColorChoice" },
+          },
+        },
+      },
+    ],
+    // A non-mana ability must not be offered as a mana source.
+    "5": [{ type: "ActivateAbility", data: { source_id: 5, ability_index: 0 } }],
+  },
+};
+
+describe("priorityManaSources", () => {
+  it("groups each permanent's tap-for-mana actions, skipping non-mana ones", () => {
+    const map = priorityManaSources(LEGAL_BY_OBJECT);
+    expect([...map.keys()].sort((a, b) => a - b)).toEqual([48, 77, 90]);
+    expect(map.get(77)!.map((o) => o.manaType)).toEqual(["White", "Black"]);
+    expect(map.get(90)![0].manaType).toBe(""); // deferred any-color
+  });
+
+  it("strips interactionActionId, echoing only type+data the engine accepts", () => {
+    const opt = priorityManaSources(LEGAL_BY_OBJECT).get(48)![0];
+    expect(Object.keys(opt.action)).toEqual(["type", "data"]);
+    expect(opt.action.type).toBe("TapLandForMana");
+  });
+
+  it("returns an empty map when there are no per-object actions", () => {
+    expect(priorityManaSources(undefined).size).toBe(0);
+    expect(priorityManaSources({}).size).toBe(0);
+  });
+});
+
+describe("canPayFromPool", () => {
+  const pool = (colors: string[]): { color: string; count: number }[] => {
+    const counts = new Map<string, number>();
+    for (const c of colors) counts.set(c, (counts.get(c) ?? 0) + 1);
+    return [...counts.entries()].map(([color, count]) => ({ color, count }));
+  };
+  const cost = (generic: number, shards: string[]) => ({
+    type: "Cost",
+    generic,
+    shards,
+  });
+
+  it("pays each colored pip from its own color and generic from the rest", () => {
+    expect(canPayFromPool(pool(["Green", "Black"]), cost(1, ["Green"]))).toBe(true);
+    expect(canPayFromPool(pool(["White", "White"]), cost(0, ["White", "White"]))).toBe(true);
+  });
+
+  it("rejects when a required color is not floating", () => {
+    expect(canPayFromPool(pool(["White", "Black"]), cost(1, ["Green"]))).toBe(false);
+  });
+
+  it("rejects when there is not enough total mana for the generic part", () => {
+    expect(canPayFromPool(pool(["Green"]), cost(1, ["Green"]))).toBe(false);
+  });
+
+  it("does not spend a colored pip's mana on the generic part", () => {
+    // {1}{G} with exactly G + G: one G pays the pip, the other covers generic.
+    expect(canPayFromPool(pool(["Green", "Green"]), cost(1, ["Green"]))).toBe(true);
+    // {1}{G} with only two generic-usable but no second mana fails.
+    expect(canPayFromPool(pool(["Green"]), cost(1, ["Green"]))).toBe(false);
+  });
+
+  it("treats a free cost (or none) as always payable", () => {
+    expect(canPayFromPool([], cost(0, []))).toBe(true);
+    expect(canPayFromPool([], null)).toBe(true);
+  });
+});
+
 describe("readManaPool", () => {
-  it("counts recognised colors in the pool, ignoring unknowns", () => {
+  it("reads the engine's mana_pool.mana entries by color", () => {
     const player = {
       mana_pool: {
-        units: [
-          { mana_type: "Blue" },
-          { mana_type: "Blue" },
-          { mana_type: "Red" },
-          { mana_type: "Mystery" },
+        mana: [
+          { color: "Blue" },
+          { color: "Blue" },
+          { color: "Red" },
+          { color: "Mystery" },
         ],
       },
     };
@@ -107,7 +210,7 @@ describe("readManaPool", () => {
   });
 
   it("returns an empty list when the pool is empty or absent", () => {
-    expect(readManaPool({ mana_pool: { units: [] } })).toEqual([]);
+    expect(readManaPool({ mana_pool: { mana: [] } })).toEqual([]);
     expect(readManaPool({})).toEqual([]);
     expect(readManaPool(null)).toEqual([]);
   });

--- a/src/sim/decisions/mana.ts
+++ b/src/sim/decisions/mana.ts
@@ -3,6 +3,13 @@
 // waiting_fors: ChooseManaColor (which color an any-color source makes) or
 // ManaSourceSelection (which of several sources to tap). We route those to the
 // player and echo the engine's own option objects back in the submitted action.
+//
+// With the "tap mana manually" setting on, the player instead pools mana ahead
+// of casting: at their priority every mana permanent is tappable (its tap action
+// rides legalActions().legalActionsByObject), and floated mana lives at
+// players[seat].mana_pool.mana. A spell is then only offered when that reserve
+// already covers its cost, so casting it (payment_mode Auto) spends the pool
+// without tapping anything extra.
 
 import type { WaitingFor } from "../../engine/types";
 
@@ -73,6 +80,45 @@ export function tapManaSourceAction(source: ManaSource): {
   };
 }
 
+/** One way a permanent can be tapped for mana, ready to submit at priority. */
+export interface ManaSourceOption {
+  /** The color/type this option produces ("" for a deferred any-color source). */
+  manaType: string;
+  /** Ready-to-submit tap action. */
+  action: { type: string; data: any };
+}
+
+/**
+ * Tappable mana sources at the human's priority, grouped by permanent, for
+ * manual-mana mode. The engine lists each source's tap action(s) under
+ * legalActions().legalActionsByObject; a permanent with more than one entry
+ * (a dual land, say) offers a color choice on tap.
+ */
+export function priorityManaSources(
+  legal: any,
+): Map<number, ManaSourceOption[]> {
+  const map = new Map<number, ManaSourceOption[]>();
+  const byObject = legal?.legalActionsByObject;
+  if (!byObject) return map;
+  for (const [key, actions] of Object.entries(byObject)) {
+    const objectId = Number(key);
+    if (!Number.isInteger(objectId) || !Array.isArray(actions)) continue;
+    const options: ManaSourceOption[] = [];
+    for (const a of actions) {
+      if (a?.type !== "TapLandForMana" && a?.type !== "ActivateManaSource") {
+        continue;
+      }
+      options.push({
+        manaType: a?.data?.selection?.mana_type ?? "",
+        // Echo only type+data; the engine rejects unknown top-level fields.
+        action: { type: a.type, data: a.data },
+      });
+    }
+    if (options.length > 0) map.set(objectId, options);
+  }
+  return map;
+}
+
 export interface ManaPip {
   color: string;
   count: number;
@@ -89,7 +135,7 @@ const MANA_COLORS = new Set([
 
 function unitColor(unit: any): string | null {
   if (typeof unit === "string") return MANA_COLORS.has(unit) ? unit : null;
-  for (const key of ["mana_type", "color", "type"]) {
+  for (const key of ["color", "mana_type", "type"]) {
     const v = unit?.[key];
     if (typeof v === "string" && MANA_COLORS.has(v)) return v;
   }
@@ -98,7 +144,8 @@ function unitColor(unit: any): string | null {
 
 /** Read a player's floating mana pool into per-color pips (empty when none). */
 export function readManaPool(player: any): ManaPip[] {
-  const units = player?.mana_pool?.units;
+  const pool = player?.mana_pool;
+  const units = pool?.mana ?? pool?.units;
   if (!Array.isArray(units) || units.length === 0) return [];
   const counts = new Map<string, number>();
   for (const u of units) {
@@ -106,4 +153,25 @@ export function readManaPool(player: any): ManaPip[] {
     if (color) counts.set(color, (counts.get(color) ?? 0) + 1);
   }
   return [...counts.entries()].map(([color, count]) => ({ color, count }));
+}
+
+/**
+ * Whether a floating pool already covers a mana cost — each colored pip paid by
+ * its own color, generic by whatever is left. Used to gate which spells the
+ * player may cast in manual-mana mode, so casting never taps extra lands. A pip
+ * whose color is not floating (including hybrids we do not model) reads as
+ * unpayable, keeping the check safe rather than over-permissive.
+ */
+export function canPayFromPool(pool: ManaPip[], cost: any): boolean {
+  if (!cost || typeof cost !== "object") return true;
+  const generic = typeof cost.generic === "number" ? cost.generic : 0;
+  const shards: unknown[] = Array.isArray(cost.shards) ? cost.shards : [];
+  const avail = new Map<string, number>();
+  for (const p of pool) avail.set(p.color, (avail.get(p.color) ?? 0) + p.count);
+  for (const shard of shards) {
+    if (typeof shard !== "string" || (avail.get(shard) ?? 0) <= 0) return false;
+    avail.set(shard, avail.get(shard)! - 1);
+  }
+  const remaining = [...avail.values()].reduce((a, b) => a + b, 0);
+  return remaining >= generic;
 }


### PR DESCRIPTION
Resolves #24.

## What

Adds a **taskbar Settings menu** with a persisted **"Tap mana manually"** toggle. When it's on, mana works the way it does at a real table:

- **Tap for mana** — at your priority, every mana permanent you control (land, rock, or dork — not just basic lands) is highlighted; clicking one pools its mana into your reserve. A dual/any-color source asks which color first.
- **Click to cast** — a spell is castable *only* once your reserve already covers its cost. Casting spends the reserve and goes straight to targeting: no payment window, no confirmation, and it never taps a land you didn't choose.
- Toggle **off** → mana auto-pays exactly as before (default).

## Why this shape

The engine has no "pay only from the pool" mode and no pool-aware affordability signal, so casting via `Auto` would silently tap lands. To honor "don't allow a cast without the mana in reserve," casting is gated client-side by a pool-vs-cost check (the same kind of client-side gating already used for combat legality). Once the reserve covers a spell, `Auto` spends the pool and taps nothing extra — verified against the engine.

## Also fixed

The floating-mana reserve beside a player's life read `mana_pool.units`, but the engine populates `mana_pool.mana` — so pooled mana never displayed. It does now.

## Verification

- **Headless integration test** driving the real `MatchRunner` + engine in float-first mode: 20 source-taps, 2 real casts, each paid from the reserve with **no extra land tapped**.
- **Live in-app**: toggled on, played a land, tapped it → land tapped, reserve pip shown, and nothing castable until the reserve covers a spell.
- Unit tests for `priorityManaSources`, `canPayFromPool`, and the fixed `readManaPool`; full suite (130) green; typecheck, lint, build, and `domainbook check` all clean.

## Notes

- Hybrid/Phyrexian pips aren't modeled, so such spells read as not-yet-payable until their plain-color mana is floating (documented in the feature doc).
- Version bumped to 0.4.6; changelog and `domains/simulation/features/pay-mana-by-hand.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)