### PR TITLE
Add a visible exile zone per seat, like the graveyard

### DIFF
--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,6 +12,13 @@ depth live there. A purely-internal PR that touches no product or architecture m
 skip its version with a `Skip-Docs: <reason>` trailer instead. There are no
 per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
+## [0.4.11] - 2026-08-28
+
+### Added
+
+- A visible exile zone per seat, opened the same way as the graveyard
+  (`inspect-an-exile-zone`).
+
 ## [0.4.10] - 2026-08-25
 
 ### Changed

--- a/domainbook/domains/board/features/inspect-an-exile-zone.md
+++ b/domainbook/domains/board/features/inspect-an-exile-zone.md
@@ -1,0 +1,72 @@
+---
+id: inspect-an-exile-zone
+name: Inspect an exile zone
+status: implemented
+---
+
+## Story
+
+As a player
+I want to open any seat's exile zone and read the cards in it
+So that I can check what has been exiled without leaving the board
+
+## Rule: The exile count is a button when the exile zone is not empty
+
+```gherkin
+Example: A filled exile zone invites a click
+  Given a seat with at least one exiled card
+  When I look at that seat's zone counts
+  Then the exile count is a button
+  And clicking it opens that seat's exile zone
+
+Example: An empty exile zone is just a number
+  Given a seat with no exiled cards
+  Then its exile count is plain text, not a button
+```
+
+## Rule: Each seat sees only its own cards, split from the engine's one shared zone
+
+```gherkin
+Example: Exile is one zone, shown per seat
+  Given the engine tracks exile as a single shared zone
+  When the board projects it
+  Then each seat's exile count and window show only the cards that seat owns
+```
+
+## Rule: The exile zone opens in a floating window, same as the graveyard
+
+```gherkin
+Example: One row of cards, titled by owner
+  Given I open a seat's exile zone
+  Then a floating window shows the exiled cards in a single row
+  And the window is titled with the seat's name
+  And a row wider than the window scrolls sideways
+
+Example: Move it out of the way
+  Given the exile window is open
+  When I hold its title bar and drag
+  Then the window follows the pointer and stays within the screen
+
+Example: Dismiss it
+  Given the exile window is open
+  When I click its close button or press Escape
+  Then the window disappears
+
+Example: Read a card up close
+  Given the exile window is open
+  When I hover a card in it
+  Then an enlarged preview of that card is shown, above the window
+```
+
+## Rule: Exiled cards are shown untapped
+
+```gherkin
+Example: A creature that was tapped when it left the battlefield lies flat in exile
+  Given a card that was tapped when it was exiled
+  When I view it in the exile window
+  Then it is drawn upright, not rotated
+```
+
+## Open Questions
+
+None.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commander-playtester",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commander-playtester",
-      "version": "0.4.10",
+      "version": "0.4.11",
       "dependencies": {
         "lucide-react": "^1.31.0",
         "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",

--- a/src/App.css
+++ b/src/App.css
@@ -1290,7 +1290,7 @@ th {
   margin-top: 0.35rem;
 }
 
-/* ── XpWindow: draggable floating window (graveyard, …) ─────────── */
+/* ── XpWindow: draggable floating window (graveyard, exile, …) ──── */
 .xpwin {
   position: fixed;
   z-index: 75;
@@ -1354,25 +1354,25 @@ th {
   background: var(--inset);
   box-shadow: var(--bevel-well);
 }
-.gy-window {
+.zone-window {
   width: min(88vw, 604px);
 }
-.gy-window__row {
+.zone-window__row {
   display: flex;
   gap: 0.4rem;
   align-items: flex-start;
 }
-.gy-window__row .card {
+.zone-window__row .card {
   flex: 0 0 auto;
   width: 92px;
   height: 128px;
 }
-.gy-window__row .card__img {
+.zone-window__row .card__img {
   width: 100%;
   height: 100%;
   object-fit: cover;
 }
-.gy-window__row .card--text {
+.zone-window__row .card--text {
   max-width: none;
   padding: 0.35rem;
   white-space: normal;

--- a/src/board/Board.tsx
+++ b/src/board/Board.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import type { MouseEvent as ReactMouseEvent } from "react";
 import {
+  Ban,
   Biohazard,
   Circle,
   Cog,
@@ -324,11 +325,13 @@ export function Board({
   const { t } = useI18n();
   const [preview, setPreview] = useState<Preview | null>(null);
   const [graveSeat, setGraveSeat] = useState<number | null>(null);
+  const [exileSeat, setExileSeat] = useState<number | null>(null);
   const oppScrollRef = useRef<HTMLDivElement | null>(null);
 
   const you = view.seats.find((s) => s.seat === 0);
   const opponents = view.seats.filter((s) => s.seat !== 0);
   const graveView = view.seats.find((s) => s.seat === graveSeat);
+  const exileView = view.seats.find((s) => s.seat === exileSeat);
 
   // In the mobile opponents gallery, follow the active opponent into view. When
   // the human (seat 0) is active, leave the gallery on the last-shown opponent.
@@ -370,6 +373,7 @@ export function Board({
             images={images}
             onHover={onHover}
             onOpenGraveyard={setGraveSeat}
+            onOpenExile={setExileSeat}
             target={target}
             attack={attack}
             block={block}
@@ -388,6 +392,7 @@ export function Board({
             images={images}
             onHover={onHover}
             onOpenGraveyard={setGraveSeat}
+            onOpenExile={setExileSeat}
             play={play}
             target={target}
             ability={ability}
@@ -400,24 +405,52 @@ export function Board({
       )}
 
       {graveView && graveView.graveyard.length > 0 && (
-        <XpWindow
+        <ZoneWindow
           title={t("board.graveyardOf", { name: seatName(graveView) })}
+          cards={graveView.graveyard}
+          images={images}
+          onHover={onHover}
           onClose={() => setGraveSeat(null)}
-        >
-          <XpScroll
-            axis="x"
-            wrapperClassName="gy-window"
-            className="gy-window__row"
-          >
-            {graveView.graveyard.map((o) => (
-              <Card key={o.id} obj={o} images={images} onHover={onHover} />
-            ))}
-          </XpScroll>
-        </XpWindow>
+        />
+      )}
+
+      {exileView && exileView.exile.length > 0 && (
+        <ZoneWindow
+          title={t("board.exileOf", { name: seatName(exileView) })}
+          cards={exileView.exile}
+          images={images}
+          onHover={onHover}
+          onClose={() => setExileSeat(null)}
+        />
       )}
 
       {preview && play?.dragging == null && <CardPreview preview={preview} />}
     </div>
+  );
+}
+
+/** A floating window listing a seat's cards in a shared zone (graveyard, exile). */
+function ZoneWindow({
+  title,
+  cards,
+  images,
+  onHover,
+  onClose,
+}: {
+  title: string;
+  cards: GameObject[];
+  images?: Record<string, string>;
+  onHover?: (p: Preview | null) => void;
+  onClose: () => void;
+}) {
+  return (
+    <XpWindow title={title} onClose={onClose}>
+      <XpScroll axis="x" wrapperClassName="zone-window" className="zone-window__row">
+        {cards.map((o) => (
+          <Card key={o.id} obj={o} images={images} onHover={onHover} />
+        ))}
+      </XpScroll>
+    </XpWindow>
   );
 }
 
@@ -430,6 +463,7 @@ function Seat({
   images,
   onHover,
   onOpenGraveyard,
+  onOpenExile,
   play,
   target,
   ability,
@@ -446,6 +480,7 @@ function Seat({
   images?: Record<string, string>;
   onHover?: (p: Preview | null) => void;
   onOpenGraveyard?: (seat: number) => void;
+  onOpenExile?: (seat: number) => void;
   play?: PlayInteraction;
   target?: TargetInteraction;
   ability?: AbilityInteraction;
@@ -490,7 +525,7 @@ function Seat({
     <div className={cls} onClick={seatClick} data-seat={seat.seat}>
       <SeatHead seat={seat} you={you} name={name} />
 
-      <SeatZones seat={seat} onOpenGraveyard={onOpenGraveyard} />
+      <SeatZones seat={seat} onOpenGraveyard={onOpenGraveyard} onOpenExile={onOpenExile} />
 
       <div className="seat__field">
         {seat.commanders.length > 0 && (
@@ -581,12 +616,48 @@ function SeatHead({
   );
 }
 
+/** A zone count in the seat header: a button when there's something to open. */
+function ZoneCount({
+  icon: Icon,
+  count,
+  onOpen,
+  title,
+}: {
+  icon: LucideIcon;
+  count: number;
+  onOpen?: () => void;
+  title: string;
+}) {
+  if (count > 0 && onOpen) {
+    return (
+      <button
+        type="button"
+        className="seat__zone-btn"
+        onClick={(e) => {
+          e.stopPropagation();
+          onOpen();
+        }}
+        title={title}
+      >
+        <Icon size={13} /> {count}
+      </button>
+    );
+  }
+  return (
+    <span>
+      <Icon size={13} /> {count}
+    </span>
+  );
+}
+
 function SeatZones({
   seat,
   onOpenGraveyard,
+  onOpenExile,
 }: {
   seat: SeatView;
   onOpenGraveyard?: (seat: number) => void;
+  onOpenExile?: (seat: number) => void;
 }) {
   const { t } = useI18n();
   return (
@@ -597,23 +668,18 @@ function SeatZones({
       <span>
         <Layers size={13} /> {seat.librarySize}
       </span>
-      {seat.graveyardSize > 0 && onOpenGraveyard ? (
-        <button
-          type="button"
-          className="seat__zone-btn"
-          onClick={(e) => {
-            e.stopPropagation();
-            onOpenGraveyard(seat.seat);
-          }}
-          title={t("board.graveyardOpen")}
-        >
-          <Skull size={13} /> {seat.graveyardSize}
-        </button>
-      ) : (
-        <span>
-          <Skull size={13} /> {seat.graveyardSize}
-        </span>
-      )}
+      <ZoneCount
+        icon={Skull}
+        count={seat.graveyardSize}
+        onOpen={onOpenGraveyard ? () => onOpenGraveyard(seat.seat) : undefined}
+        title={t("board.graveyardOpen")}
+      />
+      <ZoneCount
+        icon={Ban}
+        count={seat.exileSize}
+        onOpen={onOpenExile ? () => onOpenExile(seat.seat) : undefined}
+        title={t("board.exileOpen")}
+      />
       {seat.poison > 0 && (
         <span>
           <Biohazard size={13} /> {seat.poison}

--- a/src/board/boardView.test.ts
+++ b/src/board/boardView.test.ts
@@ -9,7 +9,10 @@ function envelope(): GameStateEnvelope {
       phase: "Main1",
       active_player: 0,
       waiting_for: { type: "Priority" },
-      players: [{ id: 0, life: 40, hand: [], library: [], graveyard: [1, 2] }],
+      players: [
+        { id: 0, life: 40, hand: [], library: [], graveyard: [1, 2] },
+        { id: 1, life: 40, hand: [], library: [], graveyard: [] },
+      ],
       objects: {
         1: {
           id: 1,
@@ -27,10 +30,27 @@ function envelope(): GameStateEnvelope {
           tapped: false,
           card_types: { core_types: ["Instant"] },
         },
+        3: {
+          id: 3,
+          name: "Exiled Attacker",
+          zone: "Exile",
+          owner: 0,
+          tapped: true,
+          card_types: { core_types: ["Creature"] },
+        },
+        4: {
+          id: 4,
+          name: "Opponent's Exiled Card",
+          zone: "Exile",
+          owner: 1,
+          tapped: false,
+          card_types: { core_types: ["Artifact"] },
+        },
       },
       battlefield: [],
       command_zone: [],
       stack: [],
+      exile: [3, 4],
       eliminated_players: [],
     },
     derived: {},
@@ -50,5 +70,29 @@ describe("toBoardView graveyard", () => {
     const gy = toBoardView(env, [{ name: "You", commander: "" }]).seats[0].graveyard;
     expect(gy.every((o) => o.tapped === false)).toBe(true);
     expect(env.state.objects[1].tapped).toBe(true);
+  });
+});
+
+describe("toBoardView exile", () => {
+  const meta = [
+    { name: "You", commander: "" },
+    { name: "Opponent", commander: "" },
+  ];
+
+  it("splits the shared exile zone by owner, one bucket per seat", () => {
+    const view = toBoardView(envelope(), meta);
+    expect(view.seats[0].exileSize).toBe(1);
+    expect(view.seats[0].exile.map((o) => o.name)).toEqual(["Exiled Attacker"]);
+    expect(view.seats[1].exileSize).toBe(1);
+    expect(view.seats[1].exile.map((o) => o.name)).toEqual([
+      "Opponent's Exiled Card",
+    ]);
+  });
+
+  it("renders every exiled card untapped without mutating the source", () => {
+    const env = envelope();
+    const exile = toBoardView(env, meta).seats[0].exile;
+    expect(exile.every((o) => o.tapped === false)).toBe(true);
+    expect(env.state.objects[3].tapped).toBe(true);
   });
 });

--- a/src/board/boardView.ts
+++ b/src/board/boardView.ts
@@ -16,6 +16,9 @@ export interface SeatView {
   graveyardSize: number;
   /** Cards in this player's graveyard, in the engine's order. */
   graveyard: GameObject[];
+  exileSize: number;
+  /** This player's cards sitting in the (shared) exile zone, in the engine's order. */
+  exile: GameObject[];
   lands: GameObject[];
   creatures: GameObject[];
   others: GameObject[];
@@ -77,6 +80,12 @@ export function toBoardView(
       .map((id) => objects[id])
       .filter((o): o is GameObject => !!o)
       .map((o) => (o.tapped ? { ...o, tapped: false } : o));
+    // Exile is one shared zone in the engine's state (unlike each player's own
+    // graveyard), so split it by owner to show each seat its own cards.
+    const exile = (st.exile ?? [])
+      .map((id) => objects[id])
+      .filter((o): o is GameObject => !!o && o.owner === seat)
+      .map((o) => (o.tapped ? { ...o, tapped: false } : o));
 
     return {
       seat,
@@ -90,6 +99,8 @@ export function toBoardView(
       librarySize: p.library?.length ?? 0,
       graveyardSize: p.graveyard?.length ?? 0,
       graveyard,
+      exileSize: exile.length,
+      exile,
       lands,
       creatures,
       others,

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -351,6 +351,11 @@ export const messages = {
     pt: "Cemitério de {name}",
     en: "{name}'s graveyard",
   },
+  "board.exileOpen": { pt: "Abrir exílio", en: "Open exile" },
+  "board.exileOf": {
+    pt: "Exílio de {name}",
+    en: "{name}'s exile",
+  },
   "common.close": { pt: "Fechar", en: "Close" },
 
   "goldfish.title": { pt: "Consistência (goldfishing)", en: "Consistency (goldfishing)" },


### PR DESCRIPTION
## Summary

Each seat now shows its exile zone the same way it already shows its graveyard: a count next to the other zone counts, which becomes a button once non-empty, opening a floating window of the exiled cards.

- New `Ban` icon (vs. the graveyard's `Skull`) marks the exile count.
- The engine tracks exile as **one shared zone** (`state.exile`), unlike the graveyard which is per-player. `boardView.toBoardView` now splits that shared list by card owner so each seat's `SeatView` gets its own `exile`/`exileSize`, mirroring `graveyard`/`graveyardSize`.
- Exiled cards are rendered untapped in the window, same rule as the graveyard.
- Refactored the graveyard window and the zone-count button into small shared components (`ZoneWindow`, `ZoneCount`) so graveyard and exile share rendering instead of duplicating it; the `gy-window` CSS class was generalized to `zone-window` accordingly.

## Docs

- Added `domainbook/domains/board/features/inspect-an-exile-zone.md`, mirroring `inspect-a-graveyard.md`.
- Bumped to `0.4.11` with a changelog entry.

## Testing

- `npm run typecheck`
- `npm run lint`
- `npm test` (132 passed, incl. new `toBoardView exile` cases covering per-owner splitting and the untapped/no-mutation rule)
- `npx domainbook validate` / `npx domainbook check --staged`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NoYNPK7ETU6teoW5JUZJRK)_