### PR TITLE
Allow multiple zone windows open at once; drag them by touch

### DIFF
--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,6 +12,14 @@ depth live there. A purely-internal PR that touches no product or architecture m
 skip its version with a `Skip-Docs: <reason>` trailer instead. There are no
 per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
+## [0.4.12] - 2026-08-28
+
+### Fixed
+
+- Zone windows (graveyard, exile) can now be open several at once instead of
+  one replacing another, and their title bar can be dragged by touch, not
+  just mouse (`inspect-a-graveyard`, `inspect-an-exile-zone`).
+
 ## [0.4.11] - 2026-08-28
 
 ### Added

--- a/domainbook/domains/board/features/inspect-a-graveyard.md
+++ b/domainbook/domains/board/features/inspect-a-graveyard.md
@@ -35,8 +35,8 @@ Example: One row of cards, titled by owner
 
 Example: Move it out of the way
   Given the graveyard window is open
-  When I hold its title bar and drag
-  Then the window follows the pointer and stays within the screen
+  When I hold or touch its title bar and drag
+  Then the window follows the pointer (or finger) and stays within the screen
 
 Example: Dismiss it
   Given the graveyard window is open
@@ -47,6 +47,12 @@ Example: Read a card up close
   Given the graveyard window is open
   When I hover a card in it
   Then an enlarged preview of that card is shown, above the window
+
+Example: Several zone windows at once
+  Given I open one seat's graveyard
+  When I open another seat's graveyard, or that seat's exile zone
+  Then both windows stay open side by side, each independently draggable
+  And opening the same seat's already-open graveyard again does not duplicate it
 ```
 
 ## Rule: Graveyard cards are shown untapped

--- a/domainbook/domains/board/features/inspect-an-exile-zone.md
+++ b/domainbook/domains/board/features/inspect-an-exile-zone.md
@@ -44,8 +44,8 @@ Example: One row of cards, titled by owner
 
 Example: Move it out of the way
   Given the exile window is open
-  When I hold its title bar and drag
-  Then the window follows the pointer and stays within the screen
+  When I hold or touch its title bar and drag
+  Then the window follows the pointer (or finger) and stays within the screen
 
 Example: Dismiss it
   Given the exile window is open
@@ -56,6 +56,12 @@ Example: Read a card up close
   Given the exile window is open
   When I hover a card in it
   Then an enlarged preview of that card is shown, above the window
+
+Example: Several zone windows at once
+  Given I open one seat's exile zone
+  When I open another seat's exile zone, or that seat's graveyard
+  Then both windows stay open side by side, each independently draggable
+  And opening the same seat's already-open exile zone again does not duplicate it
 ```
 
 ## Rule: Exiled cards are shown untapped

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commander-playtester",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commander-playtester",
-      "version": "0.4.11",
+      "version": "0.4.12",
       "dependencies": {
         "lucide-react": "^1.31.0",
         "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",

--- a/src/board/Board.tsx
+++ b/src/board/Board.tsx
@@ -27,6 +27,14 @@ import { categoryLabel } from "../i18n/messages";
 import { XpScroll } from "../components/XpScroll";
 import { XpWindow } from "../components/XpWindow";
 
+/** A shared zone with a floating card-list window (graveyard, exile). */
+type ZoneKind = "graveyard" | "exile";
+/** One open zone window: which seat, which of that seat's shared zones. */
+interface ZoneRef {
+  kind: ZoneKind;
+  seat: number;
+}
+
 /** Play-mode interaction for the human's seat: drag a hand card to a slot, or
  * click the commander in the command zone to cast it. */
 export interface PlayInteraction {
@@ -324,14 +332,27 @@ export function Board({
 }) {
   const { t } = useI18n();
   const [preview, setPreview] = useState<Preview | null>(null);
-  const [graveSeat, setGraveSeat] = useState<number | null>(null);
-  const [exileSeat, setExileSeat] = useState<number | null>(null);
+  // Every zone window currently open (a seat's graveyard or exile). Each is
+  // independent, so several can be open — even several at once for the same
+  // seat, or the same zone kind across different seats.
+  const [openZones, setOpenZones] = useState<ZoneRef[]>([]);
   const oppScrollRef = useRef<HTMLDivElement | null>(null);
 
   const you = view.seats.find((s) => s.seat === 0);
   const opponents = view.seats.filter((s) => s.seat !== 0);
-  const graveView = view.seats.find((s) => s.seat === graveSeat);
-  const exileView = view.seats.find((s) => s.seat === exileSeat);
+
+  function openZone(kind: ZoneKind, seat: number) {
+    setOpenZones((prev) =>
+      prev.some((z) => z.kind === kind && z.seat === seat)
+        ? prev
+        : [...prev, { kind, seat }],
+    );
+  }
+  function closeZone(kind: ZoneKind, seat: number) {
+    setOpenZones((prev) => prev.filter((z) => z.kind !== kind || z.seat !== seat));
+  }
+  const openGraveyard = (seat: number) => openZone("graveyard", seat);
+  const openExile = (seat: number) => openZone("exile", seat);
 
   // In the mobile opponents gallery, follow the active opponent into view. When
   // the human (seat 0) is active, leave the gallery on the last-shown opponent.
@@ -372,8 +393,8 @@ export function Board({
             winner={view.winner}
             images={images}
             onHover={onHover}
-            onOpenGraveyard={setGraveSeat}
-            onOpenExile={setExileSeat}
+            onOpenGraveyard={openGraveyard}
+            onOpenExile={openExile}
             target={target}
             attack={attack}
             block={block}
@@ -391,8 +412,8 @@ export function Board({
             winner={view.winner}
             images={images}
             onHover={onHover}
-            onOpenGraveyard={setGraveSeat}
-            onOpenExile={setExileSeat}
+            onOpenGraveyard={openGraveyard}
+            onOpenExile={openExile}
             play={play}
             target={target}
             ability={ability}
@@ -404,25 +425,26 @@ export function Board({
         </div>
       )}
 
-      {graveView && graveView.graveyard.length > 0 && (
-        <ZoneWindow
-          title={t("board.graveyardOf", { name: seatName(graveView) })}
-          cards={graveView.graveyard}
-          images={images}
-          onHover={onHover}
-          onClose={() => setGraveSeat(null)}
-        />
-      )}
-
-      {exileView && exileView.exile.length > 0 && (
-        <ZoneWindow
-          title={t("board.exileOf", { name: seatName(exileView) })}
-          cards={exileView.exile}
-          images={images}
-          onHover={onHover}
-          onClose={() => setExileSeat(null)}
-        />
-      )}
+      {openZones.map(({ kind, seat }) => {
+        const seatView = view.seats.find((s) => s.seat === seat);
+        if (!seatView) return null;
+        const cards = kind === "graveyard" ? seatView.graveyard : seatView.exile;
+        if (cards.length === 0) return null;
+        const title =
+          kind === "graveyard"
+            ? t("board.graveyardOf", { name: seatName(seatView) })
+            : t("board.exileOf", { name: seatName(seatView) });
+        return (
+          <ZoneWindow
+            key={`${kind}-${seat}`}
+            title={title}
+            cards={cards}
+            images={images}
+            onHover={onHover}
+            onClose={() => closeZone(kind, seat)}
+          />
+        );
+      })}
 
       {preview && play?.dragging == null && <CardPreview preview={preview} />}
     </div>

--- a/src/components/XpWindow.tsx
+++ b/src/components/XpWindow.tsx
@@ -11,7 +11,8 @@ interface XpWindowProps {
 
 /**
  * A floating Windows XP window: copper title bar, a close button, and a body.
- * Drag it anywhere by holding the title bar; Escape or the close button shuts it.
+ * Drag it anywhere by holding (or touching) the title bar; Escape or the
+ * close button shuts it.
  */
 export function XpWindow({ title, onClose, children }: XpWindowProps) {
   const { t } = useI18n();
@@ -26,28 +27,45 @@ export function XpWindow({ title, onClose, children }: XpWindowProps) {
     return () => document.removeEventListener("keydown", onKey);
   }, [onClose]);
 
-  function onBarDown(e: React.MouseEvent) {
+  function onBarDown(e: React.MouseEvent | React.TouchEvent) {
     const el = ref.current;
     if (!el || (e.target as HTMLElement).closest(".xpwin__close")) return;
+    const point = "touches" in e ? e.touches[0] : e;
+    if (!point) return;
     e.preventDefault();
     const rect = el.getBoundingClientRect();
-    const offX = e.clientX - rect.left;
-    const offY = e.clientY - rect.top;
+    const offX = point.clientX - rect.left;
+    const offY = point.clientY - rect.top;
     const maxX = Math.max(0, window.innerWidth - rect.width);
     const maxY = Math.max(0, window.innerHeight - rect.height);
-    function move(ev: MouseEvent) {
+    function moveTo(clientX: number, clientY: number) {
       setPos({
-        x: Math.min(Math.max(0, ev.clientX - offX), maxX),
-        y: Math.min(Math.max(0, ev.clientY - offY), maxY),
+        x: Math.min(Math.max(0, clientX - offX), maxX),
+        y: Math.min(Math.max(0, clientY - offY), maxY),
       });
     }
-    function up() {
-      document.removeEventListener("mousemove", move);
-      document.removeEventListener("mouseup", up);
+    function onMouseMove(ev: MouseEvent) {
+      moveTo(ev.clientX, ev.clientY);
+    }
+    function onTouchMove(ev: TouchEvent) {
+      const t = ev.touches[0];
+      if (!t) return;
+      ev.preventDefault();
+      moveTo(t.clientX, t.clientY);
+    }
+    function end() {
+      document.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mouseup", end);
+      document.removeEventListener("touchmove", onTouchMove);
+      document.removeEventListener("touchend", end);
+      document.removeEventListener("touchcancel", end);
       document.body.classList.remove("xpscroll-dragging");
     }
-    document.addEventListener("mousemove", move);
-    document.addEventListener("mouseup", up);
+    document.addEventListener("mousemove", onMouseMove);
+    document.addEventListener("mouseup", end);
+    document.addEventListener("touchmove", onTouchMove, { passive: false });
+    document.addEventListener("touchend", end);
+    document.addEventListener("touchcancel", end);
     document.body.classList.add("xpscroll-dragging");
   }
 
@@ -59,7 +77,7 @@ export function XpWindow({ title, onClose, children }: XpWindowProps) {
       role="dialog"
       aria-label={title}
     >
-      <div className="xpwin__bar" onMouseDown={onBarDown}>
+      <div className="xpwin__bar" onMouseDown={onBarDown} onTouchStart={onBarDown}>
         <span className="xpwin__title">{title}</span>
         <button
           type="button"


### PR DESCRIPTION
## Summary

Follow-up to #39, from testing feedback on the exile zone.

- **Multiple zone windows.** `Board` tracked the open graveyard/exile window as a single `number | null` per zone kind, so opening a second seat's window (or the other zone kind) silently replaced whichever was already open. This turned out to be true for the graveyard too, not just exile — it just hadn't come up before. Replaced both slots with one list of open `{ kind, seat }` windows, so any combination can be open side by side, each independently draggable. Opening an already-open one is a no-op instead of a duplicate.
- **Touch dragging.** `XpWindow`'s title bar only listened for mouse events, so it couldn't be dragged on a touchscreen (desktop-only regression, also pre-existing for the graveyard). Added the matching `touchstart`/`touchmove`/`touchend` handling alongside the existing mouse handling, so mobile can reposition a window by touch the same way desktop does with the mouse.

## Docs

- Updated `inspect-a-graveyard` and `inspect-an-exile-zone` with the new multi-window and touch-drag examples.
- Bumped to `0.4.12` with a changelog entry.

## Testing

- `npm run typecheck`
- `npm run lint`
- `npm test` (132 passed)
- `npx domainbook validate` / `npx domainbook check --staged`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NoYNPK7ETU6teoW5JUZJRK)_