### PR TITLE
Add eslint-plugin-sonarjs and clear all recommended-rule findings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,10 +2,15 @@ import js from "@eslint/js";
 import globals from "globals";
 import reactHooks from "eslint-plugin-react-hooks";
 import reactRefresh from "eslint-plugin-react-refresh";
+import sonarjs from "eslint-plugin-sonarjs";
 import tseslint from "typescript-eslint";
 
 export default tseslint.config(
   { ignores: ["dist"] },
+  {
+    ...sonarjs.configs.recommended,
+    files: ["**/*.{ts,tsx}"],
+  },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ["**/*.{ts,tsx}"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commander-playtester",
-  "version": "0.1.10",
+  "version": "0.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commander-playtester",
-      "version": "0.1.10",
+      "version": "0.4.6",
       "dependencies": {
         "lucide-react": "^1.31.0",
         "react": "^18.3.1",
@@ -21,6 +21,7 @@
         "eslint": "^9.15.0",
         "eslint-plugin-react-hooks": "^5.0.0",
         "eslint-plugin-react-refresh": "^0.4.14",
+        "eslint-plugin-sonarjs": "^4.2.0",
         "globals": "^15.12.0",
         "jscpd": "^5.0.12",
         "playwright": "^1.62.1",
@@ -2079,6 +2080,29 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -2439,6 +2463,96 @@
         "eslint": ">=8.40"
       }
     },
+    "node_modules/eslint-plugin-sonarjs": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-4.2.0.tgz",
+      "integrity": "sha512-bqADfuNtTL7VK6RU29eoiFTtaaBKIpVPuX3bOl+rBpWSBa0zIBVZlqZNZQjfP6s4iXkAJokv5IsD8OsACkwApg==",
+      "dev": true,
+      "license": "LGPL-3.0-only",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "builtin-modules": "^3.3.0",
+        "bytes": "^3.1.2",
+        "functional-red-black-tree": "^1.0.1",
+        "globals": "^17.7.0",
+        "jsx-ast-utils-x": "^0.1.0",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^10.2.5",
+        "scslre": "^0.3.0",
+        "semver": "^7.8.5",
+        "ts-api-utils": "^2.5.0",
+        "typescript": ">=5 <6.1.0",
+        "yaml": "^2.9.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/globals": {
+      "version": "17.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.11.0.tgz",
+      "integrity": "sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
@@ -2657,6 +2771,13 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -2950,6 +3071,16 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsx-ast-utils-x": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils-x/-/jsx-ast-utils-x-0.1.0.tgz",
+      "integrity": "sha512-eQQBjBnsVtGacsG9uJNB8qOr3yA8rga4wAaGG1qRcBzSIvfhERLrWxMAM1hp5fcS6Abo8M4+bUBTekYR0qTPQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/keyv": {
@@ -3354,6 +3485,33 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/refa": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/refa/-/refa-0.12.1.tgz",
+      "integrity": "sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/regexp-ast-analysis": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.7.1.tgz",
+      "integrity": "sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0",
+        "refa": "^0.12.1"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3417,6 +3575,21 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/scslre": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.3.0.tgz",
+      "integrity": "sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0",
+        "refa": "^0.12.0",
+        "regexp-ast-analysis": "^0.7.0"
+      },
+      "engines": {
+        "node": "^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint": "^9.15.0",
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.14",
+    "eslint-plugin-sonarjs": "^4.2.0",
     "globals": "^15.12.0",
     "jscpd": "^5.0.12",
     "playwright": "^1.62.1",

--- a/scripts/engine-smoke.test.ts
+++ b/scripts/engine-smoke.test.ts
@@ -54,12 +54,10 @@ const REQUIRED_STATE_FIELDS = [
 describe.skipIf(!ENABLED)("phase-rs engine smoke", () => {
   it("has the fetched engine assets on disk", () => {
     const missing = [WASM, CARD_GZ].filter((p) => !existsSync(p));
-    if (missing.length) {
-      throw new Error(
-        `Engine assets missing: ${missing.join(", ")}\n` +
-          "Run `npm run fetch-engine` first.",
-      );
-    }
+    expect(
+      missing,
+      `Engine assets missing: ${missing.join(", ")}\nRun \`npm run fetch-engine\` first.`,
+    ).toHaveLength(0);
   });
 
   it(

--- a/src/App.css
+++ b/src/App.css
@@ -281,9 +281,29 @@ body.xpscroll-dragging {
   color: var(--accent-ink);
 }
 .xp-settings__check {
-  font-size: 15px;
-  line-height: 1.2;
   flex: 0 0 auto;
+  box-sizing: border-box;
+  position: relative;
+  width: 18px;
+  height: 18px;
+  margin-top: 1px;
+  background: #fff;
+  box-shadow:
+    inset -1px -1px 0 #ffffff,
+    inset 1px 1px 0 #808080,
+    inset -2px -2px 0 #dfdfdf,
+    inset 2px 2px 0 #0a0a0a;
+}
+.xp-settings__item[aria-checked="true"] .xp-settings__check::after {
+  content: "";
+  position: absolute;
+  left: 6px;
+  top: 2px;
+  width: 4px;
+  height: 9px;
+  border: solid #000;
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
 }
 .xp-settings__text {
   display: flex;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,13 +17,137 @@ import iconDecks from "./assets/icon-decks.png";
 import iconPlay from "./assets/icon-play.png";
 
 type View = "decks" | "play";
+type EditingState = SavedDeck | "new" | null;
+type Translate = ReturnType<typeof useI18n>["t"];
+
+function getWindowTitle(
+  t: Translate,
+  {
+    playApp,
+    runConfig,
+    editing,
+    selected,
+  }: {
+    playApp: boolean;
+    runConfig: RunConfig | null;
+    editing: EditingState;
+    selected: SavedDeck | null;
+  },
+): string {
+  if (playApp) return runConfig ? t("run.match") : t("setup.title");
+  if (editing)
+    return editing === "new" ? t("editor.newTitle") : t("editor.editTitle");
+  if (selected) return t("win.reportTitle", { name: selected.name });
+  return t("library.title");
+}
+
+function DecksView({
+  decks,
+  editing,
+  selected,
+  save,
+  remove,
+  setEditing,
+  setSelected,
+  setPlayDeck,
+  setView,
+}: {
+  decks: SavedDeck[];
+  editing: EditingState;
+  selected: SavedDeck | null;
+  save: (deck: SavedDeck) => void;
+  remove: (id: string) => void;
+  setEditing: (value: EditingState) => void;
+  setSelected: (value: SavedDeck | null) => void;
+  setPlayDeck: (value: SavedDeck | null) => void;
+  setView: (value: View) => void;
+}) {
+  if (editing) {
+    return (
+      <DeckEditor
+        initial={editing === "new" ? undefined : editing}
+        onSave={(deck) => {
+          save(deck);
+          setEditing(null);
+        }}
+        onCancel={() => setEditing(null)}
+      />
+    );
+  }
+  if (selected) {
+    return (
+      <DeckDetail
+        deck={selected}
+        onBack={() => setSelected(null)}
+        onPlay={(deck) => {
+          setPlayDeck(deck);
+          setView("play");
+        }}
+      />
+    );
+  }
+  return (
+    <DeckLibrary
+      decks={decks}
+      save={save}
+      remove={remove}
+      onSelect={setSelected}
+      onNew={() => setEditing("new")}
+      onEdit={(deck) => setEditing(deck)}
+    />
+  );
+}
+
+function PlayView({
+  decks,
+  runConfig,
+  preferredDeckId,
+  setRunConfig,
+  t,
+}: {
+  decks: SavedDeck[];
+  runConfig: RunConfig | null;
+  preferredDeckId: string | undefined;
+  setRunConfig: (value: RunConfig | null) => void;
+  t: Translate;
+}) {
+  if (decks.length === 0) {
+    return (
+      <section className="panel">
+        <h2>{t("play.empty.title")}</h2>
+        <p className="hint">{t("play.empty.body")}</p>
+      </section>
+    );
+  }
+  if (runConfig) {
+    return (
+      <RunView
+        config={runConfig}
+        seatDecks={runConfig.seatDeckIds
+          .map((id) => decks.find((d) => d.id === id))
+          .filter((d): d is SavedDeck => !!d)}
+        onExit={() => setRunConfig(null)}
+      />
+    );
+  }
+  return (
+    <MatchSetup
+      decks={decks}
+      initialDeckId={preferredDeckId}
+      onStart={(config) => {
+        setLastPlayedDeckId(config.seatDeckIds[0]);
+        setRunConfig(config);
+      }}
+    />
+  );
+}
 
 export function App() {
   const { t } = useI18n();
   const { decks, save, remove } = useDecks();
   const [view, setView] = useState<View>("decks");
   const [selected, setSelected] = useState<SavedDeck | null>(null);
-  const [editing, setEditing] = useState<SavedDeck | "new" | null>(null);
+  const [editing, setEditing] = useState<EditingState>(null);
   const [playDeck, setPlayDeck] = useState<SavedDeck | null>(null);
   const [runConfig, setRunConfig] = useState<RunConfig | null>(null);
 
@@ -37,17 +161,7 @@ export function App() {
     undefined;
 
   // Window title + icon are derived from the active view and its sub-state.
-  const winTitle = playApp
-    ? runConfig
-      ? t("run.match")
-      : t("setup.title")
-    : editing
-      ? editing === "new"
-        ? t("editor.newTitle")
-        : t("editor.editTitle")
-      : selected
-        ? t("win.reportTitle", { name: selected.name })
-        : t("library.title");
+  const winTitle = getWindowTitle(t, { playApp, runConfig, editing, selected });
 
   return (
     <div className="xp-desktop">
@@ -64,60 +178,29 @@ export function App() {
           <XpScroll
             wrapperClassName={`xp-content ${wideContent ? "xp-content--wide" : "xp-content--narrow"}`}
           >
-            {view === "decks" &&
-              (editing ? (
-                <DeckEditor
-                  initial={editing === "new" ? undefined : editing}
-                  onSave={(deck) => {
-                    save(deck);
-                    setEditing(null);
-                  }}
-                  onCancel={() => setEditing(null)}
-                />
-              ) : selected ? (
-                <DeckDetail
-                  deck={selected}
-                  onBack={() => setSelected(null)}
-                  onPlay={(deck) => {
-                    setPlayDeck(deck);
-                    setView("play");
-                  }}
-                />
-              ) : (
-                <DeckLibrary
-                  decks={decks}
-                  save={save}
-                  remove={remove}
-                  onSelect={setSelected}
-                  onNew={() => setEditing("new")}
-                  onEdit={(deck) => setEditing(deck)}
-                />
-              ))}
+            {view === "decks" && (
+              <DecksView
+                decks={decks}
+                editing={editing}
+                selected={selected}
+                save={save}
+                remove={remove}
+                setEditing={setEditing}
+                setSelected={setSelected}
+                setPlayDeck={setPlayDeck}
+                setView={setView}
+              />
+            )}
 
-            {view === "play" &&
-              (decks.length === 0 ? (
-                <section className="panel">
-                  <h2>{t("play.empty.title")}</h2>
-                  <p className="hint">{t("play.empty.body")}</p>
-                </section>
-              ) : runConfig ? (
-                <RunView
-                  config={runConfig}
-                  seatDecks={runConfig.seatDeckIds
-                    .map((id) => decks.find((d) => d.id === id))
-                    .filter((d): d is SavedDeck => !!d)}
-                  onExit={() => setRunConfig(null)}
-                />
-              ) : (
-                <MatchSetup
-                  decks={decks}
-                  initialDeckId={preferredDeckId}
-                  onStart={(config) => {
-                    setLastPlayedDeckId(config.seatDeckIds[0]);
-                    setRunConfig(config);
-                  }}
-                />
-              ))}
+            {view === "play" && (
+              <PlayView
+                decks={decks}
+                runConfig={runConfig}
+                preferredDeckId={preferredDeckId}
+                setRunConfig={setRunConfig}
+                t={t}
+              />
+            )}
           </XpScroll>
         </div>
       </div>

--- a/src/board/Board.tsx
+++ b/src/board/Board.tsx
@@ -292,6 +292,13 @@ function slotAccepts(cat: string, o: GameObject): boolean {
   return coreTypes(o).includes(cat);
 }
 
+function classList(
+  base: string,
+  flags: Record<string, boolean | undefined>,
+): string {
+  return [base, ...Object.keys(flags).filter((k) => flags[k])].join(" ");
+}
+
 /** Render opponents (top) with the human seat centered and larger at the bottom. */
 export function Board({
   view,
@@ -452,126 +459,212 @@ function Seat({
   const seatTargetable = target?.playerSeats.has(seat.seat) ?? false;
   const seatTargeted = target?.chosenSeats.has(seat.seat) ?? false;
   const seatDefender = attack?.defenderSeats.has(seat.seat) ?? false;
-  const cls = [
-    "seat",
-    you ? "seat--you" : "",
-    seat.isActive && !gameOver ? "seat--active" : "",
-    seat.isEliminated ? "seat--out" : "",
-    won ? "seat--won" : "",
-    seatTargetable ? "seat--targetable" : "",
-    seatTargeted ? "seat--targeted" : "",
-    seatDefender ? "seat--defender" : "",
-  ]
-    .filter(Boolean)
-    .join(" ");
+  const cls = classList("seat", {
+    "seat--you": you,
+    "seat--active": seat.isActive && !gameOver,
+    "seat--out": seat.isEliminated,
+    "seat--won": won,
+    "seat--targetable": seatTargetable,
+    "seat--targeted": seatTargeted,
+    "seat--defender": seatDefender,
+  });
 
   const dragCard = play?.dragging != null
     ? seat.hand.find((o) => o.id === play.dragging)
     : undefined;
 
-  const seatClick = seatTargetable
-    ? () => target!.onChoosePlayer(seat.seat)
-    : seatDefender
-      ? () => attack!.onChooseDefender(seat.seat)
-      : undefined;
+  const seatClick = seatClickHandler(
+    seat,
+    seatTargetable,
+    seatDefender,
+    target,
+    attack,
+  );
+
+  const youPlay = you ? play : undefined;
+  const youAttack = you ? attack : undefined;
+  const youMana = you ? mana : undefined;
+  const youNinjutsu = you ? ninjutsu : undefined;
 
   return (
     <div className={cls} onClick={seatClick} data-seat={seat.seat}>
-      <div className="seat__head">
-        <div className="seat__id">
-          <span
-            className="seat__name"
-            style={you ? undefined : { color: seatColor(seat.seat) }}
-          >
-            {name}
-            {you && <span className="seat__tag">{t("board.you")}</span>}
-          </span>
-          <span className="seat__commander">{seat.commander}</span>
-        </div>
-        <div className="seat__life-wrap">
-          {seat.manaPool.length > 0 && (
-            <span className="seat__mana" title="Mana disponível">
-              {seat.manaPool.map((pip) => {
-                const color = MANA_COLOR[pip.color] ?? MANA_COLOR.Colorless;
-                return Array.from({ length: pip.count }, (_, i) => (
-                  <Circle
-                    key={`${pip.color}-${i}`}
-                    size={11}
-                    color={color}
-                    fill={color}
-                  />
-                ));
-              })}
-            </span>
-          )}
-          <span className="seat__life">
-            {seat.isEliminated ? <Skull size={22} /> : seat.life}
-          </span>
-        </div>
-      </div>
+      <SeatHead seat={seat} you={you} name={name} />
 
-      <div className="seat__zones">
-        <span>
-          <Hand size={13} /> {seat.handCount}
-        </span>
-        <span>
-          <Layers size={13} /> {seat.librarySize}
-        </span>
-        {seat.graveyardSize > 0 && onOpenGraveyard ? (
-          <button
-            type="button"
-            className="seat__zone-btn"
-            onClick={(e) => {
-              e.stopPropagation();
-              onOpenGraveyard(seat.seat);
-            }}
-            title={t("board.graveyardOpen")}
-          >
-            <Skull size={13} /> {seat.graveyardSize}
-          </button>
-        ) : (
-          <span>
-            <Skull size={13} /> {seat.graveyardSize}
-          </span>
-        )}
-        {seat.poison > 0 && (
-          <span>
-            <Biohazard size={13} /> {seat.poison}
-          </span>
-        )}
-      </div>
+      <SeatZones seat={seat} onOpenGraveyard={onOpenGraveyard} />
 
       <div className="seat__field">
         {seat.commanders.length > 0 && (
-          <div className="seat__cmd">
-            {seat.commanders.map((c) => (
-              <Card
-                key={c.id}
-                obj={c}
-                images={images}
-                onHover={onHover}
-                {...targetProps(c, target)}
-                {...abilityProps(c, ability)}
-                {...attackProps(c, you ? attack : undefined)}
-                {...(you ? blockerProps(c, block) : blockTargetProps(c, block))}
-                {...manaProps(c, you ? mana : undefined)}
-                {...commanderCastProps(c, you ? play : undefined)}
-                {...ninjutsuSourceProps(c, you ? ninjutsu : undefined)}
-              />
-            ))}
-          </div>
+          <CommandZone
+            commanders={seat.commanders}
+            images={images}
+            onHover={onHover}
+            target={target}
+            ability={ability}
+            attack={youAttack}
+            block={block}
+            mana={youMana}
+            play={youPlay}
+            ninjutsu={youNinjutsu}
+            you={you}
+          />
         )}
 
-        <Row label={t("board.rowCreatures")} cards={seat.creatures} images={images} onHover={onHover} target={target} ability={ability} ninjutsu={you ? ninjutsu : undefined} attack={you ? attack : undefined} block={block} you={you} mana={you ? mana : undefined} />
-        <Row label={t("board.rowOthers")} cards={seat.others} images={images} onHover={onHover} target={target} ability={ability} mana={you ? mana : undefined} />
-        <Row label={t("board.rowLands")} cards={seat.lands} images={images} onHover={onHover} target={target} ability={ability} mana={you ? mana : undefined} />
+        <Row label={t("board.rowCreatures")} cards={seat.creatures} images={images} onHover={onHover} target={target} ability={ability} ninjutsu={youNinjutsu} attack={youAttack} block={block} you={you} mana={youMana} />
+        <Row label={t("board.rowOthers")} cards={seat.others} images={images} onHover={onHover} target={target} ability={ability} mana={youMana} />
+        <Row label={t("board.rowLands")} cards={seat.lands} images={images} onHover={onHover} target={target} ability={ability} mana={youMana} />
 
         {play && dragCard && <DropLane card={dragCard} play={play} />}
       </div>
 
       {seat.hand.length > 0 && (
-        <HandRow seat={seat} images={images} onHover={onHover} play={play} target={target} ninjutsu={you ? ninjutsu : undefined} />
+        <HandRow seat={seat} images={images} onHover={onHover} play={play} target={target} ninjutsu={youNinjutsu} />
       )}
+    </div>
+  );
+}
+
+function seatClickHandler(
+  seat: SeatView,
+  seatTargetable: boolean,
+  seatDefender: boolean,
+  target?: TargetInteraction,
+  attack?: AttackInteraction,
+): (() => void) | undefined {
+  if (seatTargetable) return () => target!.onChoosePlayer(seat.seat);
+  if (seatDefender) return () => attack!.onChooseDefender(seat.seat);
+  return undefined;
+}
+
+function SeatHead({
+  seat,
+  you,
+  name,
+}: {
+  seat: SeatView;
+  you: boolean;
+  name: string;
+}) {
+  const { t } = useI18n();
+  return (
+    <div className="seat__head">
+      <div className="seat__id">
+        <span
+          className="seat__name"
+          style={you ? undefined : { color: seatColor(seat.seat) }}
+        >
+          {name}
+          {you && <span className="seat__tag">{t("board.you")}</span>}
+        </span>
+        <span className="seat__commander">{seat.commander}</span>
+      </div>
+      <div className="seat__life-wrap">
+        {seat.manaPool.length > 0 && (
+          <span className="seat__mana" title="Mana disponível">
+            {seat.manaPool.map((pip) => {
+              const color = MANA_COLOR[pip.color] ?? MANA_COLOR.Colorless;
+              return Array.from({ length: pip.count }, (_, i) => (
+                <Circle
+                  key={`${pip.color}-${i}`}
+                  size={11}
+                  color={color}
+                  fill={color}
+                />
+              ));
+            })}
+          </span>
+        )}
+        <span className="seat__life">
+          {seat.isEliminated ? <Skull size={22} /> : seat.life}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function SeatZones({
+  seat,
+  onOpenGraveyard,
+}: {
+  seat: SeatView;
+  onOpenGraveyard?: (seat: number) => void;
+}) {
+  const { t } = useI18n();
+  return (
+    <div className="seat__zones">
+      <span>
+        <Hand size={13} /> {seat.handCount}
+      </span>
+      <span>
+        <Layers size={13} /> {seat.librarySize}
+      </span>
+      {seat.graveyardSize > 0 && onOpenGraveyard ? (
+        <button
+          type="button"
+          className="seat__zone-btn"
+          onClick={(e) => {
+            e.stopPropagation();
+            onOpenGraveyard(seat.seat);
+          }}
+          title={t("board.graveyardOpen")}
+        >
+          <Skull size={13} /> {seat.graveyardSize}
+        </button>
+      ) : (
+        <span>
+          <Skull size={13} /> {seat.graveyardSize}
+        </span>
+      )}
+      {seat.poison > 0 && (
+        <span>
+          <Biohazard size={13} /> {seat.poison}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function CommandZone({
+  commanders,
+  images,
+  onHover,
+  target,
+  ability,
+  attack,
+  block,
+  mana,
+  play,
+  ninjutsu,
+  you,
+}: {
+  commanders: GameObject[];
+  images?: Record<string, string>;
+  onHover?: (p: Preview | null) => void;
+  target?: TargetInteraction;
+  ability?: AbilityInteraction;
+  attack?: AttackInteraction;
+  block?: BlockInteraction;
+  mana?: ManaInteraction;
+  play?: PlayInteraction;
+  ninjutsu?: NinjutsuInteraction;
+  you: boolean;
+}) {
+  return (
+    <div className="seat__cmd">
+      {commanders.map((c) => (
+        <Card
+          key={c.id}
+          obj={c}
+          images={images}
+          onHover={onHover}
+          {...targetProps(c, target)}
+          {...abilityProps(c, ability)}
+          {...attackProps(c, attack)}
+          {...(you ? blockerProps(c, block) : blockTargetProps(c, block))}
+          {...manaProps(c, mana)}
+          {...commanderCastProps(c, play)}
+          {...ninjutsuSourceProps(c, ninjutsu)}
+        />
+      ))}
     </div>
   );
 }
@@ -794,30 +887,27 @@ function Card({
     (obj.name ? images?.[obj.name.toLowerCase()] : undefined) ??
     tokenImageUrl(obj);
   const isCreature = obj.card_types?.core_types?.includes("Creature") ?? false;
-  const cls = [
-    "card",
-    obj.tapped ? "card--tapped" : "",
-    draggable ? "card--draggable" : "",
-    selected ? "card--selected" : "",
-    playable === false ? "card--unplayable" : "",
-    targetable ? "card--targetable" : "",
-    targeted ? "card--targeted" : "",
-    activatable ? "card--activatable" : "",
-    ninjutsuSource ? "card--ninjutsu" : "",
-    ninjutsuChosen ? "card--ninjutsu-chosen" : "",
-    ninjutsuReturn ? "card--ninjutsu-return" : "",
-    attacker ? "card--attacker" : "",
-    attacking ? "card--attacking" : "",
-    attackerSelected ? "card--attacker-selected" : "",
-    blocker ? "card--blocker" : "",
-    blocking ? "card--blocking" : "",
-    blockSelected ? "card--block-selected" : "",
-    blockTarget ? "card--block-target" : "",
-    manaSource ? "card--mana-source" : "",
-    castable ? "card--castable" : "",
-  ]
-    .filter(Boolean)
-    .join(" ");
+  const cls = classList("card", {
+    "card--tapped": obj.tapped,
+    "card--draggable": draggable,
+    "card--selected": selected,
+    "card--unplayable": playable === false,
+    "card--targetable": targetable,
+    "card--targeted": targeted,
+    "card--activatable": activatable,
+    "card--ninjutsu": ninjutsuSource,
+    "card--ninjutsu-chosen": ninjutsuChosen,
+    "card--ninjutsu-return": ninjutsuReturn,
+    "card--attacker": attacker,
+    "card--attacking": attacking,
+    "card--attacker-selected": attackerSelected,
+    "card--blocker": blocker,
+    "card--blocking": blocking,
+    "card--block-selected": blockSelected,
+    "card--block-target": blockTarget,
+    "card--mana-source": manaSource,
+    "card--castable": castable,
+  });
 
   const enter = (e: ReactMouseEvent) =>
     onHover?.({

--- a/src/lib/cardName.ts
+++ b/src/lib/cardName.ts
@@ -26,13 +26,13 @@ export function normalizeCardName(input: string): string {
   let name = input.trim();
 
   // Remove a trailing foil/etched marker like "*F*" or "*E*".
-  name = name.replace(/\s*\*[a-z]\*\s*$/i, "");
+  name = name.replace(/\*[a-z]\*$/i, "").trimEnd();
 
   // Remove a trailing "(SET) collector" block. Set codes are 2-6 alnum chars.
-  name = name.replace(/\s*\([0-9a-z]{2,6}\)\s*[0-9a-z-]*\s*$/i, "");
+  name = name.replace(/\([0-9a-z]{2,6}\)(?:\s+[0-9a-z-]+)?$/i, "").trimEnd();
 
   // Remove a trailing category tag in square brackets.
-  name = name.replace(/\s*\[[^\]]*\]\s*$/g, "");
+  name = name.replace(/\[[^[\]]*\]$/, "").trimEnd();
 
   name = name.trim();
 
@@ -42,7 +42,10 @@ export function normalizeCardName(input: string): string {
   if (/^[^\s/]+(?:\/[^\s/]+)+$/.test(name)) {
     name = name.split("/").join(" // ");
   } else {
-    name = name.split(/\s+\/\/\s+/).join(" // ");
+    name = name
+      .split(/(?<=\s)\/\/(?=\s)/)
+      .map((face) => face.trim())
+      .join(" // ");
   }
 
   return name.trim();

--- a/src/lib/decklist.ts
+++ b/src/lib/decklist.ts
@@ -56,8 +56,11 @@ export function parseDecklist(raw: string): ParsedDecklist {
 
 const COMMANDER_HEADER = /^commanders?\b/i;
 const IGNORED_HEADER = /^(sideboard|maybeboard|considering|tokens?|planes?)\b/i;
-const MAIN_HEADER =
-  /^(deck|mainboard|creatures?|lands?|instants?|sorceries|artifacts?|enchantments?|planeswalkers?|other|nonlands?)\b/i;
+const MAIN_HEADERS = [
+  /^(deck|mainboard|other|nonlands?)\b/i,
+  /^(creatures?|lands?|instants?|sorceries)\b/i,
+  /^(artifacts?|enchantments?|planeswalkers?)\b/i,
+];
 
 function detectSectionHeader(
   line: string,
@@ -66,14 +69,14 @@ function detectSectionHeader(
   if (/^\d+\s*x?\s+/i.test(line)) return null;
   if (COMMANDER_HEADER.test(line)) return "commander";
   if (IGNORED_HEADER.test(line)) return "ignored";
-  if (MAIN_HEADER.test(line)) return "main";
+  if (MAIN_HEADERS.some((re) => re.test(line))) return "main";
   return null;
 }
 
 /** Parse a single "N Card Name (SET) 123 *F*" line into an entry. */
 function parseLine(line: string): DecklistEntry | null {
   // Leading quantity: "1", "1x", "10 x". Optional — defaults to 1.
-  const qtyMatch = line.match(/^(\d+)\s*x?\s+(.*)$/i);
+  const qtyMatch = line.match(/^(\d+)(?:\s*x)?\s+(\S.*)$/i);
   let quantity = 1;
   let rest = line;
   if (qtyMatch) {

--- a/src/lib/goldfish.ts
+++ b/src/lib/goldfish.ts
@@ -136,6 +136,27 @@ function drawOpeningHand(
   }
 }
 
+/** Index of the highest mana-value nonland spell (least castable early), or -1. */
+function highestManaValueNonlandIndex(cards: Card[]): number {
+  let idx = -1;
+  let maxMv = -1;
+  for (let j = 0; j < cards.length; j++) {
+    if (!isLand(cards[j]) && cards[j].manaValue > maxMv) {
+      maxMv = cards[j].manaValue;
+      idx = j;
+    }
+  }
+  return idx;
+}
+
+/** Pick which card to bottom: an excess land, else the priciest nonland spell. */
+function indexToBottom(cards: Card[], targetLands: number): number {
+  const landCount = cards.filter(isLand).length;
+  if (landCount > targetLands) return cards.findIndex(isLand);
+  const idx = highestManaValueNonlandIndex(cards);
+  return idx === -1 ? 0 : idx; // all lands: bottom one anyway
+}
+
 /** Bottom `count` cards from a kept 7, trimming toward a healthy land count. */
 function bottomCards(hand: Card[], count: number): Card[] {
   if (count <= 0) return hand;
@@ -143,24 +164,7 @@ function bottomCards(hand: Card[], count: number): Card[] {
   const targetLands = 3;
 
   for (let i = 0; i < count && kept.length > 0; i++) {
-    const landCount = kept.filter(isLand).length;
-    if (landCount > targetLands) {
-      // Bottom an excess land.
-      const idx = kept.findIndex(isLand);
-      kept.splice(idx, 1);
-    } else {
-      // Bottom the highest mana-value nonland spell (least castable early).
-      let idx = -1;
-      let maxMv = -1;
-      for (let j = 0; j < kept.length; j++) {
-        if (!isLand(kept[j]) && kept[j].manaValue > maxMv) {
-          maxMv = kept[j].manaValue;
-          idx = j;
-        }
-      }
-      if (idx === -1) idx = 0; // all lands: bottom one anyway
-      kept.splice(idx, 1);
-    }
+    kept.splice(indexToBottom(kept, targetLands), 1);
   }
   return kept;
 }
@@ -213,24 +217,29 @@ function simulateGame(
     }
     landDropByTurn.push(madeLandDrop);
 
-    // Available mana this turn.
-    let availableMana = state.battlefieldLands + state.rampMana;
-
     // Greedily cast affordable ramp to accelerate future turns.
-    for (;;) {
-      const idx = cheapestCastableRamp(state.hand, availableMana);
-      if (idx === -1) break;
-      const spell = state.hand[idx];
-      availableMana -= spell.manaValue;
-      state.hand.splice(idx, 1);
-      state.rampMana += 1; // each ramp piece yields ~1 extra mana going forward
-      if (turn <= 3) rampByTurn3 = true;
-    }
+    if (castAffordableRamp(state) && turn <= 3) rampByTurn3 = true;
 
     manaByTurn.push(state.battlefieldLands + state.rampMana);
   }
 
   return { mulligans, openingLands, landDropByTurn, manaByTurn, rampByTurn3 };
+}
+
+/** Greedily cast every affordable ramp spell in hand; returns whether any was cast. */
+function castAffordableRamp(state: GameState): boolean {
+  let availableMana = state.battlefieldLands + state.rampMana;
+  let castAny = false;
+  for (;;) {
+    const idx = cheapestCastableRamp(state.hand, availableMana);
+    if (idx === -1) break;
+    const spell = state.hand[idx];
+    availableMana -= spell.manaValue;
+    state.hand.splice(idx, 1);
+    state.rampMana += 1; // each ramp piece yields ~1 extra mana going forward
+    castAny = true;
+  }
+  return castAny;
 }
 
 /** Find the cheapest ramp spell in hand castable with the given mana. */

--- a/src/lib/roles.ts
+++ b/src/lib/roles.ts
@@ -55,8 +55,7 @@ function isRamp(
 
 function isDraw(text: string): boolean {
   // "draw a card", "draw two cards", "draw X cards". Exclude pure "draw step".
-  if (/draw (a|one|two|three|four|five|\d+|x) cards?/.test(text)) return true;
-  return false;
+  return /draw (a|one|two|three|four|five|\d+|x) cards?/.test(text);
 }
 
 function isRemoval(text: string): boolean {

--- a/src/match/RunView.tsx
+++ b/src/match/RunView.tsx
@@ -1,4 +1,13 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type Dispatch,
+  type MutableRefObject,
+  type RefObject,
+  type SetStateAction,
+} from "react";
 import type { SavedDeck } from "../deck/model";
 import type { RunConfig } from "./config";
 import { getEngine } from "../engine/EngineClient";
@@ -12,6 +21,7 @@ import {
   type HumanChoice,
   type TargetPrompt,
   type TargetRef,
+  type DriverCallbacks,
 } from "../sim/driver";
 import {
   Board,
@@ -73,7 +83,12 @@ import { fetchCardsCached } from "../lib/scryfallCache";
 import { SearchableSelect } from "../components/SearchableSelect";
 import { useI18n } from "../i18n/I18nContext";
 import { useSettings } from "../settings/SettingsContext";
-import { phaseLabel, type Lang } from "../i18n/messages";
+import {
+  phaseLabel,
+  type Lang,
+  type MsgKey,
+  type Vars,
+} from "../i18n/messages";
 
 type Phase = "loading" | "running" | "done" | "error";
 type Speed = "slow" | "normal" | "fast";
@@ -205,6 +220,376 @@ interface ScryTurn {
   resolve: (choice: HumanChoice) => void;
 }
 
+function isTargetOptional(
+  targeting: TargetTurn | null,
+  chosen: TargetRef[],
+): boolean {
+  if (!targeting) return false;
+  if (targeting.prompt.multi) return targeting.prompt.min === 0;
+  const slotIdx = Math.min(chosen.length, targeting.prompt.slots.length - 1);
+  return targeting.prompt.slots[slotIdx]?.optional ?? false;
+}
+
+function partitionChosenRefs(chosen: TargetRef[]): {
+  chosenObjIds: Set<number>;
+  chosenSeats: Set<number>;
+} {
+  const chosenObjIds = new Set<number>();
+  const chosenSeats = new Set<number>();
+  for (const tr of chosen) {
+    if ("Object" in tr) chosenObjIds.add(tr.Object);
+    else chosenSeats.add(tr.Player);
+  }
+  return { chosenObjIds, chosenSeats };
+}
+
+function partitionTargetPool(
+  pool: TargetRef[],
+  multi: boolean,
+  chosenObjIds: Set<number>,
+  chosenSeats: Set<number>,
+): { objectIds: Set<number>; playerSeats: Set<number> } {
+  const objectIds = new Set<number>();
+  const playerSeats = new Set<number>();
+  for (const tr of pool) {
+    if ("Object" in tr) {
+      if (multi && chosenObjIds.has(tr.Object)) continue;
+      objectIds.add(tr.Object);
+    } else {
+      if (multi && chosenSeats.has(tr.Player)) continue;
+      playerSeats.add(tr.Player);
+    }
+  }
+  return { objectIds, playerSeats };
+}
+
+function resolveTargetPick(
+  targeting: TargetTurn,
+  chosen: TargetRef[],
+  ref: TargetRef,
+  setChosen: Dispatch<SetStateAction<TargetRef[]>>,
+) {
+  const { prompt } = targeting;
+  const next = [...chosen, ref];
+  const done = prompt.multi
+    ? next.length >= prompt.max
+    : next.length >= prompt.slots.length;
+  if (done) targeting.resolve({ action: selectTargetsAction(next) });
+  else setChosen(next);
+}
+
+function MatchStatusHeading({ board }: { board: BoardView }) {
+  const { t, lang } = useI18n();
+  if (!board.gameOver) {
+    return (
+      <>
+        <span className="match-status__turn">
+          {t("board.turn", { n: board.turn })}
+        </span>
+        <span className="match-status__phase">
+          {phaseLabel(lang, board.phase)}
+        </span>
+        <span className="match-status__active">
+          {t("board.activeTurn", {
+            name:
+              board.seats[board.activePlayer]?.name ||
+              t("board.player", { n: board.activePlayer + 1 }),
+          })}
+        </span>
+      </>
+    );
+  }
+  if (board.winner === null) return <>{t("board.draw")}</>;
+  return (
+    <>
+      {t("board.winner", {
+        name:
+          board.seats[board.winner]?.name ||
+          t("board.player", { n: board.winner + 1 }),
+      })}
+    </>
+  );
+}
+
+function describeRunError(
+  e: unknown,
+  t: (key: MsgKey, vars?: Vars) => string,
+): string {
+  if (e instanceof DeckRejectedError)
+    return t("run.invalidDeck", { reasons: e.reasons.join(" · ") });
+  if (e instanceof Error) return e.message;
+  return String(e);
+}
+
+interface RunnerCallbackDeps {
+  isCancelled: () => boolean;
+  seatMeta: SeatMeta[];
+  logIdRef: MutableRefObject<number>;
+  setBoard: Dispatch<SetStateAction<BoardView | null>>;
+  setCurrentMatch: Dispatch<SetStateAction<number>>;
+  setPassingTurn: Dispatch<SetStateAction<boolean>>;
+  setLogEntries: Dispatch<SetStateAction<LoggedEntry[]>>;
+  setResults: Dispatch<SetStateAction<MatchResult[]>>;
+  setHumanTurn: Dispatch<SetStateAction<HumanTurn | null>>;
+  setChosen: Dispatch<SetStateAction<TargetRef[]>>;
+  setTargeting: Dispatch<SetStateAction<TargetTurn | null>>;
+  setAttacks: Dispatch<SetStateAction<Map<number, AttackTargetRef>>>;
+  setSelectedAttacker: Dispatch<SetStateAction<number | null>>;
+  setAttacking: Dispatch<SetStateAction<AttackTurn | null>>;
+  setBlockAssign: Dispatch<SetStateAction<Map<number, number>>>;
+  setSelectedBlocker: Dispatch<SetStateAction<number | null>>;
+  setBlockingTurn: Dispatch<SetStateAction<BlockTurn | null>>;
+  setManaTurn: Dispatch<SetStateAction<ManaTurn | null>>;
+  setCreatureTypePick: Dispatch<SetStateAction<string>>;
+  setCreatureTypeTurn: Dispatch<SetStateAction<CreatureTypeTurn | null>>;
+  setBottomPick: Dispatch<SetStateAction<Set<number>>>;
+  setMulliganTurn: Dispatch<SetStateAction<MulliganTurn | null>>;
+  setDiscardPick: Dispatch<SetStateAction<Set<number>>>;
+  setDiscardTurn: Dispatch<SetStateAction<DiscardTurn | null>>;
+  setScryTurn: Dispatch<SetStateAction<ScryTurn | null>>;
+}
+
+function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
+  const {
+    isCancelled,
+    seatMeta,
+    logIdRef,
+    setBoard,
+    setCurrentMatch,
+    setPassingTurn,
+    setLogEntries,
+    setResults,
+    setHumanTurn,
+    setChosen,
+    setTargeting,
+    setAttacks,
+    setSelectedAttacker,
+    setAttacking,
+    setBlockAssign,
+    setSelectedBlocker,
+    setBlockingTurn,
+    setManaTurn,
+    setCreatureTypePick,
+    setCreatureTypeTurn,
+    setBottomPick,
+    setMulliganTurn,
+    setDiscardPick,
+    setDiscardTurn,
+    setScryTurn,
+  } = deps;
+  return {
+    onFrame: (env) => {
+      if (!isCancelled()) setBoard(toBoardView(env, seatMeta));
+    },
+    onMatchStart: (m) => {
+      if (!isCancelled()) {
+        setCurrentMatch(m);
+        setPassingTurn(false);
+        setLogEntries([]);
+      }
+    },
+    onMatchEnd: (r) => {
+      if (!isCancelled()) setResults((prev) => [...prev, r]);
+    },
+    onLogEntries: (entries: LogEntry[]) => {
+      if (isCancelled()) return;
+      const tagged = entries.map((entry) => ({
+        id: logIdRef.current++,
+        entry,
+      }));
+      setLogEntries((prev) => {
+        const next = prev.concat(tagged);
+        return next.length > 800 ? next.slice(next.length - 800) : next;
+      });
+    },
+    requestHumanAction: (env, legal) =>
+      new Promise<HumanChoice>((resolve) => {
+        if (isCancelled()) {
+          resolve({ ai: true });
+          return;
+        }
+        const st = env.state;
+        const stack = st.stack ?? [];
+        setHumanTurn({
+          legal,
+          myTurn: st.active_player === 0,
+          opponentActed: stack.some(
+            (id) => (st.objects?.[id]?.controller ?? -1) !== 0,
+          ),
+          manaPool: readManaPool(st.players?.[0]),
+          objects: st.objects ?? {},
+          resolve: (choice) => {
+            setHumanTurn(null);
+            resolve(choice);
+          },
+        });
+      }),
+    requestHumanTargets: (_env, prompt) =>
+      new Promise<HumanChoice>((resolve) => {
+        if (isCancelled()) {
+          resolve({ ai: true });
+          return;
+        }
+        setChosen([]);
+        setTargeting({
+          prompt,
+          resolve: (choice) => {
+            setTargeting(null);
+            setChosen([]);
+            resolve(choice);
+          },
+        });
+      }),
+    requestHumanAttackers: (_env, prompt) =>
+      new Promise<HumanChoice>((resolve) => {
+        if (isCancelled()) {
+          resolve({ ai: true });
+          return;
+        }
+        setAttacks(new Map());
+        setSelectedAttacker(null);
+        setAttacking({
+          prompt,
+          resolve: (choice) => {
+            setAttacking(null);
+            setAttacks(new Map());
+            setSelectedAttacker(null);
+            resolve(choice);
+          },
+        });
+      }),
+    requestHumanBlockers: (_env, prompt) =>
+      new Promise<HumanChoice>((resolve) => {
+        if (isCancelled()) {
+          resolve({ ai: true });
+          return;
+        }
+        setBlockAssign(new Map());
+        setSelectedBlocker(null);
+        setBlockingTurn({
+          prompt,
+          resolve: (choice) => {
+            setBlockingTurn(null);
+            setBlockAssign(new Map());
+            setSelectedBlocker(null);
+            resolve(choice);
+          },
+        });
+      }),
+    requestHumanMana: (_env, prompt) =>
+      new Promise<HumanChoice>((resolve) => {
+        if (isCancelled()) {
+          resolve({ ai: true });
+          return;
+        }
+        setManaTurn({
+          prompt,
+          resolve: (choice) => {
+            setManaTurn(null);
+            resolve(choice);
+          },
+        });
+      }),
+    requestHumanCreatureType: (_env, prompt) =>
+      new Promise<HumanChoice>((resolve) => {
+        if (isCancelled()) {
+          resolve({ ai: true });
+          return;
+        }
+        setCreatureTypePick(prompt.aiChoice ?? prompt.options[0] ?? "");
+        setCreatureTypeTurn({
+          prompt,
+          resolve: (choice) => {
+            setCreatureTypeTurn(null);
+            resolve(choice);
+          },
+        });
+      }),
+    requestHumanMulligan: (_env, prompt) =>
+      new Promise<HumanChoice>((resolve) => {
+        if (isCancelled()) {
+          resolve({ ai: true });
+          return;
+        }
+        setBottomPick(new Set());
+        setMulliganTurn({
+          prompt,
+          resolve: (choice) => {
+            setMulliganTurn(null);
+            setBottomPick(new Set());
+            resolve(choice);
+          },
+        });
+      }),
+    requestHumanDiscard: (_env, prompt) =>
+      new Promise<HumanChoice>((resolve) => {
+        if (isCancelled()) {
+          resolve({ ai: true });
+          return;
+        }
+        setDiscardPick(new Set());
+        setDiscardTurn({
+          prompt,
+          resolve: (choice) => {
+            setDiscardTurn(null);
+            setDiscardPick(new Set());
+            resolve(choice);
+          },
+        });
+      }),
+    requestHumanScry: (_env, prompt) =>
+      new Promise<HumanChoice>((resolve) => {
+        if (isCancelled()) {
+          resolve({ ai: true });
+          return;
+        }
+        setScryTurn({
+          prompt,
+          resolve: (choice) => {
+            setScryTurn(null);
+            resolve(choice);
+          },
+        });
+      }),
+  };
+}
+
+/** Traps Tab focus inside a modal and restores focus to the opener on close. */
+function useFocusTrap(modalRef: RefObject<HTMLDivElement>) {
+  useEffect(() => {
+    const node = modalRef.current;
+    if (!node) return;
+    const prev = document.activeElement as HTMLElement | null;
+    const focusable = () =>
+      [
+        ...node.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        ),
+      ];
+    focusable()[0]?.focus();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Tab") return;
+      const els = focusable();
+      if (els.length === 0) return;
+      const first = els[0];
+      const last = els[els.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+    node.addEventListener("keydown", onKey);
+    return () => {
+      node.removeEventListener("keydown", onKey);
+      prev?.focus?.();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}
+
 /** Runs a configured series of matches and renders the live board + results. */
 export function RunView({
   config,
@@ -321,183 +706,33 @@ export function RunView({
             revealHands: config.revealHands,
             paceMs: PACE_MS.normal,
           },
-          {
-            onFrame: (env) => {
-              if (!cancelled) setBoard(toBoardView(env, seatMeta));
-            },
-            onMatchStart: (m) => {
-              if (!cancelled) {
-                setCurrentMatch(m);
-                setPassingTurn(false);
-                setLogEntries([]);
-              }
-            },
-            onMatchEnd: (r) => {
-              if (!cancelled) setResults((prev) => [...prev, r]);
-            },
-            onLogEntries: (entries: LogEntry[]) => {
-              if (cancelled) return;
-              const tagged = entries.map((entry) => ({
-                id: logIdRef.current++,
-                entry,
-              }));
-              setLogEntries((prev) => {
-                const next = prev.concat(tagged);
-                return next.length > 800
-                  ? next.slice(next.length - 800)
-                  : next;
-              });
-            },
-            requestHumanAction: (env, legal) =>
-              new Promise<HumanChoice>((resolve) => {
-                if (cancelled) {
-                  resolve({ ai: true });
-                  return;
-                }
-                const st = env.state;
-                const stack = st.stack ?? [];
-                setHumanTurn({
-                  legal,
-                  myTurn: st.active_player === 0,
-                  opponentActed: stack.some(
-                    (id) => (st.objects?.[id]?.controller ?? -1) !== 0,
-                  ),
-                  manaPool: readManaPool(st.players?.[0]),
-                  objects: st.objects ?? {},
-                  resolve: (choice) => {
-                    setHumanTurn(null);
-                    resolve(choice);
-                  },
-                });
-              }),
-            requestHumanTargets: (_env, prompt) =>
-              new Promise<HumanChoice>((resolve) => {
-                if (cancelled) {
-                  resolve({ ai: true });
-                  return;
-                }
-                setChosen([]);
-                setTargeting({
-                  prompt,
-                  resolve: (choice) => {
-                    setTargeting(null);
-                    setChosen([]);
-                    resolve(choice);
-                  },
-                });
-              }),
-            requestHumanAttackers: (_env, prompt) =>
-              new Promise<HumanChoice>((resolve) => {
-                if (cancelled) {
-                  resolve({ ai: true });
-                  return;
-                }
-                setAttacks(new Map());
-                setSelectedAttacker(null);
-                setAttacking({
-                  prompt,
-                  resolve: (choice) => {
-                    setAttacking(null);
-                    setAttacks(new Map());
-                    setSelectedAttacker(null);
-                    resolve(choice);
-                  },
-                });
-              }),
-            requestHumanBlockers: (_env, prompt) =>
-              new Promise<HumanChoice>((resolve) => {
-                if (cancelled) {
-                  resolve({ ai: true });
-                  return;
-                }
-                setBlockAssign(new Map());
-                setSelectedBlocker(null);
-                setBlockingTurn({
-                  prompt,
-                  resolve: (choice) => {
-                    setBlockingTurn(null);
-                    setBlockAssign(new Map());
-                    setSelectedBlocker(null);
-                    resolve(choice);
-                  },
-                });
-              }),
-            requestHumanMana: (_env, prompt) =>
-              new Promise<HumanChoice>((resolve) => {
-                if (cancelled) {
-                  resolve({ ai: true });
-                  return;
-                }
-                setManaTurn({
-                  prompt,
-                  resolve: (choice) => {
-                    setManaTurn(null);
-                    resolve(choice);
-                  },
-                });
-              }),
-            requestHumanCreatureType: (_env, prompt) =>
-              new Promise<HumanChoice>((resolve) => {
-                if (cancelled) {
-                  resolve({ ai: true });
-                  return;
-                }
-                setCreatureTypePick(prompt.aiChoice ?? prompt.options[0] ?? "");
-                setCreatureTypeTurn({
-                  prompt,
-                  resolve: (choice) => {
-                    setCreatureTypeTurn(null);
-                    resolve(choice);
-                  },
-                });
-              }),
-            requestHumanMulligan: (_env, prompt) =>
-              new Promise<HumanChoice>((resolve) => {
-                if (cancelled) {
-                  resolve({ ai: true });
-                  return;
-                }
-                setBottomPick(new Set());
-                setMulliganTurn({
-                  prompt,
-                  resolve: (choice) => {
-                    setMulliganTurn(null);
-                    setBottomPick(new Set());
-                    resolve(choice);
-                  },
-                });
-              }),
-            requestHumanDiscard: (_env, prompt) =>
-              new Promise<HumanChoice>((resolve) => {
-                if (cancelled) {
-                  resolve({ ai: true });
-                  return;
-                }
-                setDiscardPick(new Set());
-                setDiscardTurn({
-                  prompt,
-                  resolve: (choice) => {
-                    setDiscardTurn(null);
-                    setDiscardPick(new Set());
-                    resolve(choice);
-                  },
-                });
-              }),
-            requestHumanScry: (_env, prompt) =>
-              new Promise<HumanChoice>((resolve) => {
-                if (cancelled) {
-                  resolve({ ai: true });
-                  return;
-                }
-                setScryTurn({
-                  prompt,
-                  resolve: (choice) => {
-                    setScryTurn(null);
-                    resolve(choice);
-                  },
-                });
-              }),
-          },
+          buildRunnerCallbacks({
+            isCancelled: () => cancelled,
+            seatMeta,
+            logIdRef,
+            setBoard,
+            setCurrentMatch,
+            setPassingTurn,
+            setLogEntries,
+            setResults,
+            setHumanTurn,
+            setChosen,
+            setTargeting,
+            setAttacks,
+            setSelectedAttacker,
+            setAttacking,
+            setBlockAssign,
+            setSelectedBlocker,
+            setBlockingTurn,
+            setManaTurn,
+            setCreatureTypePick,
+            setCreatureTypeTurn,
+            setBottomPick,
+            setMulliganTurn,
+            setDiscardPick,
+            setDiscardTurn,
+            setScryTurn,
+          }),
         );
         runnerRef.current = runner;
         setPhase("running");
@@ -506,13 +741,7 @@ export function RunView({
       } catch (e) {
         if (!cancelled) {
           setPhase("error");
-          setMessage(
-            e instanceof DeckRejectedError
-              ? t("run.invalidDeck", { reasons: e.reasons.join(" · ") })
-              : e instanceof Error
-                ? e.message
-                : String(e),
-          );
+          setMessage(describeRunError(e, t));
         }
       }
     })();
@@ -720,33 +949,16 @@ export function RunView({
       : Math.min(chosen.length, prompt.slots.length - 1);
     const pool = prompt.slots[slotIdx]?.legalTargets ?? [];
 
-    const chosenObjIds = new Set<number>();
-    const chosenSeats = new Set<number>();
-    for (const tr of chosen) {
-      if ("Object" in tr) chosenObjIds.add(tr.Object);
-      else chosenSeats.add(tr.Player);
-    }
+    const { chosenObjIds, chosenSeats } = partitionChosenRefs(chosen);
+    const { objectIds, playerSeats } = partitionTargetPool(
+      pool,
+      prompt.multi,
+      chosenObjIds,
+      chosenSeats,
+    );
 
-    const objectIds = new Set<number>();
-    const playerSeats = new Set<number>();
-    for (const tr of pool) {
-      if ("Object" in tr) {
-        if (prompt.multi && chosenObjIds.has(tr.Object)) continue;
-        objectIds.add(tr.Object);
-      } else {
-        if (prompt.multi && chosenSeats.has(tr.Player)) continue;
-        playerSeats.add(tr.Player);
-      }
-    }
-
-    const pick = (ref: TargetRef) => {
-      const next = [...chosen, ref];
-      const done = prompt.multi
-        ? next.length >= prompt.max
-        : next.length >= prompt.slots.length;
-      if (done) targeting.resolve({ action: selectTargetsAction(next) });
-      else setChosen(next);
-    };
+    const pick = (ref: TargetRef) =>
+      resolveTargetPick(targeting, chosen, ref, setChosen);
 
     return {
       objectIds,
@@ -758,13 +970,7 @@ export function RunView({
     };
   }, [targeting, chosen]);
 
-  const targetOptional = targeting
-    ? targeting.prompt.multi
-      ? targeting.prompt.min === 0
-      : (targeting.prompt.slots[
-          Math.min(chosen.length, targeting.prompt.slots.length - 1)
-        ]?.optional ?? false)
-    : false;
+  const targetOptional = isTargetOptional(targeting, chosen);
   const canConfirmMulti =
     !!targeting && targeting.prompt.multi && chosen.length >= targeting.prompt.min;
 
@@ -987,33 +1193,7 @@ export function RunView({
         <section className="panel play-controls">
           <div className="panel__head">
             <h2 className="match-status">
-              {board.gameOver ? (
-                board.winner === null ? (
-                  t("board.draw")
-                ) : (
-                  t("board.winner", {
-                    name:
-                      board.seats[board.winner]?.name ||
-                      t("board.player", { n: board.winner + 1 }),
-                  })
-                )
-              ) : (
-                <>
-                  <span className="match-status__turn">
-                    {t("board.turn", { n: board.turn })}
-                  </span>
-                  <span className="match-status__phase">
-                    {phaseLabel(lang, board.phase)}
-                  </span>
-                  <span className="match-status__active">
-                    {t("board.activeTurn", {
-                      name:
-                        board.seats[board.activePlayer]?.name ||
-                        t("board.player", { n: board.activePlayer + 1 }),
-                    })}
-                  </span>
-                </>
-              )}
+              <MatchStatusHeading board={board} />
             </h2>
             {humanTurn && !compact && (
               <span className="hint">
@@ -1506,37 +1686,7 @@ function MulliganModal({
   const modalRef = useRef<HTMLDivElement>(null);
 
   // Move focus into the dialog, trap Tab within it, and restore focus on close.
-  useEffect(() => {
-    const node = modalRef.current;
-    if (!node) return;
-    const prev = document.activeElement as HTMLElement | null;
-    const focusable = () =>
-      [
-        ...node.querySelectorAll<HTMLElement>(
-          'button:not([disabled]), [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
-        ),
-      ];
-    focusable()[0]?.focus();
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key !== "Tab") return;
-      const els = focusable();
-      if (els.length === 0) return;
-      const first = els[0];
-      const last = els[els.length - 1];
-      if (e.shiftKey && document.activeElement === first) {
-        e.preventDefault();
-        last.focus();
-      } else if (!e.shiftKey && document.activeElement === last) {
-        e.preventDefault();
-        first.focus();
-      }
-    };
-    node.addEventListener("keydown", onKey);
-    return () => {
-      node.removeEventListener("keydown", onKey);
-      prev?.focus?.();
-    };
-  }, []);
+  useFocusTrap(modalRef);
 
   const { cardProps, overlay } = useCardPreview({
     images,
@@ -1544,21 +1694,24 @@ function MulliganModal({
     onToggle: onToggleBottom,
   });
 
+  let instruction: string;
+  if (bottoming) {
+    instruction = t("mulligan.bottomInstruction", { n: prompt.bottomCount });
+  } else if (prompt.mulliganCount === 0 && prompt.freeFirstMulligan) {
+    instruction = t("mulligan.freeHint", { n: prompt.nextKeepSize });
+  } else {
+    instruction = t("mulligan.takenHint", {
+      n: prompt.mulliganCount,
+      keep: prompt.keepSize,
+    });
+  }
+
   return (
     <div className="mull-overlay" role="dialog" aria-modal="true" aria-labelledby="mull-title">
       <div className="mull-modal" ref={modalRef}>
         <div className="mull-modal__head">
           <h2 id="mull-title">{bottoming ? t("mulligan.bottomTitle") : t("mulligan.title")}</h2>
-          <p className="hint">
-            {bottoming
-              ? t("mulligan.bottomInstruction", { n: prompt.bottomCount })
-              : prompt.mulliganCount === 0 && prompt.freeFirstMulligan
-                ? t("mulligan.freeHint", { n: prompt.nextKeepSize })
-                : t("mulligan.takenHint", {
-                    n: prompt.mulliganCount,
-                    keep: prompt.keepSize,
-                  })}
-          </p>
+          <p className="hint">{instruction}</p>
         </div>
 
         <div className="mull-hand">
@@ -1651,37 +1804,7 @@ function DiscardModal({
   const modalRef = useRef<HTMLDivElement>(null);
 
   // Move focus into the dialog, trap Tab within it, and restore focus on close.
-  useEffect(() => {
-    const node = modalRef.current;
-    if (!node) return;
-    const prev = document.activeElement as HTMLElement | null;
-    const focusable = () =>
-      [
-        ...node.querySelectorAll<HTMLElement>(
-          'button:not([disabled]), [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
-        ),
-      ];
-    focusable()[0]?.focus();
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key !== "Tab") return;
-      const els = focusable();
-      if (els.length === 0) return;
-      const first = els[0];
-      const last = els[els.length - 1];
-      if (e.shiftKey && document.activeElement === first) {
-        e.preventDefault();
-        last.focus();
-      } else if (!e.shiftKey && document.activeElement === last) {
-        e.preventDefault();
-        first.focus();
-      }
-    };
-    node.addEventListener("keydown", onKey);
-    return () => {
-      node.removeEventListener("keydown", onKey);
-      prev?.focus?.();
-    };
-  }, []);
+  useFocusTrap(modalRef);
 
   const { cardProps, overlay } = useCardPreview({
     images,
@@ -1883,20 +2006,20 @@ function RunReport({
           </tr>
         </thead>
         <tbody>
-          {results.map((r) => (
-            <tr key={r.matchIndex}>
-              <td>{r.matchIndex + 1}</td>
-              <td>
-                {r.stopped
-                  ? "—"
-                  : r.winner === null
-                    ? t("board.draw")
-                    : seatName(r.winner)}
-              </td>
-              <td>{r.turns}</td>
-              <td>{r.seconds.toFixed(0)}s</td>
-            </tr>
-          ))}
+          {results.map((r) => {
+            let winnerLabel: string;
+            if (r.stopped) winnerLabel = "—";
+            else if (r.winner === null) winnerLabel = t("board.draw");
+            else winnerLabel = seatName(r.winner);
+            return (
+              <tr key={r.matchIndex}>
+                <td>{r.matchIndex + 1}</td>
+                <td>{winnerLabel}</td>
+                <td>{r.turns}</td>
+                <td>{r.seconds.toFixed(0)}s</td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </section>

--- a/src/match/useCardPreview.tsx
+++ b/src/match/useCardPreview.tsx
@@ -67,22 +67,33 @@ export function useCardPreview({
     else if (!canHover) setZoomed(c);
   };
 
+  const hoverHandlers = (c: PickCard) => ({
+    onMouseEnter: (e: MouseEvent) =>
+      setPreview(previewFor(c, e.currentTarget.getBoundingClientRect())),
+    onMouseLeave: () => setPreview(null),
+    onFocus: (e: FocusEvent) =>
+      setPreview(previewFor(c, e.currentTarget.getBoundingClientRect())),
+    onBlur: () => setPreview(null),
+  });
+
+  const touchHandlers = (c: PickCard) => ({
+    onTouchStart: () => startLongPress(c),
+    onTouchEnd: cancelLongPress,
+    onTouchMove: cancelLongPress,
+    onContextMenu: (e: MouseEvent) => e.preventDefault(),
+  });
+
   const cardProps = (c: PickCard) => ({
     onClick: () => onCardClick(c),
-    onMouseEnter: canHover
-      ? (e: MouseEvent) =>
-          setPreview(previewFor(c, e.currentTarget.getBoundingClientRect()))
-      : undefined,
-    onMouseLeave: canHover ? () => setPreview(null) : undefined,
-    onFocus: canHover
-      ? (e: FocusEvent) =>
-          setPreview(previewFor(c, e.currentTarget.getBoundingClientRect()))
-      : undefined,
-    onBlur: canHover ? () => setPreview(null) : undefined,
-    onTouchStart: canHover ? undefined : () => startLongPress(c),
-    onTouchEnd: canHover ? undefined : cancelLongPress,
-    onTouchMove: canHover ? undefined : cancelLongPress,
-    onContextMenu: canHover ? undefined : (e: MouseEvent) => e.preventDefault(),
+    onMouseEnter: undefined,
+    onMouseLeave: undefined,
+    onFocus: undefined,
+    onBlur: undefined,
+    onTouchStart: undefined,
+    onTouchEnd: undefined,
+    onTouchMove: undefined,
+    onContextMenu: undefined,
+    ...(canHover ? hoverHandlers(c) : touchHandlers(c)),
   });
 
   const overlay = (

--- a/src/settings/SettingsMenu.tsx
+++ b/src/settings/SettingsMenu.tsx
@@ -2,15 +2,6 @@ import { useEffect, useRef, useState } from "react";
 import { useI18n } from "../i18n/I18nContext";
 import { useSettings } from "./SettingsContext";
 
-function GearGlyph({ size = 14 }: { size?: number }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-      <path d="M12 8a4 4 0 100 8 4 4 0 000-8zm0 2.4a1.6 1.6 0 110 3.2 1.6 1.6 0 010-3.2z" />
-      <path d="M10.6 2h2.8l.5 2.3a7.6 7.6 0 011.8.75l2-1.2 2 2-1.2 2c.32.56.57 1.16.75 1.8L23 12v.8l-2.3.5c-.18.64-.43 1.24-.75 1.8l1.2 2-2 2-2-1.2c-.56.32-1.16.57-1.8.75L13.4 22h-2.8l-.5-2.3a7.6 7.6 0 01-1.8-.75l-2 1.2-2-2 1.2-2a7.6 7.6 0 01-.75-1.8L1 12.8V12l2.3-.5c.18-.64.43-1.24.75-1.8l-1.2-2 2-2 2 1.2c.56-.32 1.16-.57 1.8-.75L10.6 2z" opacity="0.55" />
-    </svg>
-  );
-}
-
 /** XP taskbar settings popup: beveled button opening a small menu upward. */
 export function SettingsMenu() {
   const { t } = useI18n();
@@ -46,7 +37,6 @@ export function SettingsMenu() {
         aria-expanded={open}
         aria-label={t("settings.title")}
       >
-        <GearGlyph />
         {t("settings.title")}
         <span className="xp-lang__caret" aria-hidden>
           {open ? "▾" : "▴"}
@@ -61,9 +51,7 @@ export function SettingsMenu() {
             className="xp-settings__item"
             onClick={() => setManualMana(!settings.manualMana)}
           >
-            <span className="xp-settings__check" aria-hidden>
-              {settings.manualMana ? "☑" : "☐"}
-            </span>
+            <span className="xp-settings__check" aria-hidden />
             <span className="xp-settings__text">
               <span className="xp-settings__label">{t("settings.manualMana")}</span>
               <span className="xp-settings__desc">{t("settings.manualManaDesc")}</span>

--- a/src/sim/decisions/abilities.ts
+++ b/src/sim/decisions/abilities.ts
@@ -2,7 +2,7 @@
 // `{ type: "ActivateAbility", data: { source_id, ability_index } }`. We group
 // them by the permanent that owns them so the board can offer click-to-activate.
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-explicit-any, sonarjs/redundant-type-aliases */
 
 export type LegalAction = any;
 

--- a/src/sim/decisions/attackers.ts
+++ b/src/sim/decisions/attackers.ts
@@ -5,7 +5,7 @@
 
 import type { GameObject, WaitingFor } from "../../engine/types";
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-explicit-any, sonarjs/redundant-type-aliases */
 
 // The vendored engine lists creatures with Defender in `valid_attacker_ids`
 // regardless of the keyword, so we drop them here — a Defender creature is

--- a/src/sim/decisions/creatureType.test.ts
+++ b/src/sim/decisions/creatureType.test.ts
@@ -33,7 +33,7 @@ describe("parseCreatureTypePrompt", () => {
     expect(p.player).toBe(1);
     expect(p.sourceName).toBe("Secluded Courtyard");
     expect(p.options).toContain("Elf");
-    expect(p.options.length).toBe(5);
+    expect(p.options).toHaveLength(5);
   });
 
   it("also matches a constrained (object) CreatureType choice_type", () => {

--- a/src/sim/driver.ts
+++ b/src/sim/driver.ts
@@ -50,6 +50,24 @@ export interface LegalActions {
 /** A human's choice at a priority window: play an action, or let the AI act. */
 export type HumanChoice = { action: unknown } | { ai: true };
 
+/** A pending request for one human decision: run it to get the human's choice. */
+type HumanRequest = () => Promise<HumanChoice>;
+
+/** One play-loop step: keep going, or end the match with this winner/stopped. */
+type StepOutcome =
+  | { done: false }
+  | { done: true; winner: number | null; stopped: boolean };
+
+/** Pair a decision callback with its parsed prompt into a request, or null. */
+function humanRequest<P>(
+  env: GameStateEnvelope,
+  cb: ((env: GameStateEnvelope, prompt: P) => Promise<HumanChoice>) | undefined,
+  prompt: P | null,
+): HumanRequest | null {
+  if (!cb || prompt == null) return null;
+  return () => cb(env, prompt);
+}
+
 /** A single legal target: an object on the board, or a player seat. */
 export type TargetRef = { Object: number } | { Player: number };
 
@@ -395,127 +413,11 @@ export class MatchRunner {
         break;
       }
 
-      const acting = actingPlayer(wf);
-      const humanNonPriority = acting === humanSeat && wf?.type !== "Priority";
-      const humanPriority =
-        acting === humanSeat && wf?.type === "Priority" && !!cb.requestHumanAction;
-      const humanTargets =
-        humanNonPriority && cb.requestHumanTargets ? parseTargetPrompt(wf) : null;
-      const humanAttackers =
-        humanNonPriority && cb.requestHumanAttackers
-          ? parseAttackersPrompt(wf, env.state.objects)
-          : null;
-      const humanBlockers =
-        humanNonPriority && cb.requestHumanBlockers
-          ? parseBlockersPrompt(wf)
-          : null;
-      const humanMana =
-        humanNonPriority && cb.requestHumanMana ? parseManaPrompt(wf) : null;
-      const humanCreatureType =
-        humanNonPriority && cb.requestHumanCreatureType
-          ? parseCreatureTypePrompt(wf)
-          : null;
-      const humanMulligan =
-        humanNonPriority && cb.requestHumanMulligan
-          ? parseMulliganPrompt(wf, env.state, humanSeat)
-          : null;
-      const humanDiscard =
-        humanNonPriority && cb.requestHumanDiscard
-          ? parseDiscardPrompt(wf, env.state, humanSeat)
-          : null;
-      const humanScry =
-        humanNonPriority && cb.requestHumanScry
-          ? parseScryPrompt(wf, env.state, humanSeat)
-          : null;
-
-      // Run the human's choice: play their action, or hand this decision to the AI.
-      const applyChoice = async (choice: HumanChoice): Promise<void> => {
-        const res =
-          "action" in choice
-            ? await engine.humanAction(humanSeat, choice.action)
-            : await engine.aiStep(opts.difficulty, humanSeat, false);
-        this.emitLog(res);
-      };
-
-      if (humanPriority) {
-        const legal: LegalActions = await engine.legalActions();
-        const choice = await cb.requestHumanAction!(env, legal);
-        if (this.aborted) {
-          stopped = true;
-          break;
-        }
-        await applyChoice(choice);
-      } else if (humanTargets) {
-        const choice = await cb.requestHumanTargets!(env, humanTargets);
-        if (this.aborted) {
-          stopped = true;
-          break;
-        }
-        await applyChoice(choice);
-      } else if (humanAttackers) {
-        const choice = await cb.requestHumanAttackers!(env, humanAttackers);
-        if (this.aborted) {
-          stopped = true;
-          break;
-        }
-        await applyChoice(choice);
-      } else if (humanBlockers) {
-        const choice = await cb.requestHumanBlockers!(env, humanBlockers);
-        if (this.aborted) {
-          stopped = true;
-          break;
-        }
-        await applyChoice(choice);
-      } else if (humanMana) {
-        const choice = await cb.requestHumanMana!(env, humanMana);
-        if (this.aborted) {
-          stopped = true;
-          break;
-        }
-        await applyChoice(choice);
-      } else if (humanCreatureType) {
-        const hint = await engine.aiProposal(opts.difficulty, humanSeat);
-        const suggested = hint?.action?.data?.choice;
-        const choice = await cb.requestHumanCreatureType!(env, {
-          ...humanCreatureType,
-          aiChoice: typeof suggested === "string" ? suggested : null,
-        });
-        if (this.aborted) {
-          stopped = true;
-          break;
-        }
-        await applyChoice(choice);
-      } else if (humanMulligan) {
-        const choice = await cb.requestHumanMulligan!(env, humanMulligan);
-        if (this.aborted) {
-          stopped = true;
-          break;
-        }
-        await applyChoice(choice);
-      } else if (humanDiscard) {
-        const choice = await cb.requestHumanDiscard!(env, humanDiscard);
-        if (this.aborted) {
-          stopped = true;
-          break;
-        }
-        await applyChoice(choice);
-      } else if (humanScry) {
-        const choice = await cb.requestHumanScry!(env, humanScry);
-        if (this.aborted) {
-          stopped = true;
-          break;
-        }
-        await applyChoice(choice);
-      } else {
-        // AI seats, and the human's non-priority sub-decisions, are AI-driven.
-        const res = await engine.aiStep(opts.difficulty, acting, false);
-        this.emitLog(res);
-        if (!res.applied) {
-          const wf2 = res.state?.state.waiting_for;
-          if (wf2?.type === "GameOver") winner = wf2.data?.winner ?? null;
-          else stopped = true;
-          break;
-        }
+      const outcome = await this.playStep(env, wf, humanSeat);
+      if (outcome.done) {
+        winner = outcome.winner;
+        stopped = outcome.stopped;
+        break;
       }
     }
 
@@ -526,6 +428,127 @@ export class MatchRunner {
       actions,
       stopped,
       seconds: (performance.now() - t0) / 1000,
+    };
+  }
+
+  /** Advance one action: run the human's decision if they own it, else the AI. */
+  private async playStep(
+    env: GameStateEnvelope,
+    wf: WaitingFor | undefined,
+    humanSeat: number,
+  ): Promise<StepOutcome> {
+    const { engine, opts } = this;
+    const acting = actingPlayer(wf);
+    const request = this.humanRequestFor(env, wf, humanSeat, acting);
+
+    if (request) {
+      const choice = await request();
+      if (this.aborted) return { done: true, winner: null, stopped: true };
+      await this.applyHumanChoice(humanSeat, choice);
+      return { done: false };
+    }
+
+    // AI seats, and the human's non-priority sub-decisions, are AI-driven.
+    const res = await engine.aiStep(opts.difficulty, acting, false);
+    this.emitLog(res);
+    if (res.applied) return { done: false };
+    const wf2 = res.state?.state.waiting_for;
+    const over = wf2?.type === "GameOver";
+    return { done: true, winner: over ? (wf2?.data?.winner ?? null) : null, stopped: !over };
+  }
+
+  /** Play the human's chosen action, or let the AI act if they deferred. */
+  private async applyHumanChoice(
+    humanSeat: number,
+    choice: HumanChoice,
+  ): Promise<void> {
+    const { engine, opts } = this;
+    const res =
+      "action" in choice
+        ? await engine.humanAction(humanSeat, choice.action)
+        : await engine.aiStep(opts.difficulty, humanSeat, false);
+    this.emitLog(res);
+  }
+
+  /** The request for whatever decision the human owns right now, or null for AI. */
+  private humanRequestFor(
+    env: GameStateEnvelope,
+    wf: WaitingFor | undefined,
+    humanSeat: number,
+    acting: number | null,
+  ): HumanRequest | null {
+    const { engine, cb } = this;
+    const isHuman = acting === humanSeat;
+    if (isHuman && wf?.type === "Priority") {
+      if (!cb.requestHumanAction) return null;
+      return async () => cb.requestHumanAction!(env, await engine.legalActions());
+    }
+    if (!isHuman || wf?.type === "Priority") return null;
+    return this.nonPriorityRequest(env, wf, humanSeat);
+  }
+
+  /** Match a human non-priority sub-decision (targets, combat, mulligan, …). */
+  private nonPriorityRequest(
+    env: GameStateEnvelope,
+    wf: WaitingFor | undefined,
+    humanSeat: number,
+  ): HumanRequest | null {
+    const { cb } = this;
+    const state = env.state;
+    const resolvers: Array<() => HumanRequest | null> = [
+      () => humanRequest(env, cb.requestHumanTargets, parseTargetPrompt(wf)),
+      () =>
+        humanRequest(
+          env,
+          cb.requestHumanAttackers,
+          parseAttackersPrompt(wf, state.objects),
+        ),
+      () => humanRequest(env, cb.requestHumanBlockers, parseBlockersPrompt(wf)),
+      () => humanRequest(env, cb.requestHumanMana, parseManaPrompt(wf)),
+      () => this.creatureTypeRequest(env, wf, humanSeat),
+      () =>
+        humanRequest(
+          env,
+          cb.requestHumanMulligan,
+          parseMulliganPrompt(wf, state, humanSeat),
+        ),
+      () =>
+        humanRequest(
+          env,
+          cb.requestHumanDiscard,
+          parseDiscardPrompt(wf, state, humanSeat),
+        ),
+      () =>
+        humanRequest(
+          env,
+          cb.requestHumanScry,
+          parseScryPrompt(wf, state, humanSeat),
+        ),
+    ];
+    for (const resolve of resolvers) {
+      const req = resolve();
+      if (req) return req;
+    }
+    return null;
+  }
+
+  /** Creature-type choice: seed the human prompt with the AI's suggested pick. */
+  private creatureTypeRequest(
+    env: GameStateEnvelope,
+    wf: WaitingFor | undefined,
+    humanSeat: number,
+  ): HumanRequest | null {
+    const { engine, opts, cb } = this;
+    if (!cb.requestHumanCreatureType) return null;
+    const prompt = parseCreatureTypePrompt(wf);
+    if (!prompt) return null;
+    return async () => {
+      const hint = await engine.aiProposal(opts.difficulty, humanSeat);
+      const suggested = hint?.action?.data?.choice;
+      return cb.requestHumanCreatureType!(env, {
+        ...prompt,
+        aiChoice: typeof suggested === "string" ? suggested : null,
+      });
     };
   }
 }


### PR DESCRIPTION
## What

Adds **eslint-plugin-sonarjs** (`4.2.0`, ESLint 9-compatible) to the flat config using its `recommended` set, scoped to `**/*.{ts,tsx}` and running **as errors**. Since `npm run lint` is a blocking CI step, this required clearing the 47 pre-existing findings the recommended set surfaced — so the tree stays green.

Also carries a small standalone commit that draws the settings checkbox in CSS (beveled XP box) and drops the gear glyph, migrated from in-progress work.

## Why

Bring SonarJS's code-quality rules into the lint gate to catch cognitive-complexity, backtracking-prone regexes, duplicated logic, and deep nesting going forward.

## The 47 findings, by area

- **Super-linear / over-complex regexes** (`lib/cardName.ts`, `lib/decklist.ts`) — rewrote patterns to remove quantifier ambiguity (empty-collector adjacency, `\s*`/`.*` overlap, pathological bracket runs) and split an over-complex header alternation. Behavior preserved.
- **Cognitive complexity** — extracted self-explaining helpers. Notably `sim/driver.ts` `playLoop` went from **80 → ≤15** by collapsing a 9-branch human-decision dispatch into a data-driven request resolver (`humanRequestFor` / `nonPriorityRequest` / `playStep`).
- **`sim/lib` logic** — `goldfish.ts` (`bottomCards`, `simulateGame`) split into named helpers.
- **UI** (`App.tsx`, `board/Board.tsx`, `match/RunView.tsx`, `match/useCardPreview.tsx`) — component/helper extraction, nested-ternary and nested-function flattening, a shared `classList` helper, and a deduped `useFocusTrap` hook.
- **Smaller rules** — redundant type aliases (intentional engine-glue `any`, added to the existing file-level disable), single-boolean-return, test assertions.

## Verification

- `eslint .` — clean
- `tsc -b --noEmit` — clean
- `vitest run` — 130 pass / 2 skipped (matches baseline)
- `vite build` — succeeds
- **Browser smoke test** of a full piloted match (setup → mulligan → board → priority loop → action apply) with zero console errors — the UI/driver refactors have no unit coverage, so this exercises them end to end.

## Notes for reviewers

- All refactors are **behavior-preserving**; no domain behavior changed. The commit carries a `Skip-Docs:` trailer, accepted by the `domainbook check` gate.
- The `RunView.tsx` change is the largest: the `MatchRunner` callbacks object was hoisted to a module-level factory with an `isCancelled()` getter (read live, no stale capture) to satisfy `no-nested-functions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
