### PR TITLE
0.4.13: let the human choose modes on modal spells and abilities

### DIFF
--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,6 +12,16 @@ depth live there. A purely-internal PR that touches no product or architecture m
 skip its version with a `Skip-Docs: <reason>` trailer instead. There are no
 per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
+## [0.4.13] - 2026-08-29
+
+### Added
+
+- A centered, board-dimming popup for "choose one or more —" modal spells and
+  abilities, so the player picks the mode(s) instead of the AI; a stepper
+  (instead of a plain toggle) on a card that allows repeating a mode, and an
+  eye button to peek at the board mid-choice without losing picks
+  (`domains/simulation/features/choose-modes-on-a-modal-spell-or-ability.md`).
+
 ## [0.4.12] - 2026-08-28
 
 ### Fixed

--- a/domainbook/domains/simulation/features/choose-modes-on-a-modal-spell-or-ability.md
+++ b/domainbook/domains/simulation/features/choose-modes-on-a-modal-spell-or-ability.md
@@ -1,0 +1,105 @@
+---
+id: choose-modes-on-a-modal-spell-or-ability
+name: Choose modes on a modal spell or ability
+status: implemented
+---
+
+## Story
+
+As a player piloting my seat
+I want to pick the mode(s) on my own "choose one or more —" spells and abilities
+So that a card's most important decision is mine, not the AI's
+
+## Rule: A modal choice opens a centered, focus-stealing popup on the human's seat
+
+When the engine asks the human to resolve a `ModeChoice` (spell) or
+`AbilityModeChoice` (activated ability) `decision request`, a popup appears
+centered over a dimmed, blurred board — the same style as the opening-hand and
+forced-discard popups — so a mode must be chosen before play continues. Other
+seats resolve it by `AI action proposal` as before.
+
+```gherkin
+Example: The popup appears when I cast a modal spell
+  Given a play-mode match where I control seat 0
+  When I cast a spell with "choose one or more —"
+  Then a centered popup dims the board and lists each mode
+  And an opponent's modal spell is still decided by the AI
+```
+
+## Rule: Each mode is its own button, checked against the card's min/max
+
+The popup lists every mode from the engine's `modal` data as a separate button,
+"~" swapped for the source's own name. Clicking a mode toggles it; once the
+card's `max_choices` are picked, further clicks past that cap are ignored.
+Confirm is disabled until at least `min_choices` are picked, then submits the
+picked indices as `SelectModes`.
+
+```gherkin
+Example: Picking within the card's limits
+  Given a modal popup for a "choose one or two" spell
+  When I click two different modes
+  Then both are marked picked and Confirm is enabled
+
+Example: The cap blocks a third pick
+  Given two modes are already picked on a "choose one or two" spell
+  When I click a third mode
+  Then it is not picked
+```
+
+## Rule: A repeatable card shows a stepper instead of a toggle
+
+When `allow_repeat_modes` is true, the same mode can be picked more than once,
+so a plain toggle can't tell "pick again" from "unpick" — that row shows a
+`− count +` stepper instead of a button. `+` adds another instance of that mode
+(disabled once the card's `max_choices` total is reached); `−` removes one
+(disabled at 0). The submitted `SelectModes` indices repeat accordingly (e.g.
+`[0, 0, 1]` for the same mode picked twice plus another once).
+
+```gherkin
+Example: Picking the same mode twice
+  Given a modal popup for a "choose two, you may repeat a mode" spell
+  When I press + twice on the first mode
+  Then its count reads 2 and the submitted indices repeat that mode's index
+
+Example: The stepper's cap still applies
+  Given two picks are already made on a "choose two" repeatable spell
+  Then every mode's + button is disabled until a − frees one back up
+```
+
+## Rule: An eye button lets the player peek at the board without losing picks
+
+A toggle button in the popup's corner hides the popup (and un-dims the board) so
+the player can check the board — a target's stats, an opponent's board — before
+deciding; toggling it again brings the popup back with the picks intact.
+
+```gherkin
+Example: Peeking mid-choice
+  Given a modal popup with one mode already picked
+  When I toggle the eye button
+  Then the popup hides and the board is visible and undimmed
+  When I toggle it again
+  Then the popup reappears with that mode still picked
+```
+
+## Rule: The choice can be handed to the AI
+
+Choosing let the AI decide hands the whole modal choice back to the engine's own
+AI, so the decision is never stuck (`simulation/ADR-0001`).
+
+```gherkin
+Example: Letting the AI decide
+  Given the modal popup is shown
+  When I choose let the AI decide
+  Then the engine's AI picks the mode(s)
+```
+
+## Open Questions
+
+- The `modal` shape (`mode_descriptions`, `min_choices`/`max_choices`,
+  `allow_repeat_modes`) and the `SelectModes { indices }` submission were captured
+  and verified against the live engine, for both a spell's `ModeChoice` and an
+  ability's `AbilityModeChoice` — but only with `allow_repeat_modes: false`. No
+  reproducible `allow_repeat_modes: true` card has been captured yet, so
+  submitting a repeated index in `SelectModes` to mean "this mode, again" is an
+  assumption from the shape, not a verified round-trip; confirm it against a live
+  repeatable card before trusting the stepper's output engine-side.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",

--- a/src/App.css
+++ b/src/App.css
@@ -2021,3 +2021,117 @@ th {
   font-weight: 700;
   text-align: center;
 }
+
+/* ── Modal spell/ability mode-choice popup ─────────────────────── */
+.modes-modal {
+  position: relative;
+  width: min(560px, 100%);
+}
+.modes-peek {
+  position: absolute;
+  top: 0.6rem;
+  right: 0.6rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--panel-2);
+  color: var(--muted);
+  cursor: pointer;
+}
+.modes-peek:hover {
+  color: var(--text);
+  border-color: var(--accent);
+}
+.modes-peek[aria-pressed="true"] {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.modes-modal__body {
+  transition: opacity 0.15s ease;
+}
+.mull-overlay--peeking {
+  background: transparent;
+  backdrop-filter: none;
+}
+.mull-overlay--peeking .modes-modal {
+  background: transparent;
+  border-color: transparent;
+  box-shadow: none;
+}
+.mull-overlay--peeking .modes-modal__body {
+  opacity: 0;
+  pointer-events: none;
+  visibility: hidden;
+}
+.modes-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.modes-choice {
+  display: block;
+  width: 100%;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--panel-2);
+  color: var(--text);
+  text-align: left;
+  line-height: 1.35;
+  cursor: pointer;
+}
+.modes-choice:hover {
+  border-color: var(--accent);
+}
+.modes-choice--picked {
+  border-color: var(--warn);
+  box-shadow: 0 0 0 2px var(--warn) inset;
+}
+.modes-choice--stepper {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  cursor: default;
+}
+.modes-choice__text {
+  flex: 1;
+}
+.modes-stepper {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+.modes-stepper__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.6rem;
+  height: 1.6rem;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--panel);
+  color: var(--text);
+  font-weight: 700;
+  line-height: 1;
+  cursor: pointer;
+}
+.modes-stepper__btn:hover:not(:disabled) {
+  border-color: var(--accent);
+}
+.modes-stepper__btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.modes-stepper__count {
+  min-width: 1.2rem;
+  text-align: center;
+  font-weight: 700;
+}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -271,6 +271,31 @@ export const messages = {
   "creatureType.confirm": { pt: "Confirmar", en: "Confirm" },
   "creatureType.letAi": { pt: "IA decide", en: "Let the AI decide" },
 
+  "modes.title": { pt: "Escolher modo", en: "Choose a mode" },
+  "modes.source": {
+    pt: "{name} pede uma escolha de modo.",
+    en: "{name} asks for a mode.",
+  },
+  "modes.instructionOne": {
+    pt: "Escolha um modo.",
+    en: "Choose one mode.",
+  },
+  "modes.instructionExact": {
+    pt: "Escolha {n} modos.",
+    en: "Choose {n} modes.",
+  },
+  "modes.instructionRange": {
+    pt: "Escolha de {min} a {max} modos.",
+    en: "Choose {min}–{max} modes.",
+  },
+  "modes.progress": { pt: "Selecionados: {n} / {max}", en: "Selected: {n} / {max}" },
+  "modes.confirm": { pt: "Confirmar", en: "Confirm" },
+  "modes.letAi": { pt: "IA decide", en: "Let the AI decide" },
+  "modes.peek": { pt: "Espiar o tabuleiro", en: "Peek at the board" },
+  "modes.hide": { pt: "Ocultar e escolher", en: "Hide and choose" },
+  "modes.addOne": { pt: "Escolher este modo de novo", en: "Pick this mode again" },
+  "modes.removeOne": { pt: "Remover uma escolha", en: "Remove one pick" },
+
   "mulligan.title": { pt: "Mão inicial", en: "Opening hand" },
   "mulligan.keepCount": { pt: "Ficar com {n}", en: "Keep {n}" },
   "mulligan.keepAll": { pt: "Ficar com a mão", en: "Keep hand" },

--- a/src/match/RunView.tsx
+++ b/src/match/RunView.tsx
@@ -66,6 +66,7 @@ import {
   chooseOptionAction,
   type CreatureTypePrompt,
 } from "../sim/decisions/creatureType";
+import { selectModesAction, type ModesPrompt } from "../sim/decisions/modes";
 import {
   mulliganKeepAction,
   mulliganTakeAction,
@@ -81,6 +82,7 @@ import { ninjutsuBySource } from "../sim/decisions/ninjutsu";
 import { aggregate } from "../analysis/matchStats";
 import { fetchCardsCached } from "../lib/scryfallCache";
 import { SearchableSelect } from "../components/SearchableSelect";
+import { Eye, EyeOff } from "lucide-react";
 import { useI18n } from "../i18n/I18nContext";
 import { useSettings } from "../settings/SettingsContext";
 import {
@@ -202,6 +204,11 @@ interface ManaTurn {
 
 interface CreatureTypeTurn {
   prompt: CreatureTypePrompt & { aiChoice: string | null };
+  resolve: (choice: HumanChoice) => void;
+}
+
+interface ModesTurn {
+  prompt: ModesPrompt;
   resolve: (choice: HumanChoice) => void;
 }
 
@@ -342,6 +349,8 @@ interface RunnerCallbackDeps {
   setManaTurn: Dispatch<SetStateAction<ManaTurn | null>>;
   setCreatureTypePick: Dispatch<SetStateAction<string>>;
   setCreatureTypeTurn: Dispatch<SetStateAction<CreatureTypeTurn | null>>;
+  setModesPick: Dispatch<SetStateAction<number[]>>;
+  setModesTurn: Dispatch<SetStateAction<ModesTurn | null>>;
   setBottomPick: Dispatch<SetStateAction<Set<number>>>;
   setMulliganTurn: Dispatch<SetStateAction<MulliganTurn | null>>;
   setDiscardPick: Dispatch<SetStateAction<Set<number>>>;
@@ -371,6 +380,8 @@ function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
     setManaTurn,
     setCreatureTypePick,
     setCreatureTypeTurn,
+    setModesPick,
+    setModesTurn,
     setBottomPick,
     setMulliganTurn,
     setDiscardPick,
@@ -505,6 +516,22 @@ function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
           },
         });
       }),
+    requestHumanModes: (_env, prompt) =>
+      new Promise<HumanChoice>((resolve) => {
+        if (isCancelled()) {
+          resolve({ ai: true });
+          return;
+        }
+        setModesPick([]);
+        setModesTurn({
+          prompt,
+          resolve: (choice) => {
+            setModesTurn(null);
+            setModesPick([]);
+            resolve(choice);
+          },
+        });
+      }),
     requestHumanMulligan: (_env, prompt) =>
       new Promise<HumanChoice>((resolve) => {
         if (isCancelled()) {
@@ -634,6 +661,8 @@ export function RunView({
   const [creatureTypeTurn, setCreatureTypeTurn] =
     useState<CreatureTypeTurn | null>(null);
   const [creatureTypePick, setCreatureTypePick] = useState("");
+  const [modesTurn, setModesTurn] = useState<ModesTurn | null>(null);
+  const [modesPick, setModesPick] = useState<number[]>([]);
   const [mulliganTurn, setMulliganTurn] = useState<MulliganTurn | null>(null);
   const [bottomPick, setBottomPick] = useState<Set<number>>(new Set());
   const [discardTurn, setDiscardTurn] = useState<DiscardTurn | null>(null);
@@ -727,6 +756,8 @@ export function RunView({
             setManaTurn,
             setCreatureTypePick,
             setCreatureTypeTurn,
+            setModesPick,
+            setModesTurn,
             setBottomPick,
             setMulliganTurn,
             setDiscardPick,
@@ -853,11 +884,24 @@ export function RunView({
   useEffect(() => {
     if (
       passingTurn &&
-      (targeting || manaTurn || blockingTurn || creatureTypeTurn || scryTurn)
+      (targeting ||
+        manaTurn ||
+        blockingTurn ||
+        creatureTypeTurn ||
+        modesTurn ||
+        scryTurn)
     ) {
       setPassingTurn(false);
     }
-  }, [passingTurn, targeting, manaTurn, blockingTurn, creatureTypeTurn, scryTurn]);
+  }, [
+    passingTurn,
+    targeting,
+    manaTurn,
+    blockingTurn,
+    creatureTypeTurn,
+    modesTurn,
+    scryTurn,
+  ]);
 
   // Map draggable hand cards to their play actions for the current window.
   // With manual mana on, a normal cast is offered only when the floating reserve
@@ -1638,6 +1682,33 @@ export function RunView({
         />
       )}
 
+      {modesTurn && (
+        <ModesModal
+          prompt={modesTurn.prompt}
+          pick={modesPick}
+          onAdd={(i) =>
+            setModesPick((prev) => {
+              if (prev.length >= modesTurn.prompt.maxChoices) return prev;
+              if (!modesTurn.prompt.allowRepeatModes && prev.includes(i)) {
+                return prev;
+              }
+              return [...prev, i];
+            })
+          }
+          onRemove={(i) =>
+            setModesPick((prev) => {
+              const idx = prev.lastIndexOf(i);
+              if (idx === -1) return prev;
+              return [...prev.slice(0, idx), ...prev.slice(idx + 1)];
+            })
+          }
+          onConfirm={() =>
+            modesTurn.resolve({ action: selectModesAction(modesPick) })
+          }
+          onLetAi={() => modesTurn.resolve({ ai: true })}
+        />
+      )}
+
       {scryTurn && (
         <ScryWindow
           prompt={scryTurn.prompt}
@@ -1868,6 +1939,153 @@ function DiscardModal({
       </div>
 
       {overlay}
+    </div>
+  );
+}
+
+function modesInstruction(
+  prompt: ModesPrompt,
+  t: (key: MsgKey, vars?: Vars) => string,
+): string {
+  if (prompt.minChoices === prompt.maxChoices) {
+    return prompt.maxChoices <= 1
+      ? t("modes.instructionOne")
+      : t("modes.instructionExact", { n: prompt.maxChoices });
+  }
+  return t("modes.instructionRange", {
+    min: prompt.minChoices,
+    max: prompt.maxChoices,
+  });
+}
+
+/**
+ * Modal spell/ability popup: the board dims behind it so a mode must be
+ * chosen before play continues. The eye button lets the player peek at the
+ * board (e.g. to check a target's stats) without losing their picks.
+ */
+function ModesModal({
+  prompt,
+  pick,
+  onAdd,
+  onRemove,
+  onConfirm,
+  onLetAi,
+}: {
+  prompt: ModesPrompt;
+  pick: number[];
+  onAdd: (index: number) => void;
+  onRemove: (index: number) => void;
+  onConfirm: () => void;
+  onLetAi: () => void;
+}) {
+  const { t } = useI18n();
+  const modalRef = useRef<HTMLDivElement>(null);
+  const [peeking, setPeeking] = useState(false);
+
+  // Move focus into the dialog, trap Tab within it, and restore focus on close.
+  useFocusTrap(modalRef);
+
+  return (
+    <div
+      className={`mull-overlay${peeking ? " mull-overlay--peeking" : ""}`}
+      role="dialog"
+      aria-modal={!peeking}
+      aria-labelledby="modes-title"
+    >
+      <div className="mull-modal modes-modal" ref={modalRef}>
+        <button
+          type="button"
+          className="modes-peek"
+          onClick={() => setPeeking((v) => !v)}
+          aria-pressed={peeking}
+          aria-label={peeking ? t("modes.hide") : t("modes.peek")}
+          title={peeking ? t("modes.hide") : t("modes.peek")}
+        >
+          {peeking ? <EyeOff size={18} /> : <Eye size={18} />}
+        </button>
+
+        <div className="modes-modal__body">
+          <div className="mull-modal__head">
+            <h2 id="modes-title">{t("modes.title")}</h2>
+            {prompt.sourceName && (
+              <p className="hint">
+                {t("modes.source", { name: prompt.sourceName })}
+              </p>
+            )}
+            <p className="hint">{modesInstruction(prompt, t)}</p>
+          </div>
+
+          <div className="modes-list">
+            {prompt.modes.map((mode, i) => {
+              const count = pick.filter((p) => p === i).length;
+              const canAddMore =
+                pick.length < prompt.maxChoices &&
+                (prompt.allowRepeatModes || count === 0);
+
+              if (!prompt.allowRepeatModes) {
+                return (
+                  <button
+                    key={i}
+                    type="button"
+                    className={`modes-choice${count > 0 ? " modes-choice--picked" : ""}`}
+                    onClick={() => (count > 0 ? onRemove(i) : onAdd(i))}
+                  >
+                    {mode}
+                  </button>
+                );
+              }
+
+              return (
+                <div
+                  key={i}
+                  className={`modes-choice modes-choice--stepper${
+                    count > 0 ? " modes-choice--picked" : ""
+                  }`}
+                >
+                  <span className="modes-choice__text">{mode}</span>
+                  <span className="modes-stepper">
+                    <button
+                      type="button"
+                      className="modes-stepper__btn"
+                      disabled={count === 0}
+                      onClick={() => onRemove(i)}
+                      aria-label={t("modes.removeOne")}
+                    >
+                      −
+                    </button>
+                    <span className="modes-stepper__count">{count}</span>
+                    <button
+                      type="button"
+                      className="modes-stepper__btn"
+                      disabled={!canAddMore}
+                      onClick={() => onAdd(i)}
+                      aria-label={t("modes.addOne")}
+                    >
+                      +
+                    </button>
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+
+          <div className="mull-actions">
+            <span className="hint">
+              {t("modes.progress", { n: pick.length, max: prompt.maxChoices })}
+            </span>
+            <button
+              className="btn"
+              disabled={pick.length < prompt.minChoices}
+              onClick={onConfirm}
+            >
+              {t("modes.confirm")}
+            </button>
+            <button className="btn btn--ghost" onClick={onLetAi}>
+              {t("modes.letAi")}
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/sim/decisions/modes.test.ts
+++ b/src/sim/decisions/modes.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { parseModesPrompt, selectModesAction } from "./modes";
+import type { GameObject, WaitingFor } from "../../engine/types";
+
+// Real ModeChoice (a modal spell, e.g. a charm) captured from the phase-rs
+// WASM build (trimmed to the fields the parser reads).
+const REAL_MODE_CHOICE: WaitingFor = {
+  type: "ModeChoice",
+  data: {
+    modal: {
+      allow_repeat_modes: false,
+      chooser: { type: "Controller" },
+      max_choices: 1,
+      min_choices: 1,
+      mode_count: 2,
+      mode_descriptions: [
+        "~ deals 3 damage to target creature or planeswalker.",
+        "Destroy target artifact or enchantment.",
+      ],
+    },
+    pending_cast: { object_id: 161, card_id: 161 },
+    player: 1,
+  },
+};
+
+// Real AbilityModeChoice (a modal activated ability) captured the same way.
+const REAL_ABILITY_MODE_CHOICE: WaitingFor = {
+  type: "AbilityModeChoice",
+  data: {
+    is_activated: false,
+    modal: {
+      allow_repeat_modes: false,
+      chooser: { type: "Controller" },
+      max_choices: 1,
+      min_choices: 1,
+      mode_count: 2,
+      mode_descriptions: ["Put a +1/+1 counter on ~.", "~ phases out."],
+    },
+    mode_abilities: [],
+    player: 1,
+    source_id: 137,
+  },
+};
+
+const OBJECTS: Record<string, GameObject> = {
+  161: { id: 161, name: "Prismari Command", zone: "Stack" },
+  137: { id: 137, name: "Some Permanent", zone: "Battlefield" },
+};
+
+describe("parseModesPrompt", () => {
+  it("parses a spell ModeChoice, substituting ~ with the source name", () => {
+    const p = parseModesPrompt(REAL_MODE_CHOICE, OBJECTS)!;
+    expect(p).not.toBeNull();
+    expect(p.player).toBe(1);
+    expect(p.sourceName).toBe("Prismari Command");
+    expect(p.minChoices).toBe(1);
+    expect(p.maxChoices).toBe(1);
+    expect(p.allowRepeatModes).toBe(false);
+    expect(p.modes).toEqual([
+      "Prismari Command deals 3 damage to target creature or planeswalker.",
+      "Destroy target artifact or enchantment.",
+    ]);
+  });
+
+  it("parses an ability AbilityModeChoice off source_id", () => {
+    const p = parseModesPrompt(REAL_ABILITY_MODE_CHOICE, OBJECTS)!;
+    expect(p).not.toBeNull();
+    expect(p.sourceName).toBe("Some Permanent");
+    expect(p.modes).toEqual([
+      "Put a +1/+1 counter on Some Permanent.",
+      "Some Permanent phases out.",
+    ]);
+  });
+
+  it("leaves ~ untouched when the source name is unknown", () => {
+    const p = parseModesPrompt(REAL_MODE_CHOICE, {})!;
+    expect(p.sourceName).toBe("");
+    expect(p.modes[0]).toBe("~ deals 3 damage to target creature or planeswalker.");
+  });
+
+  it("returns null for unrelated or empty waiting_for", () => {
+    expect(parseModesPrompt(undefined)).toBeNull();
+    expect(parseModesPrompt({ type: "Priority", data: {} })).toBeNull();
+    expect(
+      parseModesPrompt({
+        type: "ModeChoice",
+        data: { modal: { mode_descriptions: [] }, player: 0 },
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("selectModesAction", () => {
+  it("builds the SelectModes action the engine expects", () => {
+    expect(selectModesAction([0])).toEqual({
+      type: "SelectModes",
+      data: { indices: [0] },
+    });
+    expect(selectModesAction([0, 2])).toEqual({
+      type: "SelectModes",
+      data: { indices: [0, 2] },
+    });
+  });
+});

--- a/src/sim/decisions/modes.ts
+++ b/src/sim/decisions/modes.ts
@@ -1,0 +1,71 @@
+// "Choose one or more —" modal spells and abilities (Cryptic Command, Kaya's
+// Guile, charm/command cycles…) arrive as `ModeChoice` (spells, carrying
+// `pending_cast`) or `AbilityModeChoice` (activated abilities, carrying
+// `source_id`) — same `modal` shape either way: `mode_descriptions` (oracle
+// text per mode, "~" standing in for the source's own name), `min_choices`/
+// `max_choices`, and `allow_repeat_modes`. Submit the picked indices as a
+// `SelectModes` action.
+
+import type { GameObject, WaitingFor } from "../../engine/types";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export interface ModesPrompt {
+  player: number;
+  /** Oracle text per mode, in engine order — index is what SelectModes echoes back. */
+  modes: string[];
+  minChoices: number;
+  maxChoices: number;
+  allowRepeatModes: boolean;
+  /** The spell/permanent asking for the choice, for the prompt (may be empty). */
+  sourceName: string;
+}
+
+const MODE_KINDS = new Set(["ModeChoice", "AbilityModeChoice"]);
+
+function sourceObjectId(wf: WaitingFor): number | null {
+  const d: any = wf.data ?? {};
+  if (wf.type === "AbilityModeChoice") {
+    return typeof d.source_id === "number" ? d.source_id : null;
+  }
+  const id = d.pending_cast?.object_id;
+  return typeof id === "number" ? id : null;
+}
+
+/** Read a "choose modes" decision aimed at the human, or null. */
+export function parseModesPrompt(
+  wf: WaitingFor | undefined,
+  objects?: Record<string, GameObject>,
+): ModesPrompt | null {
+  if (!wf || !MODE_KINDS.has(wf.type)) return null;
+  const d: any = wf.data ?? {};
+  const modal = d.modal ?? {};
+  const descriptions: string[] = Array.isArray(modal.mode_descriptions)
+    ? modal.mode_descriptions.filter((m: unknown): m is string => typeof m === "string")
+    : [];
+  if (descriptions.length === 0) return null;
+
+  const srcId = sourceObjectId(wf);
+  const sourceName = (srcId != null && objects?.[srcId]?.name) || "";
+  const modes = sourceName
+    ? descriptions.map((m) => m.replaceAll("~", sourceName))
+    : descriptions;
+
+  return {
+    player: typeof d.player === "number" ? d.player : 0,
+    modes,
+    minChoices: typeof modal.min_choices === "number" ? modal.min_choices : 1,
+    maxChoices:
+      typeof modal.max_choices === "number" ? modal.max_choices : descriptions.length,
+    allowRepeatModes: !!modal.allow_repeat_modes,
+    sourceName,
+  };
+}
+
+/** Submit the chosen mode indices back to the engine. */
+export function selectModesAction(indices: number[]): {
+  type: string;
+  data: { indices: number[] };
+} {
+  return { type: "SelectModes", data: { indices } };
+}

--- a/src/sim/driver.ts
+++ b/src/sim/driver.ts
@@ -20,6 +20,7 @@ import {
   parseCreatureTypePrompt,
   type CreatureTypePrompt,
 } from "./decisions/creatureType";
+import { parseModesPrompt, type ModesPrompt } from "./decisions/modes";
 import {
   parseMulliganPrompt,
   type MulliganPrompt,
@@ -212,6 +213,11 @@ export interface DriverCallbacks {
   requestHumanCreatureType?: (
     env: GameStateEnvelope,
     prompt: CreatureTypePrompt & { aiChoice: string | null },
+  ) => Promise<HumanChoice>;
+  /** Called when the human must choose one or more modes on a modal spell/ability. */
+  requestHumanModes?: (
+    env: GameStateEnvelope,
+    prompt: ModesPrompt,
   ) => Promise<HumanChoice>;
   /** Called at game start for the human's opening mulligan (keep / mulligan / bottom). */
   requestHumanMulligan?: (
@@ -506,6 +512,12 @@ export class MatchRunner {
       () => humanRequest(env, cb.requestHumanBlockers, parseBlockersPrompt(wf)),
       () => humanRequest(env, cb.requestHumanMana, parseManaPrompt(wf)),
       () => this.creatureTypeRequest(env, wf, humanSeat),
+      () =>
+        humanRequest(
+          env,
+          cb.requestHumanModes,
+          parseModesPrompt(wf, state.objects),
+        ),
       () =>
         humanRequest(
           env,


### PR DESCRIPTION
Any "choose one or more —" modal spell or activated ability had its mode(s) picked by the AI even when the human cast/activated it — no prompt, no opt-out.

Adds a centered, board-dimming popup for both a spell's `ModeChoice` and an ability's `AbilityModeChoice`:
- Each mode is a floating button; a card that allows repeating a mode gets a `− count +` stepper instead of a plain toggle, so "pick again" and "unpick" aren't ambiguous.
- Gated by the card's min/max choices — Confirm disables until the minimum is met, and further picks are blocked once the max is reached.
- An eye button toggles the popup out of the way (un-dimming the board) so the player can check board state mid-decision, without losing their picks.
- "Let the AI decide" escape hatch, same as every other decision type.

The `modal` wire shape (`mode_descriptions`, `min_choices`/`max_choices`, `allow_repeat_modes`) and the `SelectModes { indices }` submission were captured and verified against the live vendored WASM — for both `ModeChoice` (a spell) and `AbilityModeChoice` (an activated ability) — confirming the state advances correctly after submission. `allow_repeat_modes: true` has no reproducible live example yet, so submitting a repeated index to mean "this mode, again" is a reasonable-but-unverified assumption; flagged as an open question in the feature doc.

Closes #41

## Verification
- `npx tsc --noEmit`, `npx eslint`, `npx vitest run` — all clean (137 passed, 2 pre-existing skips)
- `domainbook validate` / `domainbook check --range origin/main..HEAD` — clean
- Manually verified in the running app (both a non-repeat and a repeat-mode popup): centering/dimming, per-mode cap enforcement, stepper add/remove and its cap, and the eye toggle hiding/restoring the popup with picks intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)