### PR TITLE
feat(deck-draft): assisted "Draft a deck" flow

### DIFF
--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -26,6 +26,10 @@ per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
 ### Changed
 
+- Draft suggestions now tilt toward cards people actually play: each theme's
+  pool is filled by reprint count instead of an alphabetical cap, and the
+  ranking breaks ties toward more-printed cards, bringing the order closer to
+  EDHREC without any external data (`ADR-0010`, `deck-draft/ADR-0002`).
 - Decks that aren't exactly 100 cards can now be saved: they are flagged as
   partial in the library and deck detail and cannot be started in a match,
   and the editor's 100-card block is now a warning instead

--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -35,6 +35,12 @@ per-domain changelogs; this file is the single timeline (`ADR-0007`).
   and the editor's 100-card block is now a warning instead
   (`deck-library/ADR-0002`).
 
+### Fixed
+
+- Base-card color identity for the draft now comes from the local engine, so
+  the commander-selection color-identity coverage holds even when Scryfall
+  resolves a base card incompletely (`ADR-0010`).
+
 ## [0.4.14] - 2026-09-02
 
 ### Changed

--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,6 +12,25 @@ depth live there. A purely-internal PR that touches no product or architecture m
 skip its version with a `Skip-Docs: <reason>` trailer instead. There are no
 per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
+## [0.5.0] - 2026-09-03
+
+### Added
+
+- A **Draft a deck** mode: seed three or more cards (optionally flagging a
+  commander) and get rounds of up to three synergistic, in-identity
+  suggestions to add — each refreshable — steered by a selectable power
+  bracket (default Focused). The engine narrows the pool and measures power
+  and archetype; a self-built heuristic ranks by synergy. Reached from the
+  deck library; leave any time to copy or save the deck so far
+  (`domains/deck-draft/features/draft-a-deck.md`, `ADR-0009`).
+
+### Changed
+
+- Decks that aren't exactly 100 cards can now be saved: they are flagged as
+  partial in the library and deck detail and cannot be started in a match,
+  and the editor's 100-card block is now a warning instead
+  (`deck-library/ADR-0002`).
+
 ## [0.4.14] - 2026-09-02
 
 ### Changed

--- a/domainbook/decisions/0004-enter-decks-by-hand-and-save-them-as-named-decks.md
+++ b/domainbook/decisions/0004-enter-decks-by-hand-and-save-them-as-named-decks.md
@@ -1,5 +1,5 @@
 ---
-status: accepted
+status: superseded by ADR-0009
 date: 2026-08-15
 decision-makers: [RafaelAugustScherer]
 ---

--- a/domainbook/decisions/0009-assist-deck-building-by-suggesting-cards.md
+++ b/domainbook/decisions/0009-assist-deck-building-by-suggesting-cards.md
@@ -1,0 +1,92 @@
+---
+status: accepted
+date: 2026-09-03
+decision-makers: [RafaelAugustScherer]
+---
+
+# Assist deck building by suggesting cards
+
+## Context and Problem Statement
+
+The app measures decks the user already has — consistency by goldfishing, strength by
+head-to-head. It gives no help building one. A user with an idea and a few cards still
+has to know the whole card pool to fill out the other 90-odd slots.
+
+`ADR-0004` framed the project around decks the user enters by hand and settled that no
+field of decks is scraped or bundled. Its stated corollary — repeated as a deck-library
+assumption — was that "the app never curates or suggests." Adding a deck builder that
+proposes cards reopens that corollary: can the app suggest without becoming the scraped
+field `ADR-0004` ruled out, and what powers "good synergy"?
+
+A headless spike settled what the vendored engine can and cannot do here. phase-rs
+exposes, as game-independent functions over the loaded card database: `search_cards_js`
+(a card search), `estimate_bracket_for_deck` (the WotC bracket system, naming the cards
+that drive each axis) and `classify_deck_js` (archetype). It exposes **no** card-fit or
+synergy score — every "scoring" function it has operates on an in-progress game and
+scores legal plays, not deckbuilding fit.
+
+## Decision Drivers
+
+- Lower the barrier from "an idea" to "a legal, measurable 100-card deck."
+- Stay self-contained and client-side (`ADR-0003`) — no new external data feed.
+- Keep the user in control of every card that goes in.
+- Preserve `ADR-0004`'s core: the app does not scrape or browse a field of decks.
+
+## Considered Options
+
+- **Assisted draft, engine-narrowed and locally ranked** — the engine narrows its own
+  card database and measures power/legality; a self-built heuristic ranks by synergy.
+- **Pull co-occurrence data (EDHREC-style)** — best synergy quality, but a new external
+  dependency with no official API, and a clearer reversal of `ADR-0004`'s no-field stance.
+- **Rank by engine simulation** — score each candidate by the marginal change it makes to
+  goldfishing / head-to-head. Rejected: those measure whole decks, are far too slow per
+  candidate, and give almost no signal on a near-empty seed.
+- **Do nothing** — leave building to hand-entry and imports.
+
+## Decision Outcome
+
+Chosen: **an assisted draft mode**, a new `deck draft` context. The user seeds at least
+three `base cards` (optionally flagging one as the `commander card`) and the app offers
+`suggestion round`s of up to three cards, each within the commander's `color identity`,
+each individually refreshable. Candidates come from the engine's card database via
+`search_cards_js`; the ranking is a self-built `synergy score` with the commander weighted
+higher (`deck-draft/ADR-0001`). A selectable `bracket target` (default Focused) steers the
+ranking through `estimate_bracket_for_deck`.
+
+This **supersedes `ADR-0004`** by carrying its still-valid core forward and reversing one
+corollary:
+
+- **Carried forward:** the app scrapes and bundles no field of decks; the user still owns
+  the one deck they build, and opponent decks are still chosen by hand.
+- **Reversed:** the app may now curate and suggest *single cards for the deck under
+  construction*. The suggestions are drawn from the engine's own card set — not from a
+  scraped field of other people's decks.
+
+A drafted deck may be left, copied out, or saved at any point; a partial deck is flagged
+and cannot be played (`deck-library/ADR-0002`).
+
+### Consequences
+
+- Good: a first-class path from a theme to a legal deck; the engine's bracket and
+  archetype measures become live, per-card feedback during the build; nothing leaves the
+  browser, and no external feed is introduced.
+- Good: reuses the engine functions already vendored (`ADR-0006`) — only new worker
+  commands and UI, no new engine surface to build.
+- Bad: synergy is only as good as the heuristic — "reasonable thematic fit", not
+  EDHREC-grade — and the heuristic is now a thing to tune and maintain
+  (`deck-draft/ADR-0001`).
+- Bad: partial decks now exist in the library, so play must be gated where it never had to
+  be before (`deck-library/ADR-0002`).
+
+### Confirmation
+
+The `draft-a-deck` feature scenarios cover seeding, commander-first selection, a
+three-card round with refresh, color-identity legality, bracket steering, and leaving with
+a copy — and the deck-library gating scenario blocks a partial deck from play.
+
+## More Information
+
+The engine capabilities and their limits were established by a runtime spike, not from
+source (`TDR-0001`). The ranking method and the rejected alternatives live in
+`deck-draft/ADR-0001`; the partial-deck storage and play-gating rule in
+`deck-library/ADR-0002`.

--- a/domainbook/decisions/0010-serve-card-lookups-from-the-local-card-database.md
+++ b/domainbook/decisions/0010-serve-card-lookups-from-the-local-card-database.md
@@ -1,0 +1,68 @@
+---
+status: accepted
+date: 2026-09-05
+decision-makers: [RafaelAugustScherer]
+---
+
+# Serve card lookups from the local card database
+
+## Context and Problem Statement
+
+The app is fully client-side (`ADR-0003`) and its identity is "everything is local"
+— card *data* comes from a static snapshot loaded into the phase-rs engine, and the
+only runtime third-party use is meant to be card *art* from Scryfall, cached locally.
+
+New features that need to read card data — name search and autocomplete, type/text
+lookups, filtering, candidate pools — can just as easily reach for a convenient
+third-party API (Scryfall exposes a `/cards/autocomplete`, search, and more). Doing
+so puts a network call on the interaction path: latency and flicker on every
+keystroke, exposure to rate limits and outages, and a feature that stops working
+offline. It also drifts from the card pool the engine actually knows (its legality
+data, which cards exist). Which source do such features use?
+
+## Decision Drivers
+
+- Offline-first: features should keep working with no network once the app has loaded.
+- No latency, flicker, or rate-limit exposure on the interaction path.
+- Consistency: suggestions and lookups should match the pool the engine can play.
+
+## Considered Options
+
+- **The local phase-rs card database** (via the engine worker) as the source for all
+  card-data lookups.
+- **Third-party APIs** (Scryfall search / autocomplete) called at runtime per
+  interaction.
+
+## Decision Outcome
+
+Chosen: **card-data lookups are served from the local phase-rs card database**, via
+the engine worker (`search_cards_js`, `get_card_face_data`, and the like). **Do not
+add runtime third-party (Scryfall) calls for card data.** Scryfall's runtime use
+stays limited to what the local snapshot cannot provide: card art, and the
+collection-resolve step (`fetchCards`) that maps typed names to canonical cards and
+image URLs — both cached locally (`ADR-0003`).
+
+The motivating change: deck-draft base-card autocomplete was first built on
+Scryfall's `/cards/autocomplete`; it now runs against the local database through
+`EngineClient.searchCardNames`, so typing suggests names with zero network calls.
+
+### Consequences
+
+- Good: suggestions and lookups are instant, work offline, and never hit a rate
+  limit; the offered pool matches what the engine knows.
+- Bad: the engine's free-text search matches name *and* oracle text and sorts
+  alphabetically, so a name autocomplete must narrow and re-rank client-side (see
+  `src/draft/cardNameSuggest.ts`). Card-data features also gate on the one-time
+  ~95 MiB engine load, so warm it ahead of need (the draft entry calls
+  `getEngine().ready()` on mount) rather than blocking the first interaction.
+
+### Confirmation
+
+Typing in the draft's base-card fields produces suggestions with no request to
+`api.scryfall.com` (network panel shows only the local engine assets).
+
+## More Information
+
+Sharpens `ADR-0003` (the "only Scryfall for images" line) into a rule for new
+card-data features. Relates to `deck-draft/ADR-0001`, which chose the engine as the
+narrower/validator for drafting and documents the same `search_cards_js` behavior.

--- a/domainbook/domains/analysis/index.md
+++ b/domainbook/domains/analysis/index.md
@@ -75,4 +75,6 @@ Answer "how good is this deck" two ways: **consistency** now, from the deck alon
 - How many matches make a win rate trustworthy, given the 50 cap.
 - Which telemetry beyond winner / turn / mulligans is worth surfacing.
 - Whether consistency and strength later fold into one score (the old roadmap's
-  "power score").
+  "power score"). The engine's `estimate_bracket_for_deck` is now a third "how good" lens,
+  but it lives in `deck draft` as a build-time steering signal (`ADR-0009`); whether it
+  belongs here as a reported measure is open.

--- a/domainbook/domains/deck-draft/decisions/0001-rank-suggestions-with-a-self-built-synergy-heuristic.md
+++ b/domainbook/domains/deck-draft/decisions/0001-rank-suggestions-with-a-self-built-synergy-heuristic.md
@@ -38,12 +38,16 @@ the engine; it has to be built.
 
 Chosen: **a self-built heuristic ranks; the engine narrows and validates.**
 
-- **Narrow:** `search_cards_js`, queried on `theme token`s pulled from the deck, produces
-  the candidate pool; results are filtered to the commander's `color identity` and to
-  Commander legality.
+- **Narrow:** regular-card rounds query `search_cards_js` with `theme token`s pulled from
+  the deck. Commander rounds instead inspect every Commander-legal, commander-eligible
+  card locally through `get_card_face_data`, because a narrow text search can miss valid
+  leaders before the deck has a commander.
 - **Rank:** the `synergy score` sums the theme tokens a candidate shares with the deck —
   creature subtypes, keywords, salient oracle-text phrases — with `commander weighting`
-  applied, plus a term for the deck's role gaps and mana curve.
+  applied, plus a term for the deck's role gaps and mana curve. Commander ranking also
+  favors the smallest color identity that covers every base card.
+- **Enrich:** after local commander ranking, only the three displayed cards are resolved
+  through Scryfall for images and display data.
 - **Steer and validate:** for the shortlist, `estimate_bracket_for_deck` supplies the
   `bracket target` tilt (and a plain-language reason, since it names the contributing
   cards), and `classify_deck_js` shows the archetype the deck is drifting toward.

--- a/domainbook/domains/deck-draft/decisions/0001-rank-suggestions-with-a-self-built-synergy-heuristic.md
+++ b/domainbook/domains/deck-draft/decisions/0001-rank-suggestions-with-a-self-built-synergy-heuristic.md
@@ -38,16 +38,17 @@ the engine; it has to be built.
 
 Chosen: **a self-built heuristic ranks; the engine narrows and validates.**
 
-- **Narrow:** regular-card rounds query `search_cards_js` with `theme token`s pulled from
-  the deck. Commander rounds instead inspect every Commander-legal, commander-eligible
-  card locally through `get_card_face_data`, because a narrow text search can miss valid
-  leaders before the deck has a commander.
+- **Narrow:** regular-card rounds query `search_cards_js` broadly across the strongest
+  current `theme token`s, cache those local results, and use `get_card_face_data` to supply
+  text and types for scoring. They filter the pool by Commander legality and the chosen
+  color identity. Commander rounds inspect every Commander-legal, commander-eligible card
+  because a narrow search can miss valid leaders before the deck has a commander.
 - **Rank:** the `synergy score` sums the theme tokens a candidate shares with the deck —
   creature subtypes, keywords, salient oracle-text phrases — with `commander weighting`
   applied, plus a term for the deck's role gaps and mana curve. Commander ranking also
   favors the smallest color identity that covers every base card.
-- **Enrich:** after local commander ranking, only the three displayed cards are resolved
-  through Scryfall for images and display data.
+- **Enrich:** after local ranking, only the three displayed cards are resolved through
+  Scryfall for images and display data.
 - **Steer and validate:** for the shortlist, `estimate_bracket_for_deck` supplies the
   `bracket target` tilt (and a plain-language reason, since it names the contributing
   cards), and `classify_deck_js` shows the archetype the deck is drifting toward.

--- a/domainbook/domains/deck-draft/decisions/0001-rank-suggestions-with-a-self-built-synergy-heuristic.md
+++ b/domainbook/domains/deck-draft/decisions/0001-rank-suggestions-with-a-self-built-synergy-heuristic.md
@@ -1,0 +1,81 @@
+---
+status: accepted
+date: 2026-09-03
+decision-makers: [RafaelAugustScherer]
+---
+
+# Rank suggestions with a self-built synergy heuristic
+
+## Context and Problem Statement
+
+Drafting needs a per-card fit signal: given the deck so far, rank candidate cards by how
+well the next one fits. `ADR-0009` committed to assisted drafting; this decides what
+produces the ordering.
+
+A runtime spike over the vendored engine (v0.71) settled what phase-rs can supply. It
+exposes, with no running game and tolerant of a partial deck:
+
+- `search_cards_js` — a card search over the database, filterable by free text and by
+  color-identity containment; returns lean rows (name, mana value, color identity,
+  legalities).
+- `estimate_bracket_for_deck` — the WotC bracket, naming the cards that drive each axis.
+- `classify_deck_js` — the deck's archetype.
+
+It exposes **no** card-fit or synergy score. Every scoring function it has
+(`get_ai_scored_candidates` and the rest) operates on an in-progress game and scores legal
+plays — cast, land, pass — not deckbuilding fit. So the ordering cannot be borrowed from
+the engine; it has to be built.
+
+## Considered Options
+
+- **Self-built heuristic over card text and types**, with the engine as narrower and
+  validator.
+- **External co-occurrence data** (EDHREC "high synergy" and the like).
+- **Engine marginal-strength ranking** — score a candidate by the change it makes to
+  goldfishing or head-to-head when added.
+
+## Decision Outcome
+
+Chosen: **a self-built heuristic ranks; the engine narrows and validates.**
+
+- **Narrow:** `search_cards_js`, queried on `theme token`s pulled from the deck, produces
+  the candidate pool; results are filtered to the commander's `color identity` and to
+  Commander legality.
+- **Rank:** the `synergy score` sums the theme tokens a candidate shares with the deck —
+  creature subtypes, keywords, salient oracle-text phrases — with `commander weighting`
+  applied, plus a term for the deck's role gaps and mana curve.
+- **Steer and validate:** for the shortlist, `estimate_bracket_for_deck` supplies the
+  `bracket target` tilt (and a plain-language reason, since it names the contributing
+  cards), and `classify_deck_js` shows the archetype the deck is drifting toward.
+
+The two alternatives were rejected for now:
+
+- **Co-occurrence data** would give the best synergy quality, but it is a new external
+  dependency with no official API, it must be fetched or scraped, and it is a sharper
+  reversal of `ADR-0004`'s no-field stance than suggesting from the engine's own card set.
+  Left open as a later opt-in if the heuristic proves too weak.
+- **Marginal-strength ranking** measures whole decks, not a card's marginal fit; it is far
+  too slow to run per candidate over a large pool, and on a near-empty seed the padding
+  swamps any one card's signal. The engine's strength measures stay a whole-deck
+  validator, not a per-card oracle.
+
+### Consequences
+
+- Good: fully client-side, no new data feed; the heuristic is transparent and tunable; the
+  engine's bracket and archetype become live feedback for free.
+- Bad: synergy is "reasonable thematic fit", not EDHREC-grade — a card that combos only
+  through a subtle interaction the text does not name will be missed. The `theme token`
+  list is the ceiling and a standing maintenance surface.
+- Bad: the engine surface it leans on was learned by introspection and can shift under an
+  upgrade (`TDR-0001`); the draft worker commands must be re-checked when the engine is
+  re-pinned (`ADR-0006`, `docs/engine-upgrade.md`).
+
+### Confirmation
+
+The `draft-a-deck` scenarios assert that suggestions stay within color identity and
+Commander legality, that the commander leads the ranking, and that the bracket target
+shifts what is offered.
+
+## More Information
+
+The directional decision and the carried-forward parts of `ADR-0004` are in `ADR-0009`.

--- a/domainbook/domains/deck-draft/decisions/0002-tilt-ranking-toward-played-cards-with-a-reprint-count-proxy.md
+++ b/domainbook/domains/deck-draft/decisions/0002-tilt-ranking-toward-played-cards-with-a-reprint-count-proxy.md
@@ -1,0 +1,78 @@
+---
+status: accepted
+date: 2026-09-05
+decision-makers: [RafaelAugustScherer]
+---
+
+# Tilt ranking toward played cards with a reprint-count proxy
+
+## Context and Problem Statement
+
+`ADR-0001` ranks candidates by the `synergy score` — shared `theme token`s plus curve and
+role fit. Checked against EDHREC's own picks for popular commanders (Krenko, Edgar Markov,
+Meren), the *theme* came out right but the *order* did not: within a correct theme the
+staples people actually play sank beneath vanilla same-subtype cards. Two structural causes:
+
+- **The per-token search was capped at 250 rows, and `search_cards_js` returns them
+  alphabetically.** A common token like `graveyard` matches thousands of cards, so the pool
+  only ever held early-alphabet ones — Eternal Witness sits at ~#1,300 alphabetically and
+  was unreachable. The cap was excluding most of a theme, not sampling it.
+- **Nothing in the score reflects how played a card is** — which is exactly what an EDHREC
+  ordering encodes. The card database carries no `edhrec_rank` or play-rate field.
+
+## Considered Options
+
+- **A reprint-count popularity proxy** drawn from the card data we already load
+  (`metadata.source_printing_ids`), used both to pick each token's pool and to break ranking
+  ties.
+- **External EDHREC / co-occurrence data** — the option `ADR-0001` left open "if the
+  heuristic proves too weak".
+- **Weighting mechanic tokens above creature-subtype tokens**, to stop an incidental shared
+  subtype from defining a non-tribal deck.
+
+## Decision Outcome
+
+Chosen: **a reprint-count proxy for popularity**, sourced locally.
+
+- **Fix the pool.** For each theme token, pull every Commander-legal match, sort by reprint
+  count, and keep the top slice — the pool is now the most-printed matches, not an
+  alphabetical prefix. This alone makes the rest of a common theme reachable.
+- **Tilt the rank.** Add `POPULARITY_WEIGHT * log2(1 + printings)` to the `synergy score`.
+  `log2` keeps it a nudge over comparable fits rather than a re-sort by reprint count; the
+  weight (0.75) was calibrated against EDHREC staple lists for popular commanders.
+- **Source it locally.** The name→printing-count index is built once, at card-database load,
+  by parsing the same card-data JSON the worker already fetches (~250 ms). No network, no
+  Scryfall — consistent with `ADR-0010`.
+
+The alternatives were rejected:
+
+- **External EDHREC data** remains the sharper reversal of the no-field stance
+  (`ADR-0004`, `ADR-0009`) that `ADR-0001` set aside; the in-data proxy captured most of the
+  gain with none of the new dependency.
+- **Mechanic-over-subtype weighting** was implemented and measured against the same staple
+  lists, and it *reduced* alignment: boosting mechanic tokens lifted evergreen keywords
+  (haste, first strike) into the search tokens and polluted tribal pools with off-theme but
+  heavily-reprinted cards. It was dropped; the existing token weighting stands.
+
+### Consequences
+
+- Good: measurably closer to EDHREC's picks — staples like Siege-Gang Commander, Goblin
+  Warchief and Eternal Witness now surface where alphabetical filler used to sit. Softens
+  `ADR-0001`'s "reasonable thematic fit, not EDHREC-grade" limit without a data feed.
+- Bad: reprint count is a noisy proxy — long-reprinted commons are over-counted and recent
+  staples under-counted, so it nudges rather than ranks.
+- Bad: the proxy reads `metadata.source_printing_ids`, part of the introspected engine
+  surface that can shift on a re-pin (`TDR-0001`); the index build must be re-checked when
+  the engine is re-pinned (`ADR-0006`, `docs/engine-upgrade.md`).
+
+### Confirmation
+
+The `draft-a-deck` scenarios still assert legality, color identity, and commander-led
+ordering. The popularity tilt and its weight were calibrated with a headless evaluation
+against EDHREC staple lists for popular commanders (run ad hoc, not committed — it needs the
+~95 MiB engine assets, like the engine smoke gate).
+
+## More Information
+
+Refines the **Narrow** and **Rank** steps of `ADR-0001`; the local-only sourcing follows
+`ADR-0010`.

--- a/domainbook/domains/deck-draft/features/draft-a-deck.md
+++ b/domainbook/domains/deck-draft/features/draft-a-deck.md
@@ -93,10 +93,10 @@ Example: Commander themes outrank equal non-commander themes
 ## Rule: A round offers three cards, each refreshable, with no repeats in the round
 
 Each `suggestion round` shows exactly three cards whenever at least three legal candidates
-exist in the card database. Theme matches rank first; when they leave a round short, the
-engine fills the remaining slots from all legal candidates before any card is shown. Any one
-can be refreshed on its own, replaced by the closest remaining candidate that has not
-appeared in this round. Adding a card ends the round.
+exist in the card database. Commander candidates are narrowed, scored, and ranked locally
+before only the three selected cards are fetched for display. Any one can be refreshed on its
+own, replaced by the closest remaining candidate that has not appeared in this round. Adding
+a card ends the round.
 
 ```gherkin
 Example: Refresh swaps one slot for a close, unseen card
@@ -111,9 +111,8 @@ Example: Adding a card starts a fresh round
   Then a new round is offered
   And a card is free to appear again in this new round
 
-Example: A narrow theme search still produces a full commander round
-  Given the themed search finds one legal commander for the base cards
-  And at least three legal commanders exist in the card database
+Example: Commander ranking produces a full round
+  Given at least three legal commanders exist in the card database
   When the commander-selection round is suggested
   Then it shows exactly three legal commanders
 ```

--- a/domainbook/domains/deck-draft/features/draft-a-deck.md
+++ b/domainbook/domains/deck-draft/features/draft-a-deck.md
@@ -1,0 +1,127 @@
+---
+id: draft-a-deck
+name: Draft a deck
+status: draft
+---
+
+## Story
+
+As a deck author with an idea but not a full list
+I want to seed a few cards and be offered synergistic cards to add, a few at a time
+So that I can build a legal, measurable Commander deck without knowing the whole card pool
+
+The draft opens from a **Draft a deck** entry in the `deck library`, beside the by-hand
+editor. It produces the same `SavedDeck` the rest of the app already understands, so a
+finished draft flows straight into `match setup`; an unfinished one is saved partial and
+flagged (`deck-library/ADR-0002`).
+
+## Rule: A draft starts from at least three base cards
+
+The user enters three or more `base cards` to seed the theme. One may be flagged as the
+`commander card`. Fewer than three is refused — three is the floor for a theme worth
+ranking against.
+
+```gherkin
+Example: Three seed cards start a draft
+  Given the author enters "Krenko, Mob Boss", "Goblin Chieftain" and "Skirk Prospector"
+  And flags "Krenko, Mob Boss" as the commander
+  When the author starts the draft
+  Then the draft opens with those three cards in the deck
+  And the color identity is fixed to red
+
+Example: Fewer than three is refused
+  Given the author has entered only two cards
+  When the author tries to start the draft
+  Then starting is refused and the three-card minimum is shown
+```
+
+## Rule: When the seed names no commander, the commander is chosen first
+
+If none of the `base cards` is flagged commander, the first `suggestion round` offers
+commander-eligible cards. Picking one sets the deck's `color identity` before any other
+card is suggested.
+
+```gherkin
+Example: The first round picks a commander
+  Given a draft seeded with three cards and no commander flagged
+  When the draft opens
+  Then the first round offers commander-eligible cards only
+  And choosing one sets the deck's color identity
+  And the next round's suggestions all fall within that identity
+```
+
+## Rule: The commander leads the ranking
+
+Cards are ranked by `synergy score`, and `theme token`s from the `commander card` weigh
+more than those from the other cards, so suggestions follow the commander's direction.
+
+```gherkin
+Example: Commander themes outrank equal non-commander themes
+  Given a deck whose commander is an Elf and whose other cards include one Goblin
+  When a round is suggested
+  Then an Elf-tribal candidate ranks above a Goblin-tribal candidate of otherwise equal fit
+```
+
+## Rule: A round offers up to three cards, each refreshable, with no repeats in the round
+
+Each `suggestion round` shows up to three cards. Any one can be refreshed on its own,
+replaced by the closest remaining candidate that has not appeared in this round. Adding a
+card ends the round.
+
+```gherkin
+Example: Refresh swaps one slot for a close, unseen card
+  Given a round showing three suggestions
+  When the author refreshes the middle card
+  Then that slot shows a different card close to the one it replaced
+  And no card shown earlier this round reappears
+
+Example: Adding a card starts a fresh round
+  Given a round showing three suggestions
+  When the author adds one of them to the deck
+  Then a new round is offered
+  And a card is free to appear again in this new round
+```
+
+## Rule: Suggestions stay legal and follow the bracket target
+
+Every suggested card is within the commander's `color identity` and legal in Commander. A
+selectable `bracket target` (default Focused) steers the ranking; a card that would push
+the deck past the target is pushed down, not hidden.
+
+```gherkin
+Example: Out-of-identity cards are never offered
+  Given a mono-red commander
+  When any round is suggested
+  Then no suggestion has a color identity outside red
+
+Example: The bracket target shifts what is offered
+  Given a draft with the bracket target set to Focused
+  When the target is raised to cEDH
+  Then higher-powered cards the previous target held back now rank up
+```
+
+## Rule: A draft can be left at any point with its deck kept
+
+The user can stop at any time. The deck so far can be copied out as decklist text and
+saved to the library. If it is not yet 100 cards it is saved as a partial deck — flagged,
+and blocked from play (`deck-library/ADR-0002`).
+
+```gherkin
+Example: Leaving copies the partial deck out
+  Given a draft with 40 cards chosen
+  When the author copies the deck out
+  Then the clipboard holds decklist text that parses back to the same 40 cards
+
+Example: A partial draft saves flagged and unplayable
+  Given a draft with 40 cards chosen
+  When the author saves it to the library
+  Then it appears flagged as partial
+  And it cannot be selected to start a match
+```
+
+## Open Questions
+
+- Whether a completed draft (exactly 100 cards) should offer to jump straight into
+  `match setup`, or just land in the library like any saved deck.
+- Whether to show the running archetype and bracket as live labels every round, or only on
+  request, given each is an engine call.

--- a/domainbook/domains/deck-draft/features/draft-a-deck.md
+++ b/domainbook/domains/deck-draft/features/draft-a-deck.md
@@ -90,11 +90,13 @@ Example: Commander themes outrank equal non-commander themes
   Then an Elf-tribal candidate ranks above a Goblin-tribal candidate of otherwise equal fit
 ```
 
-## Rule: A round offers up to three cards, each refreshable, with no repeats in the round
+## Rule: A round offers three cards, each refreshable, with no repeats in the round
 
-Each `suggestion round` shows up to three cards. Any one can be refreshed on its own,
-replaced by the closest remaining candidate that has not appeared in this round. Adding a
-card ends the round.
+Each `suggestion round` shows exactly three cards whenever at least three legal candidates
+exist in the card database. Theme matches rank first; when they leave a round short, the
+engine fills the remaining slots from all legal candidates before any card is shown. Any one
+can be refreshed on its own, replaced by the closest remaining candidate that has not
+appeared in this round. Adding a card ends the round.
 
 ```gherkin
 Example: Refresh swaps one slot for a close, unseen card
@@ -108,6 +110,12 @@ Example: Adding a card starts a fresh round
   When the author adds one of them to the deck
   Then a new round is offered
   And a card is free to appear again in this new round
+
+Example: A narrow theme search still produces a full commander round
+  Given the themed search finds one legal commander for the base cards
+  And at least three legal commanders exist in the card database
+  When the commander-selection round is suggested
+  Then it shows exactly three legal commanders
 ```
 
 ## Rule: Suggestions stay legal and follow the bracket target

--- a/domainbook/domains/deck-draft/features/draft-a-deck.md
+++ b/domainbook/domains/deck-draft/features/draft-a-deck.md
@@ -1,7 +1,7 @@
 ---
 id: draft-a-deck
 name: Draft a deck
-status: draft
+status: implemented
 ---
 
 ## Story

--- a/domainbook/domains/deck-draft/features/draft-a-deck.md
+++ b/domainbook/domains/deck-draft/features/draft-a-deck.md
@@ -97,6 +97,22 @@ Example: Commander themes outrank equal non-commander themes
   Then an Elf-tribal candidate ranks above a Goblin-tribal candidate of otherwise equal fit
 ```
 
+## Rule: Among comparable fits, more-played cards rank higher
+
+When two candidates fit the theme about equally, the one that is more played wins. The
+`synergy score` has no play-rate data to read, so a card's reprint count stands in for
+popularity: it both fills each theme's candidate pool with the most-printed matches and
+tilts the final ranking toward them (`deck-draft/ADR-0002`). It is a nudge over comparable
+fits, not an override — a clearly stronger theme match still leads.
+
+```gherkin
+Example: A staple outranks a vanilla card of equal theme fit
+  Given two mono-red Goblins whose only shared theme token is Goblin
+  And one is a long-reprinted staple and the other a fringe printing
+  When a round is suggested
+  Then the staple ranks above the fringe card
+```
+
 ## Rule: A round offers three cards, each refreshable, with no repeats in the round
 
 Each `suggestion round` shows exactly three cards whenever at least three legal candidates

--- a/domainbook/domains/deck-draft/features/draft-a-deck.md
+++ b/domainbook/domains/deck-draft/features/draft-a-deck.md
@@ -71,6 +71,10 @@ identities to cover the base cards. This only applies when exactly one Backgroun
 the base cards — with more than one, pairing is ambiguous and every candidate falls back to
 the solo-coverage rule.
 
+Each base card's color identity is read from the local engine, the source of truth for
+card data (`ADR-0010`), not from Scryfall — so the coverage rule holds regardless of
+network or Scryfall state.
+
 ```gherkin
 Example: An off-color candidate is never offered
   Given base cards whose color identities union to green and blue only

--- a/domainbook/domains/deck-draft/features/draft-a-deck.md
+++ b/domainbook/domains/deck-draft/features/draft-a-deck.md
@@ -11,15 +11,22 @@ I want to seed a few cards and be offered synergistic cards to add, a few at a t
 So that I can build a legal, measurable Commander deck without knowing the whole card pool
 
 The draft opens from a **Draft a deck** entry in the `deck library`, beside the by-hand
-editor. It produces the same `SavedDeck` the rest of the app already understands, so a
-finished draft flows straight into `match setup`; an unfinished one is saved partial and
-flagged (`deck-library/ADR-0002`).
+editor. It can also be launched from the editor itself with **Draft from this deck**, which
+seeds the draft with the cards already in the list being edited (its commander pre-picked).
+It produces the same `SavedDeck` the rest of the app already understands, so a finished
+draft flows straight into `match setup`; an unfinished one is saved partial and flagged
+(`deck-library/ADR-0002`).
 
 ## Rule: A draft starts from at least three base cards
 
 The user enters three or more `base cards` to seed the theme. One may be flagged as the
 `commander card`. Fewer than three is refused — three is the floor for a theme worth
 ranking against.
+
+Base cards can be entered two ways: **one by one**, where each field suggests matching card
+names as it is typed and a card is flagged commander with a radio; or by **pasting a list**
+of names (the same decklist text the editor accepts), with the commander chosen from a
+select below. Seeding from an existing deck uses the paste form, pre-filled.
 
 ```gherkin
 Example: Three seed cards start a draft
@@ -93,10 +100,11 @@ Example: Commander themes outrank equal non-commander themes
 ## Rule: A round offers three cards, each refreshable, with no repeats in the round
 
 Each `suggestion round` shows exactly three cards whenever at least three legal candidates
-exist in the card database. Commander candidates are narrowed, scored, and ranked locally
-before only the three selected cards are fetched for display. Any one can be refreshed on its
-own, replaced by the closest remaining candidate that has not appeared in this round. Adding
-a card ends the round.
+exist in the card database. Candidates are narrowed, scored, bracket-adjusted, and ranked
+locally before only the three selected cards are fetched for display. Any one can be refreshed
+on its own, replaced by the closest remaining candidate that has not appeared in this round.
+Adding a card ends the round. The next ranking rebuilds its profile from the commander and
+every card selected so far.
 
 ```gherkin
 Example: Refresh swaps one slot for a close, unseen card
@@ -109,6 +117,7 @@ Example: Adding a card starts a fresh round
   Given a round showing three suggestions
   When the author adds one of them to the deck
   Then a new round is offered
+  And its suggestions are scored against the updated deck
   And a card is free to appear again in this new round
 
 Example: Commander ranking produces a full round

--- a/domainbook/domains/deck-draft/features/draft-a-deck.md
+++ b/domainbook/domains/deck-draft/features/draft-a-deck.md
@@ -50,6 +50,34 @@ Example: The first round picks a commander
   And the next round's suggestions all fall within that identity
 ```
 
+## Rule: Only candidates that can cover every base card's color identity are offered
+
+When no `base card` is flagged commander, the first `suggestion round` offers only
+commander-eligible candidates whose `color identity` is a superset of the union of every
+base card's own color identity — the same subset rule that governs a legal Commander deck,
+enforced up front instead of left to chance. A candidate that would leave some base card
+outside the eventual commander's identity is never offered, in either direction.
+
+The one exception is a **Background**: a legendary Background enchantment among the base
+cards may pair with a candidate that has **Choose a Background**, unioning their two
+identities to cover the base cards. This only applies when exactly one Background is among
+the base cards — with more than one, pairing is ambiguous and every candidate falls back to
+the solo-coverage rule.
+
+```gherkin
+Example: An off-color candidate is never offered
+  Given base cards whose color identities union to green and blue only
+  When the first round offers commander candidates
+  Then no candidate has a color identity outside green and blue
+
+Example: A Choose a Background candidate may cover with its Background
+  Given base cards that include exactly one Background, blue
+  And another base card is green
+  When the first round offers commander candidates
+  Then a green candidate with Choose a Background is offered
+  And picking it makes both cards commanders, with their identities unioned
+```
+
 ## Rule: The commander leads the ranking
 
 Cards are ranked by `synergy score`, and `theme token`s from the `commander card` weigh

--- a/domainbook/domains/deck-draft/glossary.md
+++ b/domainbook/domains/deck-draft/glossary.md
@@ -39,7 +39,8 @@ slot holds its flavour.
 
 The self-built ranking of a candidate card against the cards already in the deck — the
 sum of the `theme token`s it shares (with `commander weighting` applied), plus fit for
-the deck's role gaps and mana curve, plus the `bracket target` tilt. The engine supplies
+the deck's role gaps and mana curve, plus the `bracket target` tilt, plus a small tilt
+toward more-played cards by reprint count (`deck-draft/ADR-0002`). The engine supplies
 no such score; this context owns it (`deck-draft/ADR-0001`).
 
 - **Status:** draft

--- a/domainbook/domains/deck-draft/glossary.md
+++ b/domainbook/domains/deck-draft/glossary.md
@@ -1,0 +1,81 @@
+# Deck draft glossary
+
+The words the deck-draft context uses. Shared Magic and Commander terms — `deck`,
+`commander card`, `color identity` — are in the book glossary, and `partial deck` lives
+in the deck-library glossary; these are the ones this context adds.
+
+## Base cards
+
+The three or more cards the user enters to start a draft, setting its theme. One of them
+may be flagged as the `commander card`; if none is, the first `suggestion round` picks
+the commander.
+
+- **Aliases:** seed cards, seed
+- **Status:** draft
+- **Example:** Seeding "Krenko, Mob Boss", "Goblin Chieftain" and "Skirk Prospector"
+  points the draft at mono-red Goblins.
+
+## Suggestion round
+
+One set of up to three suggested cards, offered after a card is added (or at the start).
+Within a round the same card is never shown twice, refreshes included; adding a card ends
+the round and begins the next.
+
+- **Status:** draft
+- **Example:** After adding a card, the round shows three new candidates ranked by
+  `synergy score`.
+
+## Refresh
+
+Replacing a single suggested card in the current round with the next best candidate that
+has not been shown this round — kept as close as possible to the card it replaces, so the
+slot holds its flavour.
+
+- **Status:** draft
+- **Example:** Refreshing a suggested board wipe offers a different board wipe before an
+  unrelated card.
+
+## Synergy score
+
+The self-built ranking of a candidate card against the cards already in the deck — the
+sum of the `theme token`s it shares (with `commander weighting` applied), plus fit for
+the deck's role gaps and mana curve, plus the `bracket target` tilt. The engine supplies
+no such score; this context owns it (`deck-draft/ADR-0001`).
+
+- **Status:** draft
+
+## Theme token
+
+A signal pulled from a card that the score matches on: a creature subtype (a tribe like
+Goblin), a keyword, or a salient oracle-text phrase (`+1/+1 counter`, `sacrifice`,
+`create ... token`, `landfall`). The set of tokens the heuristic recognises sets its
+ceiling.
+
+- **Aliases:** theme signal
+- **Status:** draft
+
+## Commander weighting
+
+The rule that `theme token`s coming from the `commander card` count for more than those
+from the other 99 when scoring a candidate, so the commander leads the deck's direction.
+
+- **Status:** draft
+- **Example:** With an Elf commander, Elf-tribal candidates outrank cards that only match
+  a non-commander theme of equal strength.
+
+## Bracket target
+
+The power level (Exhibition, Core, Upgraded/Focused, Optimized, cEDH) the user aims the
+draft at, defaulting to Focused. It steers the ranking through the engine's
+`estimate_bracket_for_deck`; a card that would push the deck past the target is penalised.
+
+- **Aliases:** target bracket
+- **Status:** draft
+
+## Draft session
+
+The in-progress draft state: the `base cards`, the chosen `bracket target`, the deck so
+far, and the current `suggestion round`. It is not a saved `deck` until the user saves or
+copies it out.
+
+- **Status:** draft

--- a/domainbook/domains/deck-draft/index.md
+++ b/domainbook/domains/deck-draft/index.md
@@ -1,0 +1,114 @@
+---
+id: deck-draft
+name: Deck draft
+classification:
+  domain: supporting-domain
+  business-model: engagement-creator
+  evolution: custom-built
+owners: [RafaelAugustScherer]
+code:
+  - src/draft/**
+relationships:
+  - with: simulation
+    type: customer-supplier
+    direction: downstream
+  - with: deck-library
+    type: customer-supplier
+    direction: downstream
+---
+
+## Purpose
+
+Help the user build a `deck` from scratch. They seed a few `base cards` that set the
+theme, and the context suggests the next cards to add — one `suggestion round` of up
+to three at a time, each within the `commander card`'s `color identity`, ranked by how
+well it fits what is already in the deck. The point is to get from an idea to a legal
+100-card deck the rest of the app can then measure, without the user having to know the
+whole card pool by heart.
+
+## Domain Roles
+
+- Assisted-authoring context: the counterpart to `deck library`'s by-hand authoring.
+  The user still owns every choice — they pick from three, or refresh for three more —
+  but the context proposes the candidates rather than leaving the blank page (`ADR-0009`).
+- Ranking context: it owns the `synergy score`. Candidates come from the engine's own
+  card database (narrowed by `search_cards_js`); the *ordering* is a self-built
+  heuristic over card text and types, because the engine has no card-fit signal to lean
+  on (`deck-draft/ADR-0001`).
+- Steering context: a selectable `bracket target` (default Focused) tilts the ranking
+  using the engine's `estimate_bracket_for_deck`, so a draft aimed at a casual table and
+  one aimed at cEDH pull different cards.
+
+## Inbound Communication
+
+| Message             | Collaborator | Type    |
+| ------------------- | ------------ | ------- |
+| `StartDraft`        | user         | Command |
+| `SetBracketTarget`  | user         | Command |
+| `RequestSuggestions`| user         | Command |
+| `RefreshSuggestion` | user         | Command |
+| `AddCard`           | user         | Command |
+| `ExportDraft`       | user         | Query   |
+
+## Outbound Communication
+
+| Message           | Collaborator          | Type    |
+| ----------------- | --------------------- | ------- |
+| `SearchCards`     | phase-rs (via simulation) | Query |
+| `EstimateBracket` | phase-rs (via simulation) | Query |
+| `ClassifyDeck`    | phase-rs (via simulation) | Query |
+| `ResolveCardNames`| Scryfall (extern)     | Query   |
+| `SaveNamedDeck`   | deck-library          | Command |
+
+## Business Decisions
+
+- Candidates are drawn from the engine's own card database and narrowed by
+  `search_cards_js`; they are then ranked locally by a `synergy score`, because the
+  engine exposes deck-power and archetype measures but no card-fit scorer
+  (`deck-draft/ADR-0001`, `ADR-0009`).
+- The `commander card` carries more weight than the other 99 when scoring fit; if the
+  `base cards` name no commander, the first `suggestion round` picks the commander, so
+  `color identity` is fixed before any other suggestion is made (`draft-a-deck`).
+- A `bracket target` (default Focused) steers the ranking through the engine's bracket
+  estimate; a card that would push the deck past the target is penalised, not hidden —
+  the user stays in control (`ADR-0009`).
+- The draft never scrapes or browses a field of decks. It proposes single cards for the
+  one deck the user is building — carrying forward `ADR-0004`'s stance while reversing
+  its "the app never curates or suggests" corollary (`ADR-0009`).
+- A draft can be left at any point: its partial deck is copy/paste-able and can be
+  saved to the `deck library`, but a partial deck is flagged and cannot be played
+  (`deck-library/ADR-0002`).
+
+## Assumptions
+
+- The engine's deck-evaluation functions (`search_cards_js`, `estimate_bracket_for_deck`,
+  `classify_deck_js`) are game-independent and partial-deck-safe — they need only the
+  loaded card database, not a running game. This was confirmed by runtime introspection,
+  not from source, so the churning-ABI risk still applies (`TDR-0001`).
+- Synergy quality lives entirely in the heuristic; the engine measures power and
+  legality, never synergy. The heuristic is the tuning lever, and its `theme token` list
+  is where its ceiling is set.
+- Scryfall supplies card text and images for the handful of cards on screen; the
+  candidate pool is filtered to the commander's `color identity` from the engine result
+  before that enrichment, so only a small set is fetched per round.
+
+## Verification Metrics
+
+- Every suggested card is within the `commander card`'s `color identity` and legal in
+  Commander.
+- A card shown in a `suggestion round` never reappears in that same round, including
+  across refreshes.
+- Leaving a draft yields a decklist that round-trips through the parser — pasting it
+  back produces the same cards.
+- A partial deck produced by a draft cannot be started in `match setup`.
+
+## Open Questions
+
+- How large and how curated the oracle-text `theme token` list should be — it is the
+  main lever of synergy quality, and too broad a list dilutes the score.
+- Whether the engine `bracket` folds into analysis's contemplated "power score" or stays
+  a draft-only steering signal (`analysis` open questions).
+- Whether a `refresh` should replace a card with the closest remaining candidate to the
+  one dropped, or simply walk the global ranking.
+- Whether to hard-filter unsupported cards (`coverage`) out of suggestions or only
+  surface them, mirroring `deck library`'s open question.

--- a/domainbook/domains/deck-library/decisions/0002-store-partial-decks-but-flag-them-unplayable.md
+++ b/domainbook/domains/deck-library/decisions/0002-store-partial-decks-but-flag-them-unplayable.md
@@ -1,0 +1,59 @@
+---
+status: accepted
+date: 2026-09-03
+decision-makers: [RafaelAugustScherer]
+---
+
+# Store partial decks but flag them unplayable
+
+## Context and Problem Statement
+
+Until now every saved deck was legal: the editor refused to save anything but exactly 100
+cards, so completeness never had to be checked again downstream. `match setup` picks decks
+straight from the library with no legality gate, because it never needed one.
+
+Assisted drafting (`ADR-0009`) breaks that guarantee. A user drafting a deck wants to leave
+partway through and keep what they have, and the same relaxation lets a deck be hand-entered
+incomplete. So the library must now hold decks that are not yet 100 cards — without letting
+one reach a game, where the engine would reject it or, worse, play it short.
+
+## Considered Options
+
+- **Allow any card count; derive playability from the 100-card rule; gate at play time.**
+- **Add an explicit `draft`/`complete` flag to the deck model** and gate on that.
+- **Keep the editor strict** and let only the draft flow emit partial decks.
+
+## Decision Outcome
+
+Chosen: **partial decks are first-class in storage but gated from play, and playability is
+derived, not stored.**
+
+- The editor's hard 100-card block becomes a warning; any card count can be saved.
+- Playability stays derived from the existing 100-card rule (`isHundredCards`) — no new
+  field on the deck model, so an incomplete deck completed later is simply playable, with
+  nothing to reconcile.
+- The library and deck detail flag a deck that is not exactly 100 cards as partial and not
+  playable.
+- `match setup` will not start with a partial deck selected — the deck picker marks it and
+  the start control refuses it — so an incomplete deck is caught before a game, the same
+  discipline `TDR-0002` set for unsupported cards.
+
+An explicit flag was rejected because the count already carries the truth; a stored flag
+could drift from the actual card count and would have to be kept in sync on every edit.
+
+### Consequences
+
+- Good: a draft can be saved and resumed; nothing incomplete can be played; the rule is
+  one derivation reused everywhere.
+- Bad: play-time now has a gate it never had, in `match setup` — a place that previously
+  trusted the library completely.
+
+### Confirmation
+
+The deck-library scenarios cover saving a partial deck, seeing it flagged, and being
+refused when trying to start a match with it.
+
+## More Information
+
+The draft flow that first produces partial decks is `deck-draft` (`ADR-0009`,
+`draft-a-deck`).

--- a/domainbook/domains/deck-library/features/author-a-named-deck.md
+++ b/domainbook/domains/deck-library/features/author-a-named-deck.md
@@ -62,6 +62,22 @@ Example: The name field previews the commander
   Then its placeholder shows the commander's name
 ```
 
+## Rule: The editor can hand its list to a deck draft
+
+While editing, the author can start an assisted draft seeded from the cards currently in
+the editor with **Draft from this deck**. The cards in the list become the draft's `base
+cards` and the list's commander is pre-picked, so an existing or half-typed deck can be
+grown through the `draft-a-deck` flow. The action is offered only once the list holds at
+least three distinct cards — the draft's own floor.
+
+```gherkin
+Example: Drafting from the deck being edited
+  Given the editor holds a commander and a handful of cards
+  When the author chooses "Draft from this deck"
+  Then a draft opens seeded with those cards
+  And the list's commander is already picked
+```
+
 ## Rule: A saved deck round-trips
 
 ```gherkin

--- a/domainbook/domains/deck-library/features/author-a-named-deck.md
+++ b/domainbook/domains/deck-library/features/author-a-named-deck.md
@@ -32,11 +32,16 @@ Example: A duplicate nonland is rejected
 ```
 
 ```gherkin
-Example: A deck that isn't exactly 100 cards can't be saved
+Example: A deck that isn't exactly 100 cards can still be saved, but flagged
   Given a decklist with 99 cards (or any count other than 100)
-  When the author looks at the editor
-  Then saving is refused and the count is flagged with the 100-card rule
+  When the author saves it
+  Then the deck is saved and appears in the library flagged as partial
+  And it cannot be chosen to start a match until it reaches 100 cards
 ```
+
+Whether a saved deck is playable is derived from its card count, not stored
+(`deck-library/ADR-0002`) — so a partial deck completed later becomes playable
+with nothing to reconcile.
 
 ## Rule: A deck left unnamed takes its commander's name
 
@@ -69,4 +74,5 @@ Example: Reload yields the same list
 ## Open Questions
 
 - Whether to also block on singleton and color-identity at save, or keep the
-  engine as the arbiter for those (only the exact-100 count is enforced here).
+  engine as the arbiter for those (only the card count is checked here, and
+  since `deck-library/ADR-0002` that check flags rather than blocks).

--- a/domainbook/domains/deck-library/glossary.md
+++ b/domainbook/domains/deck-library/glossary.md
@@ -31,6 +31,18 @@ context surfaces these at authoring time, not at game start (`TDR-0002`).
 - **Aliases:** not-implemented card
 - **Status:** validated
 
+## Partial deck
+
+A `deck` that is not yet exactly 100 cards — most often one left mid-build by the assisted
+`deck draft`. It can be saved and copied out, but it is flagged in the library and cannot
+be chosen to play; playability is derived from the 100-card rule, not stored
+(`deck-library/ADR-0002`).
+
+- **Aliases:** incomplete deck, draft deck
+- **Status:** draft
+- **Example:** A saved deck showing 62 cards is partial and cannot be started in
+  `match setup`.
+
 ## Deck author
 
 The person building decks — the only role this context serves. There is no

--- a/domainbook/domains/deck-library/index.md
+++ b/domainbook/domains/deck-library/index.md
@@ -33,6 +33,7 @@ actually play, so `match setup` always has legal, playable decks to choose from.
 | --------------- | ------------ | ------- |
 | `AuthorDeck`    | deck author  | Command |
 | `SaveNamedDeck` | deck author  | Command |
+| `SaveNamedDeck` | deck draft   | Command |
 | `CheckCoverage` | deck author  | Query   |
 | `ListDecks`     | match-setup  | Query   |
 
@@ -60,6 +61,9 @@ actually play, so `match setup` always has legal, playable decks to choose from.
   the front face alone.
 - The existing `src/lib/decklist.ts` parser and `src/lib/scryfall.ts` resolver are
   reused rather than rewritten.
+- A deck may be saved before it is complete: a partial deck (not exactly 100 cards) is
+  stored and flagged, but blocked from play, so the assisted `deck draft` can be left and
+  resumed without ever letting an incomplete deck reach a game (`deck-library/ADR-0002`).
 - A deck may also be brought in by its Moxfield or Archidekt URL, which is fetched
   and turned into the same pasted-decklist text the author would otherwise type.
   This does not walk back `ADR-0004`: the user still supplies one deck they chose,
@@ -74,7 +78,10 @@ actually play, so `match setup` always has legal, playable decks to choose from.
   known exception.
 - The engine exposes a queryable list of implemented cards (phase-rs
   `classify_deck`), so coverage is checked before a game, not discovered during one.
-- The user maintains their own decks; the library does not curate or suggest.
+- The user maintains their own decks and the library scrapes or browses no field of
+  decks. Card *suggestions* for a deck under construction now come from the `deck draft`
+  context, which hands finished or partial decks here to store; the library itself still
+  does not curate a field (`ADR-0009`, superseding `ADR-0004`).
 
 ## Verification Metrics
 

--- a/domainbook/domains/match-setup/features/configure-a-run.md
+++ b/domainbook/domains/match-setup/features/configure-a-run.md
@@ -62,6 +62,19 @@ Example: A count above the cap is refused
   Then it is not accepted above 50
 ```
 
+## Rule: A partial deck cannot start a match
+
+A deck that is not exactly 100 cards is stored but unplayable
+(`deck-library/ADR-0002`). Setup marks it in the deck pickers, and the start
+control refuses to begin a run while one is chosen, for you or an opponent.
+
+```gherkin
+Example: Starting is refused with a partial deck chosen
+  Given a partial deck is chosen as your deck or an opponent's
+  When you look at the start control
+  Then it is disabled with a reason explaining that a chosen deck is partial
+```
+
 ## Rule: The same seed and decks reproduce the same run
 
 ```gherkin

--- a/domainbook/domains/simulation/index.md
+++ b/domainbook/domains/simulation/index.md
@@ -37,6 +37,9 @@ and the finished-game result.
 | `StartSession`       | match-setup  | Command |
 | `SubmitPlayerAction` | board        | Command |
 | `AdvancePhase`       | board        | Command |
+| `QueryCardPool`      | deck-draft   | Query   |
+| `EstimateBracket`    | deck-draft   | Query   |
+| `ClassifyDeck`       | deck-draft   | Query   |
 
 ## Outbound Communication
 
@@ -44,6 +47,9 @@ and the finished-game result.
 | --------------------- | ----------------- | ------- |
 | `GetAiActionProposal` | phase-rs (extern) | Query   |
 | `SubmitAction`        | phase-rs (extern) | Command |
+| `SearchCards`         | phase-rs (extern) | Query   |
+| `EstimateBracket`     | phase-rs (extern) | Query   |
+| `ClassifyDeck`        | phase-rs (extern) | Query   |
 | `GameStateChanged`    | board             | Event   |
 | `MatchEnded`          | analysis          | Event   |
 
@@ -60,6 +66,10 @@ and the finished-game result.
   the only face the engine's card database keys on (`src/engine/deckPayload.ts`).
 - One game runs per WASM instance, in a Web Worker; a `run` plays its matches
   sequentially (`ADR-0005`).
+- The `engine adapter` also answers `deck draft`'s game-independent card queries —
+  `search_cards_js`, `estimate_bracket_for_deck`, `classify_deck_js`. These read only the
+  loaded card database, not a running game, so they sit outside the one-game-per-instance
+  rule and keep the adapter the sole thing that talks to phase-rs (`ADR-0009`).
 - A match takes a seed from the session, so games are reproducible.
 
 ## Assumptions

--- a/domainbook/roadmap.md
+++ b/domainbook/roadmap.md
@@ -8,6 +8,7 @@ milestones:
   - { id: simulation, name: Simulation — play and auto-play, status: done }
   - { id: board, name: Board, status: done }
   - { id: head-to-head-analysis, name: Head-to-head analysis, status: done }
+  - { id: deck-draft, name: Deck draft, status: planned }
   - { id: polish-and-deploy, name: Polish and deploy, status: in-progress }
 ---
 
@@ -50,9 +51,10 @@ needs no backend. The consequence chain is recorded as decisions:
 - `ADR-0001` — phase-rs is the rules and AI engine (over Forge, XMage, a custom engine).
 - `ADR-0002` — we embed the engine and drive our own minimal front-end, rather than fork the phase-rs client.
 - `ADR-0003` — the app runs fully client-side; no backend, static hosting.
-- `ADR-0004` — decks are entered by hand and saved as named, reusable decks; there is no bundled or scraped field of decks.
+- `ADR-0004` — decks are entered by hand and saved as named, reusable decks; there is no bundled or scraped field of decks. *(Superseded by `ADR-0009`, which carries the no-scraped-field core forward.)*
 - `ADR-0005` — a pre-game toggle picks play or watch; a run is 1–50 games, sequential, in real time on the board.
 - `ADR-0006` — we vendor a pinned prebuilt WASM snapshot (rather than build from source) and run the engine in a Web Worker; confirmed by the integration spike.
+- `ADR-0009` — an assisted **deck draft** suggests cards for the deck under construction: the engine narrows its own card database and measures power, a self-built heuristic ranks by synergy. Supersedes `ADR-0004`'s "the app never curates or suggests" while keeping its no-scraped-field stance.
 
 The two standing risks of leaning on an alpha engine are recorded as debt:
 `TDR-0001` (single-maintainer alpha with a churning ABI) and `TDR-0002` (rules
@@ -130,6 +132,18 @@ Turn a finished run into an answer: win rate (with a confidence interval), per
 matchup, plus telemetry (turn the game ended, who won, mulligans taken). This is
 `docs/ROADMAP.md`'s old "Phase 4 — head-to-head" delivered client-side, without the
 Forge backend that phase assumed.
+
+### Deck draft — planned
+
+Build a deck from scratch with help. The user seeds at least three cards (optionally one
+flagged as the commander) and the app offers rounds of up to three synergistic cards to
+add, each refreshable, all within the commander's color identity. Candidates come from the
+engine's own card database (`search_cards_js`); a self-built heuristic ranks them by
+synergy with the commander weighted higher; a selectable bracket target (default Focused)
+steers the ranking through the engine's bracket estimate (`ADR-0009`,
+`deck-draft/ADR-0001`). The draft can be left at any point and copied out or saved — a
+partial deck is flagged and blocked from play (`deck-library/ADR-0002`). This is the
+project's first step from *measuring* a deck to *helping build* one.
 
 ### Polish and deploy — planned
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commander-playtester",
-  "version": "0.4.12",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commander-playtester",
-      "version": "0.4.12",
+      "version": "0.5.0",
       "dependencies": {
         "lucide-react": "^1.31.0",
         "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.4.14",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",

--- a/scripts/engine-smoke.test.ts
+++ b/scripts/engine-smoke.test.ts
@@ -217,6 +217,18 @@ describe.skipIf(!ENABLED)("phase-rs deck-draft query functions", () => {
         "a non-legendary artifact should not be commander-eligible",
       ).toBe(false);
 
+      const commanderCandidates = draftQueries
+        .search_cards_js({ limit: 100_000 })
+        .results.filter(
+          (candidate) =>
+            candidate.legalities?.commander === "legal" &&
+            draftQueries.is_card_commander_eligible(candidate.name),
+        );
+      expect(
+        commanderCandidates.length,
+        "the card database should contain more than three Commander candidates",
+      ).toBeGreaterThan(3);
+
       const panic = take_last_panic_message();
       expect(panic, `engine panicked: ${panic}`).toBeFalsy();
     },

--- a/scripts/engine-smoke.test.ts
+++ b/scripts/engine-smoke.test.ts
@@ -30,6 +30,7 @@ import init, {
 import { STARTER_DECKS } from "../src/deck/starterDecks";
 import { buildDeckList } from "../src/engine/deckPayload";
 import type { SavedDeck } from "../src/deck/model";
+import { draftQueries } from "../src/engine/draftQueries";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const WASM = resolve(ROOT, "public/engine/engine_wasm_bg.wasm");
@@ -137,6 +138,78 @@ describe.skipIf(!ENABLED)("phase-rs engine smoke", () => {
       ).toBe("gameover");
       // A Commander game ends with a winner or a draw; both are valid.
       expect(winner === null || typeof winner === "number").toBe(true);
+    },
+  );
+});
+
+// Guard for the three game-independent deck-draft query functions
+// (search_cards_js, estimate_bracket_for_deck, classify_deck_js). They are
+// real exports of the vendored glue but untyped in engine_wasm.d.ts
+// (src/engine/draftQueries.ts supplies the app-owned typing); this locks
+// their runtime contract so a future engine upgrade's ABI drift fails here
+// rather than silently in the draft worker (deck-draft/ADR-0001, TDR-0001).
+describe.skipIf(!ENABLED)("phase-rs deck-draft query functions", () => {
+  it(
+    "boots the WASM, loads the DB, and locks the search/bracket/classify contracts",
+    { timeout: 60_000 },
+    async () => {
+      const bytes = new Uint8Array(readFileSync(WASM));
+      await init({ module_or_path: bytes });
+      init_panic_hook();
+
+      const cardJson = gunzipSync(readFileSync(CARD_GZ)).toString("utf8");
+      load_card_database(cardJson);
+
+      const commander = "Krenko, Mob Boss";
+      const mainDeck = ["Mountain", "Lightning Bolt"];
+
+      const search = draftQueries.search_cards_js({
+        text: "Goblin",
+        colors: ["R"],
+        limit: 10,
+      });
+      expect(Array.isArray(search.results), "search_cards_js should return .results[]").toBe(
+        true,
+      );
+      expect(typeof search.total).toBe("number");
+      expect(search.results.length, "the Goblin/red search should find cards").toBeGreaterThan(0);
+      const row = search.results[0];
+      expect(typeof row.name).toBe("string");
+      expect(typeof row.oracle_id).toBe("string");
+      expect(typeof row.mana_value).toBe("number");
+      expect(Array.isArray(row.color_identity)).toBe(true);
+      expect(typeof row.legalities).toBe("object");
+
+      const bracket = draftQueries.estimate_bracket_for_deck({
+        commander: [commander],
+        main_deck: mainDeck,
+      });
+      expect(
+        bracket,
+        "estimate_bracket_for_deck should return a result when a commander is given",
+      ).toBeTruthy();
+      expect(typeof bracket!.tier).toBe("string");
+      expect(typeof bracket!.contributing).toBe("object");
+
+      const bracketNoCommander = draftQueries.estimate_bracket_for_deck({
+        main_deck: mainDeck,
+      } as any);
+      expect(
+        bracketNoCommander,
+        "estimate_bracket_for_deck should return null when the commander is omitted",
+      ).toBeNull();
+
+      const classify = draftQueries.classify_deck_js([commander, ...mainDeck]);
+      expect(typeof classify.archetype).toBe("string");
+
+      const classifyEmpty = draftQueries.classify_deck_js([]);
+      expect(
+        typeof classifyEmpty.archetype,
+        "classify_deck_js should tolerate an empty name list",
+      ).toBe("string");
+
+      const panic = take_last_panic_message();
+      expect(panic, `engine panicked: ${panic}`).toBeFalsy();
     },
   );
 });

--- a/scripts/engine-smoke.test.ts
+++ b/scripts/engine-smoke.test.ts
@@ -208,6 +208,15 @@ describe.skipIf(!ENABLED)("phase-rs deck-draft query functions", () => {
         "classify_deck_js should tolerate an empty name list",
       ).toBe("string");
 
+      expect(
+        draftQueries.is_card_commander_eligible(commander),
+        "a legendary creature should be commander-eligible",
+      ).toBe(true);
+      expect(
+        draftQueries.is_card_commander_eligible("Sol Ring"),
+        "a non-legendary artifact should not be commander-eligible",
+      ).toBe(false);
+
       const panic = take_last_panic_message();
       expect(panic, `engine panicked: ${panic}`).toBeFalsy();
     },

--- a/scripts/engine-smoke.test.ts
+++ b/scripts/engine-smoke.test.ts
@@ -228,6 +228,10 @@ describe.skipIf(!ENABLED)("phase-rs deck-draft query functions", () => {
         commanderCandidates.length,
         "the card database should contain more than three Commander candidates",
       ).toBeGreaterThan(3);
+      const commanderFace = draftQueries.get_card_face_data(commander);
+      expect(commanderFace?.name).toBe(commander);
+      expect(typeof commanderFace?.oracle_text).toBe("string");
+      expect(commanderFace?.card_type?.core_types).toContain("Creature");
 
       const panic = take_last_panic_message();
       expect(panic, `engine panicked: ${panic}`).toBeFalsy();

--- a/src/App.css
+++ b/src/App.css
@@ -392,6 +392,67 @@ body.xpscroll-dragging {
   border-color: var(--accent);
 }
 
+/* Enchanted glint — a Minecraft-style violet sheen that sweeps across the
+   button so a new feature draws the eye. Two offset sheens shift over one
+   another for the iridescent look; both sit behind the label (z-index below
+   the text) so it stays crisp. */
+.btn--enchanted {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+  border-color: color-mix(in srgb, #a880ff 55%, var(--line));
+  box-shadow: 0 0 10px rgba(150, 90, 255, 0.35);
+}
+.btn--enchanted:hover:not(:disabled) {
+  border-color: color-mix(in srgb, #b89bff 70%, var(--accent));
+  box-shadow: 0 0 16px rgba(168, 120, 255, 0.6);
+}
+.btn--enchanted::before,
+.btn--enchanted::after {
+  content: "";
+  position: absolute;
+  inset: -80% -40%;
+  z-index: -1;
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+.btn--enchanted::before {
+  background: linear-gradient(
+    115deg,
+    transparent 42%,
+    rgba(150, 100, 255, 0.55) 49%,
+    rgba(214, 190, 255, 0.95) 50%,
+    rgba(150, 100, 255, 0.55) 51%,
+    transparent 58%
+  );
+  animation: enchant-sweep 2.9s linear infinite;
+}
+.btn--enchanted::after {
+  background: linear-gradient(
+    75deg,
+    transparent 40%,
+    rgba(120, 90, 255, 0.4) 50%,
+    rgba(180, 130, 255, 0.65) 52%,
+    transparent 62%
+  );
+  opacity: 0.85;
+  animation: enchant-sweep 4.7s linear infinite reverse;
+}
+@keyframes enchant-sweep {
+  0% {
+    transform: translateX(-60%);
+  }
+  100% {
+    transform: translateX(60%);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .btn--enchanted::before,
+  .btn--enchanted::after {
+    animation: none;
+  }
+}
+
 .hint {
   color: var(--muted);
   font-size: 0.85rem;

--- a/src/App.css
+++ b/src/App.css
@@ -698,6 +698,81 @@ th {
   min-width: 0;
 }
 
+.draft-entry-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-bottom: 0.5rem;
+}
+.draft-entry-row .input {
+  flex: 1;
+  min-width: 0;
+}
+.draft-entry-row__commander {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.82rem;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.draft-round {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+.draft-round--loading {
+  opacity: 0.5;
+}
+
+.draft-card {
+  display: flex;
+  gap: 0.6rem;
+  background: var(--panel-2);
+  border: 1px solid var(--line);
+  padding: 0.6rem;
+}
+
+.draft-card__img {
+  width: 84px;
+  height: auto;
+  flex-shrink: 0;
+  border-radius: 4px;
+  display: block;
+}
+.draft-card__img--placeholder {
+  min-height: 117px;
+  background: var(--inset);
+  border: 1px solid var(--line);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  font-size: 0.7rem;
+  color: var(--muted);
+  padding: 0.3rem;
+}
+
+.draft-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 0;
+  flex: 1;
+}
+
+.draft-card__name {
+  font-weight: 700;
+}
+
+.draft-card__actions {
+  display: flex;
+  gap: 0.4rem;
+  margin-top: auto;
+}
+
 .field-row {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));

--- a/src/App.css
+++ b/src/App.css
@@ -708,6 +708,11 @@ th {
   flex: 1;
   min-width: 0;
 }
+.draft-entry-row .combobox {
+  flex: 1;
+  min-width: 0;
+  max-width: none;
+}
 .draft-entry-row__commander {
   display: flex;
   align-items: center;

--- a/src/App.css
+++ b/src/App.css
@@ -527,6 +527,10 @@ th {
   padding: 0.5rem 0.6rem;
   font-size: 0.9rem;
 }
+.input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
 
 .btn--sm {
   padding: 0.35rem 0.7rem;
@@ -713,6 +717,9 @@ th {
   min-width: 0;
   max-width: none;
 }
+.input[aria-invalid="true"] {
+  border-color: var(--bad);
+}
 .draft-entry-row__commander {
   display: flex;
   align-items: center;
@@ -720,6 +727,29 @@ th {
   font-size: 0.82rem;
   color: var(--muted);
   white-space: nowrap;
+}
+.draft-commander-field .combobox {
+  max-width: none;
+}
+.input--has-clear {
+  padding-right: 2rem;
+}
+.combobox__clear {
+  position: absolute;
+  top: 50%;
+  right: 0.4rem;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.15rem;
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+}
+.combobox__clear:hover {
+  color: var(--text);
 }
 
 .draft-round {
@@ -734,15 +764,16 @@ th {
 
 .draft-card {
   display: flex;
-  align-items: flex-start;
-  gap: 0.6rem;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
   background: var(--panel-2);
   border: 1px solid var(--line);
   padding: 0.6rem;
 }
 
 .draft-card__img {
-  width: 84px;
+  width: 112px;
   aspect-ratio: 0.716;
   object-fit: cover;
   flex-shrink: 0;
@@ -762,22 +793,18 @@ th {
   padding: 0.3rem;
 }
 
-.draft-card__body {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  min-width: 0;
-  flex: 1;
-}
-
-.draft-card__name {
-  font-weight: 700;
+.draft-card__tags {
+  justify-content: center;
 }
 
 .draft-card__actions {
   display: flex;
   gap: 0.4rem;
+  width: 100%;
   margin-top: auto;
+}
+.draft-card__actions .btn {
+  flex: 1;
 }
 
 .field-row {

--- a/src/App.css
+++ b/src/App.css
@@ -729,6 +729,7 @@ th {
 
 .draft-card {
   display: flex;
+  align-items: flex-start;
   gap: 0.6rem;
   background: var(--panel-2);
   border: 1px solid var(--line);
@@ -737,13 +738,14 @@ th {
 
 .draft-card__img {
   width: 84px;
-  height: auto;
+  aspect-ratio: 0.716;
+  object-fit: cover;
   flex-shrink: 0;
   border-radius: 4px;
   display: block;
 }
 .draft-card__img--placeholder {
-  min-height: 117px;
+  aspect-ratio: 0.716;
   background: var(--inset);
   border: 1px solid var(--line);
   display: flex;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import "./App.css";
 import { DeckLibrary } from "./deck/DeckLibrary";
 import { DeckDetail } from "./deck/DeckDetail";
 import { DeckEditor } from "./deck/DeckEditor";
+import { DraftView } from "./draft/DraftView";
 import { useDecks } from "./deck/useDecks";
 import { getLastPlayedDeckId, setLastPlayedDeckId } from "./deck/storage";
 import type { SavedDeck } from "./deck/model";
@@ -27,14 +28,17 @@ function getWindowTitle(
     runConfig,
     editing,
     selected,
+    drafting,
   }: {
     playApp: boolean;
     runConfig: RunConfig | null;
     editing: EditingState;
     selected: SavedDeck | null;
+    drafting: boolean;
   },
 ): string {
   if (playApp) return runConfig ? t("run.match") : t("setup.title");
+  if (drafting) return t("draft.windowTitle");
   if (editing)
     return editing === "new" ? t("editor.newTitle") : t("editor.editTitle");
   if (selected) return t("win.reportTitle", { name: selected.name });
@@ -45,23 +49,38 @@ function DecksView({
   decks,
   editing,
   selected,
+  drafting,
   save,
   remove,
   setEditing,
   setSelected,
+  setDrafting,
   setPlayDeck,
   setView,
 }: {
   decks: SavedDeck[];
   editing: EditingState;
   selected: SavedDeck | null;
+  drafting: boolean;
   save: (deck: SavedDeck) => void;
   remove: (id: string) => void;
   setEditing: (value: EditingState) => void;
   setSelected: (value: SavedDeck | null) => void;
+  setDrafting: (value: boolean) => void;
   setPlayDeck: (value: SavedDeck | null) => void;
   setView: (value: View) => void;
 }) {
+  if (drafting) {
+    return (
+      <DraftView
+        onSave={(deck) => {
+          save(deck);
+          setDrafting(false);
+        }}
+        onExit={() => setDrafting(false)}
+      />
+    );
+  }
   if (editing) {
     return (
       <DeckEditor
@@ -94,6 +113,7 @@ function DecksView({
       onSelect={setSelected}
       onNew={() => setEditing("new")}
       onEdit={(deck) => setEditing(deck)}
+      onDraft={() => setDrafting(true)}
     />
   );
 }
@@ -148,12 +168,13 @@ export function App() {
   const [view, setView] = useState<View>("decks");
   const [selected, setSelected] = useState<SavedDeck | null>(null);
   const [editing, setEditing] = useState<EditingState>(null);
+  const [drafting, setDrafting] = useState(false);
   const [playDeck, setPlayDeck] = useState<SavedDeck | null>(null);
   const [runConfig, setRunConfig] = useState<RunConfig | null>(null);
 
   const playApp = view === "play";
-  // Report and live board go full-bleed; forms (library, editor, setup) cap width.
-  const wideContent = playApp ? !!runConfig : !editing && !!selected;
+  // Report, drafting and live board go full-bleed; forms (library, editor, setup) cap width.
+  const wideContent = playApp ? !!runConfig : drafting || (!editing && !!selected);
 
   const preferredDeckId =
     (playDeck && decks.some((d) => d.id === playDeck.id) && playDeck.id) ||
@@ -161,7 +182,7 @@ export function App() {
     undefined;
 
   // Window title + icon are derived from the active view and its sub-state.
-  const winTitle = getWindowTitle(t, { playApp, runConfig, editing, selected });
+  const winTitle = getWindowTitle(t, { playApp, runConfig, editing, selected, drafting });
 
   return (
     <div className="xp-desktop">
@@ -183,10 +204,12 @@ export function App() {
                 decks={decks}
                 editing={editing}
                 selected={selected}
+                drafting={drafting}
                 save={save}
                 remove={remove}
                 setEditing={setEditing}
                 setSelected={setSelected}
+                setDrafting={setDrafting}
                 setPlayDeck={setPlayDeck}
                 setView={setView}
               />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import "./App.css";
 import { DeckLibrary } from "./deck/DeckLibrary";
 import { DeckDetail } from "./deck/DeckDetail";
 import { DeckEditor } from "./deck/DeckEditor";
-import { DraftView } from "./draft/DraftView";
+import { DraftView, type DraftSeed } from "./draft/DraftView";
 import { useDecks } from "./deck/useDecks";
 import { getLastPlayedDeckId, setLastPlayedDeckId } from "./deck/storage";
 import type { SavedDeck } from "./deck/model";
@@ -50,11 +50,13 @@ function DecksView({
   editing,
   selected,
   drafting,
+  draftSeed,
   save,
   remove,
   setEditing,
   setSelected,
   setDrafting,
+  setDraftSeed,
   setPlayDeck,
   setView,
 }: {
@@ -62,22 +64,29 @@ function DecksView({
   editing: EditingState;
   selected: SavedDeck | null;
   drafting: boolean;
+  draftSeed: DraftSeed | null;
   save: (deck: SavedDeck) => void;
   remove: (id: string) => void;
   setEditing: (value: EditingState) => void;
   setSelected: (value: SavedDeck | null) => void;
   setDrafting: (value: boolean) => void;
+  setDraftSeed: (value: DraftSeed | null) => void;
   setPlayDeck: (value: SavedDeck | null) => void;
   setView: (value: View) => void;
 }) {
+  function stopDrafting() {
+    setDrafting(false);
+    setDraftSeed(null);
+  }
   if (drafting) {
     return (
       <DraftView
+        seed={draftSeed ?? undefined}
         onSave={(deck) => {
           save(deck);
-          setDrafting(false);
+          stopDrafting();
         }}
-        onExit={() => setDrafting(false)}
+        onExit={stopDrafting}
       />
     );
   }
@@ -90,6 +99,11 @@ function DecksView({
           setEditing(null);
         }}
         onCancel={() => setEditing(null)}
+        onDraft={(names, commander) => {
+          setDraftSeed({ names, commander });
+          setEditing(null);
+          setDrafting(true);
+        }}
       />
     );
   }
@@ -113,7 +127,10 @@ function DecksView({
       onSelect={setSelected}
       onNew={() => setEditing("new")}
       onEdit={(deck) => setEditing(deck)}
-      onDraft={() => setDrafting(true)}
+      onDraft={() => {
+        setDraftSeed(null);
+        setDrafting(true);
+      }}
     />
   );
 }
@@ -169,6 +186,7 @@ export function App() {
   const [selected, setSelected] = useState<SavedDeck | null>(null);
   const [editing, setEditing] = useState<EditingState>(null);
   const [drafting, setDrafting] = useState(false);
+  const [draftSeed, setDraftSeed] = useState<DraftSeed | null>(null);
   const [playDeck, setPlayDeck] = useState<SavedDeck | null>(null);
   const [runConfig, setRunConfig] = useState<RunConfig | null>(null);
 
@@ -205,11 +223,13 @@ export function App() {
                 editing={editing}
                 selected={selected}
                 drafting={drafting}
+                draftSeed={draftSeed}
                 save={save}
                 remove={remove}
                 setEditing={setEditing}
                 setSelected={setSelected}
                 setDrafting={setDrafting}
+                setDraftSeed={setDraftSeed}
                 setPlayDeck={setPlayDeck}
                 setView={setView}
               />

--- a/src/components/CardNameInput.tsx
+++ b/src/components/CardNameInput.tsx
@@ -1,29 +1,35 @@
 import { useEffect, useId, useRef, useState } from "react";
-import { fetchCardNameSuggestions } from "../lib/scryfall";
 import { XpScroll } from "./XpScroll";
 
 interface CardNameInputProps {
   value: string;
   onChange: (value: string) => void;
+  /** Resolve card-name suggestions for the typed text (e.g. the local engine DB). */
+  fetchSuggestions: (query: string) => Promise<string[]>;
   placeholder?: string;
   id?: string;
   disabled?: boolean;
+  /** Mark the field as holding an unusable value (unknown or illegal card). */
+  invalid?: boolean;
   className?: string;
 }
 
 const DEBOUNCE_MS = 200;
 
 /**
- * A free-text card-name input with live suggestions from Scryfall's
- * autocomplete: as you type, the cards whose name contains the text drop down
- * below. Picking one fills the field; the typed text is always kept otherwise.
+ * A free-text card-name input with live suggestions: as you type, the cards
+ * whose name contains the text drop down below. Picking one fills the field;
+ * the typed text is always kept otherwise. The suggestion source is injected so
+ * the field stays decoupled from where names come from.
  */
 export function CardNameInput({
   value,
   onChange,
+  fetchSuggestions,
   placeholder,
   id,
   disabled,
+  invalid,
   className,
 }: CardNameInputProps) {
   const listId = useId();
@@ -43,7 +49,7 @@ export function CardNameInput({
     }
     const seq = ++reqSeq.current;
     const timer = setTimeout(() => {
-      fetchCardNameSuggestions(query)
+      fetchSuggestions(query)
         .then((names) => {
           if (seq === reqSeq.current) {
             setItems(names);
@@ -55,7 +61,7 @@ export function CardNameInput({
         });
     }, DEBOUNCE_MS);
     return () => clearTimeout(timer);
-  }, [value, open]);
+  }, [value, open, fetchSuggestions]);
 
   useEffect(() => {
     if (!open) return;
@@ -108,6 +114,7 @@ export function CardNameInput({
         aria-expanded={open}
         aria-controls={listId}
         aria-autocomplete="list"
+        aria-invalid={invalid || undefined}
         autoComplete="off"
         spellCheck={false}
         disabled={disabled}

--- a/src/components/CardNameInput.tsx
+++ b/src/components/CardNameInput.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useId, useRef, useState } from "react";
+import { fetchCardNameSuggestions } from "../lib/scryfall";
+import { XpScroll } from "./XpScroll";
+
+interface CardNameInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  id?: string;
+  disabled?: boolean;
+  className?: string;
+}
+
+const DEBOUNCE_MS = 200;
+
+/**
+ * A free-text card-name input with live suggestions from Scryfall's
+ * autocomplete: as you type, the cards whose name contains the text drop down
+ * below. Picking one fills the field; the typed text is always kept otherwise.
+ */
+export function CardNameInput({
+  value,
+  onChange,
+  placeholder,
+  id,
+  disabled,
+  className,
+}: CardNameInputProps) {
+  const listId = useId();
+  const rootRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+  const reqSeq = useRef(0);
+  const [open, setOpen] = useState(false);
+  const [items, setItems] = useState<string[]>([]);
+  const [active, setActive] = useState(0);
+
+  useEffect(() => {
+    if (!open) return;
+    const query = value.trim();
+    if (query.length < 2) {
+      setItems([]);
+      return;
+    }
+    const seq = ++reqSeq.current;
+    const timer = setTimeout(() => {
+      fetchCardNameSuggestions(query)
+        .then((names) => {
+          if (seq === reqSeq.current) {
+            setItems(names);
+            setActive(0);
+          }
+        })
+        .catch(() => {
+          if (seq === reqSeq.current) setItems([]);
+        });
+    }, DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [value, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    function onDown(e: MouseEvent) {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const el = listRef.current?.children[active] as HTMLElement | undefined;
+    el?.scrollIntoView({ block: "nearest" });
+  }, [active, open]);
+
+  function select(name: string) {
+    onChange(name);
+    setOpen(false);
+    setItems([]);
+  }
+
+  function onKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (!open || items.length === 0) return;
+    if (e.key === "ArrowDown") {
+      setActive((a) => Math.min(a + 1, items.length - 1));
+      e.preventDefault();
+    } else if (e.key === "ArrowUp") {
+      setActive((a) => Math.max(a - 1, 0));
+      e.preventDefault();
+    } else if (e.key === "Enter") {
+      if (items[active]) {
+        select(items[active]);
+        e.preventDefault();
+      }
+    } else if (e.key === "Escape") {
+      setOpen(false);
+    }
+  }
+
+  return (
+    <div className="combobox" ref={rootRef}>
+      <input
+        id={id}
+        className={className ?? "input"}
+        type="text"
+        role="combobox"
+        aria-expanded={open}
+        aria-controls={listId}
+        aria-autocomplete="list"
+        autoComplete="off"
+        spellCheck={false}
+        disabled={disabled}
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => {
+          onChange(e.target.value);
+          setOpen(true);
+        }}
+        onFocus={() => setOpen(true)}
+        onKeyDown={onKeyDown}
+      />
+      {open && items.length > 0 && (
+        <XpScroll wrapperClassName="combobox__list">
+          <ul
+            className="combobox__options"
+            id={listId}
+            role="listbox"
+            ref={listRef}
+          >
+            {items.map((name, i) => (
+              <li
+                key={name}
+                role="option"
+                aria-selected={name === value}
+                className={`combobox__option ${i === active ? "combobox__option--active" : ""}`}
+                onMouseEnter={() => setActive(i)}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  select(name);
+                }}
+              >
+                {name}
+              </li>
+            ))}
+          </ul>
+        </XpScroll>
+      )}
+    </div>
+  );
+}

--- a/src/components/SearchableSelect.tsx
+++ b/src/components/SearchableSelect.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useId, useMemo, useRef, useState } from "react";
+import { X } from "lucide-react";
 import { XpScroll } from "./XpScroll";
 
 interface SearchableSelectProps {
@@ -7,6 +8,10 @@ interface SearchableSelectProps {
   onChange: (value: string) => void;
   placeholder?: string;
   emptyLabel?: string;
+  disabled?: boolean;
+  /** Show an X inside the field to clear the selection back to empty. */
+  clearable?: boolean;
+  clearLabel?: string;
   id?: string;
 }
 
@@ -17,6 +22,9 @@ export function SearchableSelect({
   onChange,
   placeholder,
   emptyLabel,
+  disabled,
+  clearable,
+  clearLabel,
   id,
 }: SearchableSelectProps) {
   const listId = useId();
@@ -50,6 +58,7 @@ export function SearchableSelect({
   }, [active, open]);
 
   function openList() {
+    if (disabled) return;
     setOpen(true);
     setQuery("");
     setActive(Math.max(0, options.indexOf(value)));
@@ -82,16 +91,19 @@ export function SearchableSelect({
     }
   }
 
+  const showClear = clearable && !!value && !open && !disabled;
+
   return (
     <div className="combobox" ref={rootRef}>
       <input
         id={id}
-        className="input"
+        className={`input ${showClear ? "input--has-clear" : ""}`}
         type="text"
         role="combobox"
         aria-expanded={open}
         aria-controls={listId}
         autoComplete="off"
+        disabled={disabled}
         placeholder={placeholder}
         value={open ? query : value}
         onChange={(e) => {
@@ -102,6 +114,19 @@ export function SearchableSelect({
         onFocus={openList}
         onKeyDown={onKeyDown}
       />
+      {showClear && (
+        <button
+          type="button"
+          className="combobox__clear"
+          aria-label={clearLabel}
+          onMouseDown={(e) => {
+            e.preventDefault();
+            onChange("");
+          }}
+        >
+          <X size={16} aria-hidden="true" />
+        </button>
+      )}
       {open && (
         <XpScroll wrapperClassName="combobox__list">
           <ul

--- a/src/deck/DeckDetail.tsx
+++ b/src/deck/DeckDetail.tsx
@@ -4,6 +4,7 @@ import { goldfish, DEFAULT_CONFIG, type GoldfishResult } from "../lib/goldfish";
 import type { ResolvedDeck } from "../lib/types";
 import { GoldfishReport } from "../components/GoldfishReport";
 import type { SavedDeck } from "./model";
+import { isHundredCards } from "./model";
 import { useI18n } from "../i18n/I18nContext";
 
 type State =
@@ -26,6 +27,7 @@ export function DeckDetail({
     kind: "loading",
     message: t("detail.resolving"),
   });
+  const playable = isHundredCards(deck);
 
   useEffect(() => {
     let cancelled = false;
@@ -68,13 +70,28 @@ export function DeckDetail({
             <button className="btn btn--ghost btn--sm" onClick={onBack}>
               {t("detail.back")}
             </button>
-            <h2 style={{ marginTop: "0.5rem" }}>{deck.name}</h2>
+            <h2 style={{ marginTop: "0.5rem" }}>
+              {deck.name}
+              {!playable && (
+                <span
+                  className="chip"
+                  style={{ color: "var(--warn)", marginLeft: "0.5rem" }}
+                >
+                  {t("deck.partial")}
+                </span>
+              )}
+            </h2>
           </div>
-          <button className="btn" onClick={() => onPlay(deck)}>
+          <button
+            className="btn"
+            onClick={() => onPlay(deck)}
+            disabled={!playable}
+          >
             {t("detail.play")}
           </button>
         </div>
 
+        {!playable && <p className="hint">{t("detail.partialReason")}</p>}
         {state.kind === "loading" && (
           <p className="hint">{state.message}</p>
         )}

--- a/src/deck/DeckEditor.tsx
+++ b/src/deck/DeckEditor.tsx
@@ -28,10 +28,12 @@ export function DeckEditor({
   initial,
   onSave,
   onCancel,
+  onDraft,
 }: {
   initial?: SavedDeck;
   onSave: (deck: SavedDeck) => void;
   onCancel: () => void;
+  onDraft: (names: string[], commander: string | null) => void;
 }) {
   const { t } = useI18n();
   const [name, setName] = useState(initial?.name ?? "");
@@ -64,6 +66,16 @@ export function DeckEditor({
   const mainboardCount = parsed.mainboard.reduce((n, e) => n + e.quantity, 0);
   const total = commanderCount + mainboardCount;
   const isHundred = total === 100;
+
+  const draftNames = [
+    ...parsed.commanders.map((e) => e.name),
+    ...parsed.mainboard.map((e) => e.name),
+  ];
+  const canDraft = new Set(draftNames.map((n) => n.toLowerCase())).size >= 3;
+
+  function handleDraft() {
+    onDraft(draftNames, parsed.commanders[0]?.name ?? null);
+  }
 
   function handleSave() {
     const now = Date.now();
@@ -180,6 +192,11 @@ export function DeckEditor({
         <button className="btn btn--ghost" onClick={onCancel}>
           {t("editor.cancel")}
         </button>
+        {canDraft && (
+          <button className="btn btn--ghost" onClick={handleDraft}>
+            {t("editor.draftFromDeck")}
+          </button>
+        )}
         {!initial && (
           <button
             className="btn btn--ghost"

--- a/src/deck/DeckEditor.tsx
+++ b/src/deck/DeckEditor.tsx
@@ -148,7 +148,7 @@ export function DeckEditor({
         </span>
         <span
           className="chip"
-          style={total > 0 && !isHundred ? { color: "var(--bad)" } : undefined}
+          style={total > 0 && !isHundred ? { color: "var(--warn)" } : undefined}
         >
           {t("deck.cards", { n: total })}
         </span>
@@ -168,11 +168,13 @@ export function DeckEditor({
         </p>
       )}
       {total > 0 && !isHundred && (
-        <p className="error">{t("editor.needHundred", { n: total })}</p>
+        <p className="hint" style={{ color: "var(--warn)" }}>
+          {t("editor.needHundredWarning", { n: total })}
+        </p>
       )}
 
       <div className="import__row">
-        <button className="btn" onClick={handleSave} disabled={!isHundred}>
+        <button className="btn" onClick={handleSave}>
           {t("editor.save")}
         </button>
         <button className="btn btn--ghost" onClick={onCancel}>

--- a/src/deck/DeckLibrary.tsx
+++ b/src/deck/DeckLibrary.tsx
@@ -1,5 +1,5 @@
 import type { SavedDeck } from "./model";
-import { totalCards } from "./model";
+import { isHundredCards, totalCards } from "./model";
 import { STARTER_DECKS } from "./starterDecks";
 import { useI18n } from "../i18n/I18nContext";
 
@@ -59,7 +59,17 @@ export function DeckLibrary({
                 className="deck-list__info"
                 onClick={() => onSelect(deck)}
               >
-                <span className="deck-list__name">{deck.name}</span>
+                <span className="deck-list__name">
+                  {deck.name}
+                  {!isHundredCards(deck) && (
+                    <span
+                      className="chip"
+                      style={{ color: "var(--warn)", marginLeft: "0.5rem" }}
+                    >
+                      {t("deck.partial")}
+                    </span>
+                  )}
+                </span>
                 <span className="deck-list__meta">
                   {deck.commanders.map((c) => c.name).join(", ") ||
                     t("deck.noCommander")}{" "}

--- a/src/deck/DeckLibrary.tsx
+++ b/src/deck/DeckLibrary.tsx
@@ -45,7 +45,7 @@ export function DeckLibrary({
           <button className="btn" onClick={onNew}>
             {t("library.new")}
           </button>
-          <button className="btn btn--ghost" onClick={onDraft}>
+          <button className="btn btn--ghost btn--enchanted" onClick={onDraft}>
             {t("library.draft")}
           </button>
         </div>

--- a/src/deck/DeckLibrary.tsx
+++ b/src/deck/DeckLibrary.tsx
@@ -11,6 +11,7 @@ export function DeckLibrary({
   onSelect,
   onNew,
   onEdit,
+  onDraft,
 }: {
   decks: SavedDeck[];
   save: (deck: SavedDeck) => void;
@@ -18,6 +19,7 @@ export function DeckLibrary({
   onSelect: (deck: SavedDeck) => void;
   onNew: () => void;
   onEdit: (deck: SavedDeck) => void;
+  onDraft: () => void;
 }) {
   const { t } = useI18n();
 
@@ -39,9 +41,14 @@ export function DeckLibrary({
     <section className="panel">
       <div className="panel__head">
         <h2>{t("library.title")}</h2>
-        <button className="btn" onClick={onNew}>
-          {t("library.new")}
-        </button>
+        <div className="import__row" style={{ margin: 0 }}>
+          <button className="btn" onClick={onNew}>
+            {t("library.new")}
+          </button>
+          <button className="btn btn--ghost" onClick={onDraft}>
+            {t("library.draft")}
+          </button>
+        </div>
       </div>
 
       {decks.length === 0 ? (

--- a/src/deck/model.test.ts
+++ b/src/deck/model.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { totalCards, deckToText } from "./model";
+import { totalCards, isHundredCards, deckToText } from "./model";
 import type { SavedDeck } from "./model";
 import { parseDecklist } from "../lib/decklist";
 import { SAMPLE_DECK } from "../lib/sampleDeck";
@@ -35,5 +35,17 @@ describe("deck model", () => {
     );
     expect(total).toBe(100);
     expect(parsed.warnings).toEqual([]);
+  });
+
+  it("a deck short of 100 cards is not playable", () => {
+    expect(isHundredCards(deck)).toBe(false);
+  });
+
+  it("a deck with exactly 100 cards is playable", () => {
+    const full: SavedDeck = {
+      ...deck,
+      mainboard: [{ quantity: 99, name: "Forest" }],
+    };
+    expect(isHundredCards(full)).toBe(true);
   });
 });

--- a/src/deck/model.ts
+++ b/src/deck/model.ts
@@ -29,9 +29,9 @@ export function uniqueCardNames(deck: SavedDeck): string[] {
 }
 
 /**
- * Commander legality is exactly 100 cards (1-2 commanders + the rest). The
- * editor blocks saving anything else, matching what the engine enforces at
- * game start.
+ * Commander legality is exactly 100 cards (1-2 commanders + the rest),
+ * matching what the engine enforces at game start. The single source of
+ * truth for whether a saved deck is playable (`deck-library/ADR-0002`).
  */
 export function isHundredCards(deck: SavedDeck): boolean {
   return totalCards(deck) === 100;

--- a/src/draft/DraftCandidateCard.tsx
+++ b/src/draft/DraftCandidateCard.tsx
@@ -1,5 +1,7 @@
+import type { MouseEvent as ReactMouseEvent } from "react";
 import type { RankedCandidate } from "./candidates";
 import { useI18n } from "../i18n/I18nContext";
+import type { Preview } from "../board/CardPreview";
 
 /** One suggested card in a `suggestion round`: art, rationale chips, and its actions. */
 export function DraftCandidateCard({
@@ -8,15 +10,41 @@ export function DraftCandidateCard({
   primaryLabel,
   onPrimary,
   onRefresh,
+  onHover,
+  preview,
 }: {
   candidate: RankedCandidate;
   busy: boolean;
   primaryLabel: string;
   onPrimary: () => void;
   onRefresh: () => void;
+  onHover: (p: Preview | null) => void;
+  preview: Preview | null;
 }) {
   const { t } = useI18n();
   const { card, score, bracketTilt } = candidate;
+
+  function enter(e: ReactMouseEvent) {
+    onHover({
+      url: card.imageUrl,
+      name: card.name,
+      isCreature: false,
+      rect: (e.currentTarget as HTMLElement).getBoundingClientRect(),
+    });
+  }
+
+  function toggle(e: ReactMouseEvent) {
+    onHover(
+      preview && preview.name === card.name && preview.url === card.imageUrl
+        ? null
+        : {
+            url: card.imageUrl,
+            name: card.name,
+            isCreature: false,
+            rect: (e.currentTarget as HTMLElement).getBoundingClientRect(),
+          },
+    );
+  }
 
   return (
     <div className="draft-card">
@@ -26,6 +54,9 @@ export function DraftCandidateCard({
           src={card.imageUrl}
           alt={card.name}
           loading="lazy"
+          onMouseEnter={enter}
+          onMouseLeave={() => onHover(null)}
+          onClick={toggle}
         />
       ) : (
         <div className="draft-card__img draft-card__img--placeholder">

--- a/src/draft/DraftCandidateCard.tsx
+++ b/src/draft/DraftCandidateCard.tsx
@@ -1,0 +1,66 @@
+import type { RankedCandidate } from "./candidates";
+import { useI18n } from "../i18n/I18nContext";
+
+/** One suggested card in a `suggestion round`: art, rationale chips, and its actions. */
+export function DraftCandidateCard({
+  candidate,
+  busy,
+  primaryLabel,
+  onPrimary,
+  onRefresh,
+}: {
+  candidate: RankedCandidate;
+  busy: boolean;
+  primaryLabel: string;
+  onPrimary: () => void;
+  onRefresh: () => void;
+}) {
+  const { t } = useI18n();
+  const { card, score, bracketTilt } = candidate;
+
+  return (
+    <div className="draft-card">
+      {card.imageUrl ? (
+        <img
+          className="draft-card__img"
+          src={card.imageUrl}
+          alt={card.name}
+          loading="lazy"
+        />
+      ) : (
+        <div className="draft-card__img draft-card__img--placeholder">
+          {card.name}
+        </div>
+      )}
+      <div className="draft-card__body">
+        <span className="draft-card__name">{card.name}</span>
+        {score.matchedTokens.length > 0 && (
+          <div className="chips">
+            {score.matchedTokens.map((token) => (
+              <span className="chip" key={token}>
+                {token}
+              </span>
+            ))}
+          </div>
+        )}
+        {bracketTilt < 0 && (
+          <p className="hint" style={{ color: "var(--warn)" }}>
+            {t("draft.round.tiltNote")}
+          </p>
+        )}
+        <div className="draft-card__actions">
+          <button className="btn btn--sm" onClick={onPrimary} disabled={busy}>
+            {primaryLabel}
+          </button>
+          <button
+            className="btn btn--ghost btn--sm"
+            onClick={onRefresh}
+            disabled={busy}
+          >
+            {t("draft.round.refresh")}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/draft/DraftCandidateCard.tsx
+++ b/src/draft/DraftCandidateCard.tsx
@@ -1,4 +1,5 @@
 import type { MouseEvent as ReactMouseEvent } from "react";
+import { Plus, RefreshCw } from "lucide-react";
 import type { RankedCandidate } from "./candidates";
 import { useI18n } from "../i18n/I18nContext";
 import type { Preview } from "../board/CardPreview";
@@ -80,15 +81,23 @@ export function DraftCandidateCard({
           </p>
         )}
         <div className="draft-card__actions">
-          <button className="btn btn--sm" onClick={onPrimary} disabled={busy}>
-            {primaryLabel}
+          <button
+            className="btn btn--sm btn--icon has-tooltip"
+            onClick={onPrimary}
+            disabled={busy}
+            aria-label={primaryLabel}
+            data-tooltip={primaryLabel}
+          >
+            <Plus size={16} aria-hidden="true" />
           </button>
           <button
-            className="btn btn--ghost btn--sm"
+            className="btn btn--ghost btn--sm btn--icon has-tooltip"
             onClick={onRefresh}
             disabled={busy}
+            aria-label={t("draft.round.refresh")}
+            data-tooltip={t("draft.round.refresh")}
           >
-            {t("draft.round.refresh")}
+            <RefreshCw size={15} aria-hidden="true" />
           </button>
         </div>
       </div>

--- a/src/draft/DraftCandidateCard.tsx
+++ b/src/draft/DraftCandidateCard.tsx
@@ -64,42 +64,39 @@ export function DraftCandidateCard({
           {card.name}
         </div>
       )}
-      <div className="draft-card__body">
-        <span className="draft-card__name">{card.name}</span>
-        {score.matchedTokens.length > 0 && (
-          <div className="chips">
-            {score.matchedTokens.map((token) => (
-              <span className="chip" key={token}>
-                {token}
-              </span>
-            ))}
-          </div>
-        )}
-        {bracketTilt < 0 && (
-          <p className="hint" style={{ color: "var(--warn)" }}>
-            {t("draft.round.tiltNote")}
-          </p>
-        )}
-        <div className="draft-card__actions">
-          <button
-            className="btn btn--sm btn--icon has-tooltip"
-            onClick={onPrimary}
-            disabled={busy}
-            aria-label={primaryLabel}
-            data-tooltip={primaryLabel}
-          >
-            <Plus size={16} aria-hidden="true" />
-          </button>
-          <button
-            className="btn btn--ghost btn--sm btn--icon has-tooltip"
-            onClick={onRefresh}
-            disabled={busy}
-            aria-label={t("draft.round.refresh")}
-            data-tooltip={t("draft.round.refresh")}
-          >
-            <RefreshCw size={15} aria-hidden="true" />
-          </button>
+      {score.matchedTokens.length > 0 && (
+        <div className="chips draft-card__tags">
+          {score.matchedTokens.map((token) => (
+            <span className="chip" key={token}>
+              {token}
+            </span>
+          ))}
         </div>
+      )}
+      {bracketTilt < 0 && (
+        <p className="hint" style={{ color: "var(--warn)" }}>
+          {t("draft.round.tiltNote")}
+        </p>
+      )}
+      <div className="draft-card__actions">
+        <button
+          className="btn btn--sm btn--icon has-tooltip"
+          onClick={onPrimary}
+          disabled={busy}
+          aria-label={primaryLabel}
+          data-tooltip={primaryLabel}
+        >
+          <Plus size={16} aria-hidden="true" />
+        </button>
+        <button
+          className="btn btn--ghost btn--sm btn--icon has-tooltip"
+          onClick={onRefresh}
+          disabled={busy}
+          aria-label={t("draft.round.refresh")}
+          data-tooltip={t("draft.round.refresh")}
+        >
+          <RefreshCw size={15} aria-hidden="true" />
+        </button>
       </div>
     </div>
   );

--- a/src/draft/DraftView.tsx
+++ b/src/draft/DraftView.tsx
@@ -1,19 +1,44 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { SavedDeck } from "../deck/model";
 import { fetchCardsCached } from "../lib/scryfallCache";
 import { getEngine } from "../engine/EngineClient";
 import { frontFace } from "../lib/cardName";
+import { parseDecklist } from "../lib/decklist";
 import type { BracketEstimate, ClassifyDeckResult } from "../engine/draftQueries";
 import { DraftSession } from "./draftSession";
 import { engineDraftEngine, scryfallCardResolver } from "./candidates";
 import { BRACKET_TARGETS, DEFAULT_BRACKET_TARGET, type BracketTarget } from "./bracket";
 import { DraftCandidateCard } from "./DraftCandidateCard";
+import { CardNameInput } from "../components/CardNameInput";
+import { SearchableSelect } from "../components/SearchableSelect";
 import { CardPreview, type Preview } from "../board/CardPreview";
 import { useI18n } from "../i18n/I18nContext";
 import type { MsgKey } from "../i18n/messages";
 
 const MIN_BASE_CARDS = 3;
 const MAX_BASE_CARD_ROWS = 10;
+
+/** Seed cards for a draft launched from an existing deck (see `DeckEditor`). */
+export interface DraftSeed {
+  names: string[];
+  commander: string | null;
+}
+
+type EntryMode = "rows" | "paste";
+
+/** Unique base-card names parsed from pasted decklist text, order preserved. */
+function parsePastedNames(text: string): string[] {
+  const parsed = parseDecklist(text);
+  const seen = new Set<string>();
+  const names: string[] = [];
+  for (const entry of [...parsed.commanders, ...parsed.mainboard]) {
+    const key = entry.name.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    names.push(entry.name);
+  }
+  return names;
+}
 
 const BRACKET_TARGET_LABEL: Record<BracketTarget, MsgKey> = {
   exhibition: "draft.bracket.exhibition",
@@ -69,11 +94,118 @@ function shiftCommanderRow(row: number | null, removedIndex: number): number | n
   return row > removedIndex ? row - 1 : row;
 }
 
-/** Entry form: three or more base cards, an optional commander flag, and the bracket target. */
+/** The rows-mode inputs: up to ten card-name fields with autocomplete + a commander flag. */
+function DraftEntryRows({
+  names,
+  commanderRow,
+  onSetName,
+  onAddRow,
+  onRemoveRow,
+  onSetCommanderRow,
+}: {
+  names: string[];
+  commanderRow: number | null;
+  onSetName: (index: number, value: string) => void;
+  onAddRow: () => void;
+  onRemoveRow: (index: number) => void;
+  onSetCommanderRow: (row: number | null) => void;
+}) {
+  const { t } = useI18n();
+  return (
+    <>
+      {names.map((name, i) => (
+        <div className="draft-entry-row" key={i}>
+          <CardNameInput
+            value={name}
+            onChange={(value) => onSetName(i, value)}
+            placeholder={t("draft.entry.baseCardPlaceholder")}
+          />
+          <label className="draft-entry-row__commander">
+            <input
+              type="radio"
+              name="draft-commander"
+              checked={commanderRow === i}
+              onChange={() => onSetCommanderRow(i)}
+              disabled={!name.trim()}
+            />
+            {t("draft.entry.commanderFlag")}
+          </label>
+          {commanderRow === i && (
+            <button
+              type="button"
+              className="btn btn--ghost btn--sm"
+              onClick={() => onSetCommanderRow(null)}
+            >
+              {t("draft.entry.unflag")}
+            </button>
+          )}
+          {names.length > MIN_BASE_CARDS && (
+            <button
+              type="button"
+              className="btn btn--ghost btn--sm"
+              onClick={() => onRemoveRow(i)}
+              aria-label={t("draft.entry.removeCard")}
+            >
+              ×
+            </button>
+          )}
+        </div>
+      ))}
+      {names.length < MAX_BASE_CARD_ROWS && (
+        <button type="button" className="btn btn--ghost btn--sm" onClick={onAddRow}>
+          {t("draft.entry.addCard")}
+        </button>
+      )}
+    </>
+  );
+}
+
+/** The paste-mode inputs: a decklist textarea and an optional commander picker. */
+function DraftEntryPaste({
+  text,
+  commander,
+  onSetText,
+  onSetCommander,
+}: {
+  text: string;
+  commander: string;
+  onSetText: (value: string) => void;
+  onSetCommander: (value: string) => void;
+}) {
+  const { t } = useI18n();
+  const noCommander = t("draft.entry.noCommander");
+  const pastedNames = useMemo(() => parsePastedNames(text), [text]);
+  const options = [noCommander, ...pastedNames];
+  return (
+    <>
+      <textarea
+        className="import__textarea"
+        value={text}
+        onChange={(e) => onSetText(e.target.value)}
+        placeholder={"Sol Ring\nArcane Signet\n1 Cultivate\n..."}
+        spellCheck={false}
+      />
+      <label className="field" style={{ marginTop: "0.6rem" }}>
+        <span className="field__label">{t("draft.entry.commanderLabel")}</span>
+        <SearchableSelect
+          options={options}
+          value={commander || noCommander}
+          onChange={(value) => onSetCommander(value === noCommander ? "" : value)}
+          placeholder={t("draft.entry.commanderSearchPlaceholder")}
+          emptyLabel={t("draft.entry.commanderNoMatch")}
+        />
+      </label>
+    </>
+  );
+}
+
+/** Entry form: three or more base cards, an optional commander, and the bracket target. */
 function DraftEntry({
+  seed,
   onStart,
   onCancel,
 }: {
+  seed?: DraftSeed;
   onStart: (
     names: string[],
     commanderName: string | null,
@@ -82,8 +214,11 @@ function DraftEntry({
   onCancel: () => void;
 }) {
   const { t } = useI18n();
+  const [mode, setMode] = useState<EntryMode>(seed ? "paste" : "rows");
   const [names, setNames] = useState<string[]>(["", "", ""]);
   const [commanderRow, setCommanderRow] = useState<number | null>(null);
+  const [pasteText, setPasteText] = useState<string>(seed ? seed.names.join("\n") : "");
+  const [pasteCommander, setPasteCommander] = useState<string>(seed?.commander ?? "");
   const [target, setTarget] = useState<BracketTarget>(DEFAULT_BRACKET_TARGET);
   const [status, setStatus] = useState<EntryStatus>({ kind: "idle" });
   const [unresolved, setUnresolved] = useState<string[]>([]);
@@ -101,9 +236,18 @@ function DraftEntry({
     setCommanderRow((row) => shiftCommanderRow(row, index));
   }
 
+  /** The raw names and flagged commander for the active input mode. */
+  function collectEntry(): { names: string[]; commander: string } {
+    if (mode === "paste") {
+      return { names: parsePastedNames(pasteText), commander: pasteCommander.trim() };
+    }
+    const commander = commanderRow !== null ? (names[commanderRow]?.trim() ?? "") : "";
+    return { names, commander };
+  }
+
   async function handleStart() {
-    const trimmed = names.map((n) => n.trim()).filter(Boolean);
-    const unique = [...new Set(trimmed)];
+    const entry = collectEntry();
+    const unique = [...new Set(entry.names.map((n) => n.trim()).filter(Boolean))];
     if (unique.length < MIN_BASE_CARDS) {
       setStatus({
         kind: "error",
@@ -122,11 +266,10 @@ function DraftEntry({
       return;
     }
 
-    const flaggedName = commanderRow !== null ? names[commanderRow]?.trim() : "";
     const commanderName =
-      flaggedName &&
-      resolvedNames.some((n) => n.toLowerCase() === flaggedName.toLowerCase())
-        ? flaggedName
+      entry.commander &&
+      resolvedNames.some((n) => n.toLowerCase() === entry.commander.toLowerCase())
+        ? entry.commander
         : null;
 
     setStatus({ kind: "starting" });
@@ -153,52 +296,41 @@ function DraftEntry({
       </div>
       <p className="hint">{t("draft.entry.subtitle")}</p>
 
+      <div className="seg" style={{ marginBottom: "0.75rem" }}>
+        <button
+          className={`seg__btn ${mode === "rows" ? "seg__btn--active" : ""}`}
+          onClick={() => setMode("rows")}
+          aria-pressed={mode === "rows"}
+        >
+          {t("draft.entry.modeRows")}
+        </button>
+        <button
+          className={`seg__btn ${mode === "paste" ? "seg__btn--active" : ""}`}
+          onClick={() => setMode("paste")}
+          aria-pressed={mode === "paste"}
+        >
+          {t("draft.entry.modePaste")}
+        </button>
+      </div>
+
       <div className="field">
         <span className="field__label">{t("draft.entry.baseCardsLabel")}</span>
-        {names.map((name, i) => (
-          <div className="draft-entry-row" key={i}>
-            <input
-              className="input"
-              value={name}
-              onChange={(e) => setName(i, e.target.value)}
-              placeholder={t("draft.entry.baseCardPlaceholder")}
-              spellCheck={false}
-            />
-            <label className="draft-entry-row__commander">
-              <input
-                type="radio"
-                name="draft-commander"
-                checked={commanderRow === i}
-                onChange={() => setCommanderRow(i)}
-                disabled={!name.trim()}
-              />
-              {t("draft.entry.commanderFlag")}
-            </label>
-            {commanderRow === i && (
-              <button
-                type="button"
-                className="btn btn--ghost btn--sm"
-                onClick={() => setCommanderRow(null)}
-              >
-                {t("draft.entry.unflag")}
-              </button>
-            )}
-            {names.length > MIN_BASE_CARDS && (
-              <button
-                type="button"
-                className="btn btn--ghost btn--sm"
-                onClick={() => removeRow(i)}
-                aria-label={t("draft.entry.removeCard")}
-              >
-                ×
-              </button>
-            )}
-          </div>
-        ))}
-        {names.length < MAX_BASE_CARD_ROWS && (
-          <button type="button" className="btn btn--ghost btn--sm" onClick={addRow}>
-            {t("draft.entry.addCard")}
-          </button>
+        {mode === "rows" ? (
+          <DraftEntryRows
+            names={names}
+            commanderRow={commanderRow}
+            onSetName={setName}
+            onAddRow={addRow}
+            onRemoveRow={removeRow}
+            onSetCommanderRow={setCommanderRow}
+          />
+        ) : (
+          <DraftEntryPaste
+            text={pasteText}
+            commander={pasteCommander}
+            onSetText={setPasteText}
+            onSetCommander={setPasteCommander}
+          />
         )}
       </div>
 
@@ -624,9 +756,11 @@ function DraftSessionView({
 
 /** Assisted deck draft (`draft-a-deck`): seed cards, a commander step, then suggestion rounds. */
 export function DraftView({
+  seed,
   onSave,
   onExit,
 }: {
+  seed?: DraftSeed;
   onSave: (deck: SavedDeck) => void;
   onExit: () => void;
 }) {
@@ -648,7 +782,7 @@ export function DraftView({
   }
 
   if (!started || !sessionRef.current) {
-    return <DraftEntry onStart={handleStart} onCancel={onExit} />;
+    return <DraftEntry seed={seed} onStart={handleStart} onCancel={onExit} />;
   }
 
   return (

--- a/src/draft/DraftView.tsx
+++ b/src/draft/DraftView.tsx
@@ -344,6 +344,9 @@ function DraftSummaryPanel({
   const tierLabel = bracket
     ? t(ENGINE_TIER_LABEL[bracket.tier] ?? "draft.bracket.exhibition")
     : "—";
+  const commanderName = session.background
+    ? `${session.commander?.name} + ${session.background.name}`
+    : (session.commander?.name ?? t("deck.noCommander"));
 
   return (
     <section className="panel">
@@ -356,9 +359,7 @@ function DraftSummaryPanel({
       <div className="chips">
         <span className="chip">{t("draft.summary.cards", { n: totalCards })}</span>
         <span className="chip">
-          {t("draft.summary.commander", {
-            name: session.commander?.name ?? t("deck.noCommander"),
-          })}
+          {t("draft.summary.commander", { name: commanderName })}
         </span>
         {session.profile.colorIdentity.length > 0 && (
           <span className="chip">

--- a/src/draft/DraftView.tsx
+++ b/src/draft/DraftView.tsx
@@ -4,7 +4,11 @@ import { fetchCardsCached } from "../lib/scryfallCache";
 import { getEngine } from "../engine/EngineClient";
 import { frontFace } from "../lib/cardName";
 import { parseDecklist } from "../lib/decklist";
-import type { BracketEstimate, ClassifyDeckResult } from "../engine/draftQueries";
+import type {
+  BracketEstimate,
+  CardValidation,
+  ClassifyDeckResult,
+} from "../engine/draftQueries";
 import { DraftSession } from "./draftSession";
 import { engineDraftEngine, scryfallCardResolver } from "./candidates";
 import { BRACKET_TARGETS, DEFAULT_BRACKET_TARGET, type BracketTarget } from "./bracket";
@@ -17,6 +21,50 @@ import type { MsgKey } from "../i18n/messages";
 
 const MIN_BASE_CARDS = 3;
 const MAX_BASE_CARD_ROWS = 10;
+
+/** Card-name autocomplete backed by the local engine card database (no network). */
+const suggestCardNames = (query: string): Promise<string[]> =>
+  getEngine().searchCardNames(query);
+
+/**
+ * Live validation of the entered base-card names against the engine's card
+ * database (debounced, no network): existence, Commander legality, and
+ * commander eligibility. `checked` is false until every entered name has a
+ * result, so callers can hold the Start button while validation catches up.
+ */
+function indexValidations(results: CardValidation[]): Map<string, CardValidation> {
+  return new Map(results.map((r) => [r.name.trim().toLowerCase(), r]));
+}
+
+function useCardValidation(names: string[]): {
+  statuses: Map<string, CardValidation>;
+  checked: boolean;
+} {
+  const key = names.join("\n");
+  const [statuses, setStatuses] = useState<Map<string, CardValidation>>(new Map());
+  const seqRef = useRef(0);
+
+  useEffect(() => {
+    const list = key.split("\n").filter(Boolean);
+    if (list.length === 0) {
+      setStatuses(new Map());
+      return;
+    }
+    const seq = ++seqRef.current;
+    const timer = setTimeout(() => {
+      getEngine()
+        .validateCards(list)
+        .then((results) => {
+          if (seq === seqRef.current) setStatuses(indexValidations(results));
+        })
+        .catch(() => {});
+    }, 250);
+    return () => clearTimeout(timer);
+  }, [key]);
+
+  const checked = names.every((n) => statuses.has(n.trim().toLowerCase()));
+  return { statuses, checked };
+}
 
 /** Seed cards for a draft launched from an existing deck (see `DeckEditor`). */
 export interface DraftSeed {
@@ -98,6 +146,8 @@ function shiftCommanderRow(row: number | null, removedIndex: number): number | n
 function DraftEntryRows({
   names,
   commanderRow,
+  isInvalid,
+  isCommanderEligible,
   onSetName,
   onAddRow,
   onRemoveRow,
@@ -105,6 +155,8 @@ function DraftEntryRows({
 }: {
   names: string[];
   commanderRow: number | null;
+  isInvalid: (name: string) => boolean;
+  isCommanderEligible: (name: string) => boolean;
   onSetName: (index: number, value: string) => void;
   onAddRow: () => void;
   onRemoveRow: (index: number) => void;
@@ -118,7 +170,9 @@ function DraftEntryRows({
           <CardNameInput
             value={name}
             onChange={(value) => onSetName(i, value)}
+            fetchSuggestions={suggestCardNames}
             placeholder={t("draft.entry.baseCardPlaceholder")}
+            invalid={isInvalid(name)}
           />
           <label className="draft-entry-row__commander">
             <input
@@ -126,7 +180,7 @@ function DraftEntryRows({
               name="draft-commander"
               checked={commanderRow === i}
               onChange={() => onSetCommanderRow(i)}
-              disabled={!name.trim()}
+              disabled={!name.trim() || !isCommanderEligible(name)}
             />
             {t("draft.entry.commanderFlag")}
           </label>
@@ -164,18 +218,19 @@ function DraftEntryRows({
 function DraftEntryPaste({
   text,
   commander,
+  commanderOptions,
   onSetText,
   onSetCommander,
 }: {
   text: string;
   commander: string;
+  /** The pasted names that may be a commander (eligible only). */
+  commanderOptions: string[];
   onSetText: (value: string) => void;
   onSetCommander: (value: string) => void;
 }) {
   const { t } = useI18n();
-  const noCommander = t("draft.entry.noCommander");
-  const pastedNames = useMemo(() => parsePastedNames(text), [text]);
-  const options = [noCommander, ...pastedNames];
+  const hasOptions = commanderOptions.length > 0;
   return (
     <>
       <textarea
@@ -185,14 +240,21 @@ function DraftEntryPaste({
         placeholder={"Sol Ring\nArcane Signet\n1 Cultivate\n..."}
         spellCheck={false}
       />
-      <label className="field" style={{ marginTop: "0.6rem" }}>
+      <label className="field draft-commander-field" style={{ marginTop: "0.6rem" }}>
         <span className="field__label">{t("draft.entry.commanderLabel")}</span>
         <SearchableSelect
-          options={options}
-          value={commander || noCommander}
-          onChange={(value) => onSetCommander(value === noCommander ? "" : value)}
-          placeholder={t("draft.entry.commanderSearchPlaceholder")}
+          options={commanderOptions}
+          value={commander}
+          onChange={onSetCommander}
+          placeholder={
+            hasOptions
+              ? t("draft.entry.commanderSearchPlaceholder")
+              : t("draft.entry.commanderNone")
+          }
           emptyLabel={t("draft.entry.commanderNoMatch")}
+          disabled={!hasOptions}
+          clearable
+          clearLabel={t("draft.entry.clearCommander")}
         />
       </label>
     </>
@@ -222,6 +284,48 @@ function DraftEntry({
   const [target, setTarget] = useState<BracketTarget>(DEFAULT_BRACKET_TARGET);
   const [status, setStatus] = useState<EntryStatus>({ kind: "idle" });
   const [unresolved, setUnresolved] = useState<string[]>([]);
+
+  // Warm the engine (WASM + card database) so name suggestions and the start
+  // step are ready by the time the author needs them.
+  useEffect(() => {
+    void getEngine().ready();
+  }, []);
+
+  const enteredNames = useMemo(() => {
+    const raw = mode === "paste" ? parsePastedNames(pasteText) : names;
+    return [...new Set(raw.map((n) => n.trim()).filter(Boolean))];
+  }, [mode, names, pasteText]);
+
+  const { statuses, checked } = useCardValidation(enteredNames);
+  const statusOf = (name: string) => statuses.get(name.trim().toLowerCase());
+  const isInvalidName = (name: string) => {
+    const s = statusOf(name);
+    return s !== undefined && (!s.exists || !s.commanderLegal);
+  };
+  const isCommanderEligible = (name: string) => statusOf(name)?.commanderEligible === true;
+
+  const notFoundNames = enteredNames.filter((n) => statusOf(n)?.exists === false);
+  const notLegalNames = enteredNames.filter((n) => {
+    const s = statusOf(n);
+    return s?.exists === true && !s.commanderLegal;
+  });
+  const legalCount = enteredNames.filter((n) => statusOf(n)?.commanderLegal).length;
+  const commanderOptions = enteredNames.filter(isCommanderEligible);
+
+  // Drop a chosen commander once validation shows it can't be one.
+  useEffect(() => {
+    if (!pasteCommander) return;
+    const s = statuses.get(pasteCommander.trim().toLowerCase());
+    if (s && !s.commanderEligible) setPasteCommander("");
+  }, [statuses, pasteCommander]);
+
+  useEffect(() => {
+    if (commanderRow === null) return;
+    const name = names[commanderRow]?.trim();
+    if (!name) return;
+    const s = statuses.get(name.toLowerCase());
+    if (s && !s.commanderEligible) setCommanderRow(null);
+  }, [statuses, commanderRow, names]);
 
   function setName(index: number, value: string) {
     setNames((prev) => prev.map((n, i) => (i === index ? value : n)));
@@ -319,6 +423,8 @@ function DraftEntry({
           <DraftEntryRows
             names={names}
             commanderRow={commanderRow}
+            isInvalid={isInvalidName}
+            isCommanderEligible={isCommanderEligible}
             onSetName={setName}
             onAddRow={addRow}
             onRemoveRow={removeRow}
@@ -328,17 +434,38 @@ function DraftEntry({
           <DraftEntryPaste
             text={pasteText}
             commander={pasteCommander}
+            commanderOptions={commanderOptions}
             onSetText={setPasteText}
             onSetCommander={setPasteCommander}
           />
         )}
       </div>
 
+      {checked &&
+        enteredNames.length > 0 &&
+        notFoundNames.length === 0 &&
+        notLegalNames.length === 0 &&
+        legalCount < MIN_BASE_CARDS && (
+          <p className="hint" style={{ color: "var(--bad)" }}>
+            {t("draft.entry.tooFew", { n: MIN_BASE_CARDS - legalCount })}
+          </p>
+        )}
+
       <div className="field">
         <span className="field__label">{t("draft.entry.bracketLabel")}</span>
         <BracketTargetPicker target={target} onChange={setTarget} />
       </div>
 
+      {notFoundNames.length > 0 && (
+        <p className="hint" style={{ color: "var(--bad)" }}>
+          {t("draft.entry.notFoundCards", { list: notFoundNames.join(", ") })}
+        </p>
+      )}
+      {notLegalNames.length > 0 && (
+        <p className="hint" style={{ color: "var(--bad)" }}>
+          {t("draft.entry.notLegalCards", { list: notLegalNames.join(", ") })}
+        </p>
+      )}
       {unresolved.length > 0 && (
         <p className="hint" style={{ color: "var(--warn)" }}>
           {t("draft.entry.unresolved", { list: unresolved.join(", ") })}
@@ -350,7 +477,17 @@ function DraftEntry({
       )}
 
       <div className="import__row">
-        <button className="btn" onClick={() => void handleStart()} disabled={busy}>
+        <button
+          className="btn"
+          onClick={() => void handleStart()}
+          disabled={
+            busy ||
+            !checked ||
+            legalCount < MIN_BASE_CARDS ||
+            notFoundNames.length > 0 ||
+            notLegalNames.length > 0
+          }
+        >
           {status.kind === "checking"
             ? t("draft.entry.checking")
             : t("draft.entry.start")}

--- a/src/draft/DraftView.tsx
+++ b/src/draft/DraftView.tsx
@@ -8,6 +8,7 @@ import { DraftSession } from "./draftSession";
 import { engineDraftEngine, scryfallCardResolver } from "./candidates";
 import { BRACKET_TARGETS, DEFAULT_BRACKET_TARGET, type BracketTarget } from "./bracket";
 import { DraftCandidateCard } from "./DraftCandidateCard";
+import { CardPreview, type Preview } from "../board/CardPreview";
 import { useI18n } from "../i18n/I18nContext";
 import type { MsgKey } from "../i18n/messages";
 
@@ -274,6 +275,8 @@ function DraftCommanderPanel({
   onPick,
   onRefresh,
   onExit,
+  onHover,
+  preview,
 }: {
   session: DraftSession;
   roundBusy: RoundBusy;
@@ -281,6 +284,8 @@ function DraftCommanderPanel({
   onPick: (index: number) => void;
   onRefresh: (index: number) => void;
   onExit: () => void;
+  onHover: (p: Preview | null) => void;
+  preview: Preview | null;
 }) {
   const { t } = useI18n();
   return (
@@ -305,6 +310,8 @@ function DraftCommanderPanel({
               primaryLabel={t("draft.commander.choose")}
               onPrimary={() => onPick(i)}
               onRefresh={() => onRefresh(i)}
+              onHover={onHover}
+              preview={preview}
             />
           ))}
         </div>
@@ -384,12 +391,16 @@ function DraftRoundPanel({
   roundError,
   onAdd,
   onRefresh,
+  onHover,
+  preview,
 }: {
   session: DraftSession;
   roundBusy: RoundBusy;
   roundError: string | null;
   onAdd: (index: number) => void;
   onRefresh: (index: number) => void;
+  onHover: (p: Preview | null) => void;
+  preview: Preview | null;
 }) {
   const { t } = useI18n();
   const loadingNext = roundBusy === "all";
@@ -409,6 +420,8 @@ function DraftRoundPanel({
               primaryLabel={t("draft.round.add")}
               onPrimary={() => onAdd(i)}
               onRefresh={() => onRefresh(i)}
+              onHover={onHover}
+              preview={preview}
             />
           ))}
         </div>
@@ -490,6 +503,7 @@ function DraftSessionView({
   const [target, setTarget] = useState<BracketTarget>(session.target);
   const [saveName, setSaveName] = useState("");
   const [copied, setCopied] = useState(false);
+  const [preview, setPreview] = useState<Preview | null>(null);
   const copyTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const { archetype, bracket, loading: measuresLoading } = useDeckMeasures(
@@ -555,19 +569,25 @@ function DraftSessionView({
 
   if (session.phase === "commander-selection") {
     return (
-      <DraftCommanderPanel
-        session={session}
-        roundBusy={roundBusy}
-        roundError={roundError}
-        onPick={handlePick}
-        onRefresh={handleRefresh}
-        onExit={onExit}
-      />
+      <>
+        {preview && <CardPreview preview={preview} />}
+        <DraftCommanderPanel
+          session={session}
+          roundBusy={roundBusy}
+          roundError={roundError}
+          onPick={handlePick}
+          onRefresh={handleRefresh}
+          onExit={onExit}
+          onHover={setPreview}
+          preview={preview}
+        />
+      </>
     );
   }
 
   return (
     <div>
+      {preview && <CardPreview preview={preview} />}
       <DraftSummaryPanel
         session={session}
         target={target}
@@ -584,6 +604,8 @@ function DraftSessionView({
         roundError={roundError}
         onAdd={handleAdd}
         onRefresh={handleRefresh}
+        onHover={setPreview}
+        preview={preview}
       />
       <DraftLeavePanel
         session={session}

--- a/src/draft/DraftView.tsx
+++ b/src/draft/DraftView.tsx
@@ -1,0 +1,634 @@
+import { useEffect, useRef, useState } from "react";
+import type { SavedDeck } from "../deck/model";
+import { fetchCardsCached } from "../lib/scryfallCache";
+import { getEngine } from "../engine/EngineClient";
+import { frontFace } from "../lib/cardName";
+import type { BracketEstimate, ClassifyDeckResult } from "../engine/draftQueries";
+import { DraftSession } from "./draftSession";
+import { engineDraftEngine, scryfallCardResolver } from "./candidates";
+import { BRACKET_TARGETS, DEFAULT_BRACKET_TARGET, type BracketTarget } from "./bracket";
+import { DraftCandidateCard } from "./DraftCandidateCard";
+import { useI18n } from "../i18n/I18nContext";
+import type { MsgKey } from "../i18n/messages";
+
+const MIN_BASE_CARDS = 3;
+const MAX_BASE_CARD_ROWS = 10;
+
+const BRACKET_TARGET_LABEL: Record<BracketTarget, MsgKey> = {
+  exhibition: "draft.bracket.exhibition",
+  core: "draft.bracket.core",
+  focused: "draft.bracket.focused",
+  optimized: "draft.bracket.optimized",
+  cedh: "draft.bracket.cedh",
+};
+
+const ENGINE_TIER_LABEL: Record<string, MsgKey> = {
+  exhibition: "draft.bracket.exhibition",
+  core: "draft.bracket.core",
+  upgraded: "draft.bracket.focused",
+  optimized: "draft.bracket.optimized",
+  cedh: "draft.bracket.cedh",
+};
+
+type EntryStatus =
+  | { kind: "idle" }
+  | { kind: "checking" }
+  | { kind: "starting" }
+  | { kind: "error"; message: string };
+
+type RoundBusy = number | "all" | null;
+
+function BracketTargetPicker({
+  target,
+  onChange,
+}: {
+  target: BracketTarget;
+  onChange: (target: BracketTarget) => void;
+}) {
+  const { t } = useI18n();
+  return (
+    <div className="seg">
+      {BRACKET_TARGETS.map((bt) => (
+        <button
+          key={bt}
+          className={`seg__btn ${target === bt ? "seg__btn--active" : ""}`}
+          onClick={() => onChange(bt)}
+          aria-pressed={target === bt}
+        >
+          {t(BRACKET_TARGET_LABEL[bt])}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/** After removing base-card row `removedIndex`, where the flagged commander row lands. */
+function shiftCommanderRow(row: number | null, removedIndex: number): number | null {
+  if (row === null || row === removedIndex) return null;
+  return row > removedIndex ? row - 1 : row;
+}
+
+/** Entry form: three or more base cards, an optional commander flag, and the bracket target. */
+function DraftEntry({
+  onStart,
+  onCancel,
+}: {
+  onStart: (
+    names: string[],
+    commanderName: string | null,
+    target: BracketTarget,
+  ) => Promise<void>;
+  onCancel: () => void;
+}) {
+  const { t } = useI18n();
+  const [names, setNames] = useState<string[]>(["", "", ""]);
+  const [commanderRow, setCommanderRow] = useState<number | null>(null);
+  const [target, setTarget] = useState<BracketTarget>(DEFAULT_BRACKET_TARGET);
+  const [status, setStatus] = useState<EntryStatus>({ kind: "idle" });
+  const [unresolved, setUnresolved] = useState<string[]>([]);
+
+  function setName(index: number, value: string) {
+    setNames((prev) => prev.map((n, i) => (i === index ? value : n)));
+  }
+
+  function addRow() {
+    setNames((prev) => [...prev, ""]);
+  }
+
+  function removeRow(index: number) {
+    setNames((prev) => prev.filter((_, i) => i !== index));
+    setCommanderRow((row) => shiftCommanderRow(row, index));
+  }
+
+  async function handleStart() {
+    const trimmed = names.map((n) => n.trim()).filter(Boolean);
+    const unique = [...new Set(trimmed)];
+    if (unique.length < MIN_BASE_CARDS) {
+      setStatus({
+        kind: "error",
+        message: t("draft.entry.tooFew", { n: MIN_BASE_CARDS - unique.length }),
+      });
+      return;
+    }
+
+    setStatus({ kind: "checking" });
+    setUnresolved([]);
+    const { cards, notFound } = await fetchCardsCached(unique);
+    setUnresolved(notFound);
+    const resolvedNames = unique.filter((n) => cards.has(n.toLowerCase()));
+    if (resolvedNames.length < MIN_BASE_CARDS) {
+      setStatus({ kind: "error", message: t("draft.entry.tooFewResolved") });
+      return;
+    }
+
+    const flaggedName = commanderRow !== null ? names[commanderRow]?.trim() : "";
+    const commanderName =
+      flaggedName &&
+      resolvedNames.some((n) => n.toLowerCase() === flaggedName.toLowerCase())
+        ? flaggedName
+        : null;
+
+    setStatus({ kind: "starting" });
+    try {
+      await getEngine().ready();
+      await onStart(resolvedNames, commanderName, target);
+    } catch (err) {
+      setStatus({
+        kind: "error",
+        message: err instanceof Error ? err.message : t("draft.entry.startFailed"),
+      });
+    }
+  }
+
+  const busy = status.kind === "checking" || status.kind === "starting";
+
+  return (
+    <section className="panel">
+      <div className="panel__head">
+        <h2>{t("draft.entry.title")}</h2>
+        <button className="btn btn--ghost btn--sm" onClick={onCancel}>
+          {t("draft.leave.back")}
+        </button>
+      </div>
+      <p className="hint">{t("draft.entry.subtitle")}</p>
+
+      <div className="field">
+        <span className="field__label">{t("draft.entry.baseCardsLabel")}</span>
+        {names.map((name, i) => (
+          <div className="draft-entry-row" key={i}>
+            <input
+              className="input"
+              value={name}
+              onChange={(e) => setName(i, e.target.value)}
+              placeholder={t("draft.entry.baseCardPlaceholder")}
+              spellCheck={false}
+            />
+            <label className="draft-entry-row__commander">
+              <input
+                type="radio"
+                name="draft-commander"
+                checked={commanderRow === i}
+                onChange={() => setCommanderRow(i)}
+                disabled={!name.trim()}
+              />
+              {t("draft.entry.commanderFlag")}
+            </label>
+            {commanderRow === i && (
+              <button
+                type="button"
+                className="btn btn--ghost btn--sm"
+                onClick={() => setCommanderRow(null)}
+              >
+                {t("draft.entry.unflag")}
+              </button>
+            )}
+            {names.length > MIN_BASE_CARDS && (
+              <button
+                type="button"
+                className="btn btn--ghost btn--sm"
+                onClick={() => removeRow(i)}
+                aria-label={t("draft.entry.removeCard")}
+              >
+                ×
+              </button>
+            )}
+          </div>
+        ))}
+        {names.length < MAX_BASE_CARD_ROWS && (
+          <button type="button" className="btn btn--ghost btn--sm" onClick={addRow}>
+            {t("draft.entry.addCard")}
+          </button>
+        )}
+      </div>
+
+      <div className="field">
+        <span className="field__label">{t("draft.entry.bracketLabel")}</span>
+        <BracketTargetPicker target={target} onChange={setTarget} />
+      </div>
+
+      {unresolved.length > 0 && (
+        <p className="hint" style={{ color: "var(--warn)" }}>
+          {t("draft.entry.unresolved", { list: unresolved.join(", ") })}
+        </p>
+      )}
+      {status.kind === "error" && <p className="error">{status.message}</p>}
+      {status.kind === "starting" && (
+        <p className="hint">{t("draft.entry.starting")}</p>
+      )}
+
+      <div className="import__row">
+        <button className="btn" onClick={() => void handleStart()} disabled={busy}>
+          {status.kind === "checking"
+            ? t("draft.entry.checking")
+            : t("draft.entry.start")}
+        </button>
+        <button className="btn btn--ghost" onClick={onCancel} disabled={busy}>
+          {t("draft.entry.cancel")}
+        </button>
+      </div>
+    </section>
+  );
+}
+
+/** The live archetype + bracket estimate, refetched whenever the deck's cards change. */
+function useDeckMeasures(session: DraftSession, deckVersion: number) {
+  const [archetype, setArchetype] = useState<ClassifyDeckResult | null>(null);
+  const [bracket, setBracket] = useState<BracketEstimate | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const commanderNames = session.commanders.map((e) => frontFace(e.name));
+    const mainNames = session.mainboard.map((e) => frontFace(e.name));
+    setLoading(true);
+    Promise.all([
+      getEngine().classifyDeck([...commanderNames, ...mainNames]),
+      getEngine().estimateBracket({ commander: commanderNames, main_deck: mainNames }),
+    ])
+      .then(([a, b]) => {
+        if (cancelled) return;
+        setArchetype(a);
+        setBracket(b);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setArchetype(null);
+          setBracket(null);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [session, deckVersion]);
+
+  return { archetype, bracket, loading };
+}
+
+function DraftCommanderPanel({
+  session,
+  roundBusy,
+  roundError,
+  onPick,
+  onRefresh,
+  onExit,
+}: {
+  session: DraftSession;
+  roundBusy: RoundBusy;
+  roundError: string | null;
+  onPick: (index: number) => void;
+  onRefresh: (index: number) => void;
+  onExit: () => void;
+}) {
+  const { t } = useI18n();
+  return (
+    <section className="panel">
+      <div className="panel__head">
+        <h2>{t("draft.commander.title")}</h2>
+        <button className="btn btn--ghost btn--sm" onClick={onExit}>
+          {t("draft.leave.back")}
+        </button>
+      </div>
+      <p className="hint">{t("draft.commander.hint")}</p>
+      {roundBusy === "all" && <p className="hint">{t("draft.round.loadingNext")}</p>}
+      {session.round.length === 0 ? (
+        <p className="hint">{t("draft.commander.empty")}</p>
+      ) : (
+        <div className={`draft-round ${roundBusy === "all" ? "draft-round--loading" : ""}`}>
+          {session.round.map((candidate, i) => (
+            <DraftCandidateCard
+              key={candidate.card.name}
+              candidate={candidate}
+              busy={roundBusy === i || roundBusy === "all"}
+              primaryLabel={t("draft.commander.choose")}
+              onPrimary={() => onPick(i)}
+              onRefresh={() => onRefresh(i)}
+            />
+          ))}
+        </div>
+      )}
+      {roundError && <p className="error">{roundError}</p>}
+    </section>
+  );
+}
+
+function DraftSummaryPanel({
+  session,
+  target,
+  totalCards,
+  archetype,
+  bracket,
+  measuresLoading,
+  onTargetChange,
+  onExit,
+}: {
+  session: DraftSession;
+  target: BracketTarget;
+  totalCards: number;
+  archetype: ClassifyDeckResult | null;
+  bracket: BracketEstimate | null;
+  measuresLoading: boolean;
+  onTargetChange: (target: BracketTarget) => void;
+  onExit: () => void;
+}) {
+  const { t } = useI18n();
+  const tierLabel = bracket
+    ? t(ENGINE_TIER_LABEL[bracket.tier] ?? "draft.bracket.exhibition")
+    : "—";
+
+  return (
+    <section className="panel">
+      <div className="panel__head">
+        <h2>{t("draft.windowTitle")}</h2>
+        <button className="btn btn--ghost btn--sm" onClick={onExit}>
+          {t("draft.leave.back")}
+        </button>
+      </div>
+      <div className="chips">
+        <span className="chip">{t("draft.summary.cards", { n: totalCards })}</span>
+        <span className="chip">
+          {t("draft.summary.commander", {
+            name: session.commander?.name ?? t("deck.noCommander"),
+          })}
+        </span>
+        {session.profile.colorIdentity.length > 0 && (
+          <span className="chip">
+            {t("draft.summary.colorIdentity", {
+              list: session.profile.colorIdentity.join(""),
+            })}
+          </span>
+        )}
+        <span className="chip">
+          {measuresLoading
+            ? "…"
+            : t("draft.summary.archetype", { name: archetype?.archetype ?? "—" })}
+        </span>
+        <span className="chip">
+          {measuresLoading ? "…" : t("draft.summary.bracket", { tier: tierLabel })}
+        </span>
+      </div>
+      <div className="field" style={{ marginTop: "0.75rem" }}>
+        <span className="field__label">{t("draft.summary.bracketTarget")}</span>
+        <BracketTargetPicker target={target} onChange={onTargetChange} />
+        <p className="hint">{t("draft.summary.targetHint")}</p>
+      </div>
+    </section>
+  );
+}
+
+function DraftRoundPanel({
+  session,
+  roundBusy,
+  roundError,
+  onAdd,
+  onRefresh,
+}: {
+  session: DraftSession;
+  roundBusy: RoundBusy;
+  roundError: string | null;
+  onAdd: (index: number) => void;
+  onRefresh: (index: number) => void;
+}) {
+  const { t } = useI18n();
+  const loadingNext = roundBusy === "all";
+  return (
+    <section className="panel">
+      <h3>{t("draft.round.title")}</h3>
+      {loadingNext && <p className="hint">{t("draft.round.loadingNext")}</p>}
+      {session.round.length === 0 ? (
+        <p className="hint">{t("draft.round.empty")}</p>
+      ) : (
+        <div className={`draft-round ${loadingNext ? "draft-round--loading" : ""}`}>
+          {session.round.map((candidate, i) => (
+            <DraftCandidateCard
+              key={candidate.card.name}
+              candidate={candidate}
+              busy={roundBusy === i || roundBusy === "all"}
+              primaryLabel={t("draft.round.add")}
+              onPrimary={() => onAdd(i)}
+              onRefresh={() => onRefresh(i)}
+            />
+          ))}
+        </div>
+      )}
+      {roundError && <p className="error">{roundError}</p>}
+    </section>
+  );
+}
+
+function DraftLeavePanel({
+  session,
+  totalCards,
+  saveName,
+  setSaveName,
+  copied,
+  onCopy,
+  onSave,
+  onExit,
+}: {
+  session: DraftSession;
+  totalCards: number;
+  saveName: string;
+  setSaveName: (value: string) => void;
+  copied: boolean;
+  onCopy: () => void;
+  onSave: () => void;
+  onExit: () => void;
+}) {
+  const { t } = useI18n();
+  return (
+    <section className="panel">
+      <h3>{t("draft.leave.title")}</h3>
+      <div className="import__row">
+        <button className="btn btn--ghost" onClick={onCopy}>
+          {copied ? t("draft.leave.copied") : t("draft.leave.copy")}
+        </button>
+      </div>
+      <label className="field">
+        <span className="field__label">{t("draft.leave.nameLabel")}</span>
+        <input
+          className="input"
+          value={saveName}
+          onChange={(e) => setSaveName(e.target.value)}
+          placeholder={session.commander?.name ?? t("editor.untitled")}
+        />
+      </label>
+      {totalCards !== 100 && (
+        <p className="hint" style={{ color: "var(--warn)" }}>
+          {t("draft.leave.partialHint")}
+        </p>
+      )}
+      <div className="import__row">
+        <button className="btn" onClick={onSave}>
+          {t("draft.leave.save")}
+        </button>
+        <button className="btn btn--ghost" onClick={onExit}>
+          {t("draft.leave.back")}
+        </button>
+      </div>
+    </section>
+  );
+}
+
+/** The commander-selection or drafting session UI, driven by a live `DraftSession`. */
+function DraftSessionView({
+  session,
+  onExit,
+  onSave,
+}: {
+  session: DraftSession;
+  onExit: () => void;
+  onSave: (deck: SavedDeck) => void;
+}) {
+  const { t } = useI18n();
+  const [, setTick] = useState(0);
+  const [deckVersion, setDeckVersion] = useState(0);
+  const [roundBusy, setRoundBusy] = useState<RoundBusy>(null);
+  const [roundError, setRoundError] = useState<string | null>(null);
+  const [target, setTarget] = useState<BracketTarget>(session.target);
+  const [saveName, setSaveName] = useState("");
+  const [copied, setCopied] = useState(false);
+  const copyTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const { archetype, bracket, loading: measuresLoading } = useDeckMeasures(
+    session,
+    deckVersion,
+  );
+
+  useEffect(() => () => {
+    if (copyTimer.current) clearTimeout(copyTimer.current);
+  }, []);
+
+  async function runRoundAction(busy: RoundBusy, action: () => Promise<void>) {
+    setRoundBusy(busy);
+    setRoundError(null);
+    try {
+      await action();
+      setTick((n) => n + 1);
+    } catch (err) {
+      setRoundError(
+        err instanceof Error ? err.message : t("draft.round.actionFailed"),
+      );
+    } finally {
+      setRoundBusy(null);
+    }
+  }
+
+  function handlePick(index: number) {
+    void runRoundAction("all", async () => {
+      await session.pickCommander(session.round[index].card.name);
+      setDeckVersion((v) => v + 1);
+    });
+  }
+
+  function handleAdd(index: number) {
+    void runRoundAction("all", async () => {
+      await session.addCard(index);
+      setDeckVersion((v) => v + 1);
+    });
+  }
+
+  function handleRefresh(index: number) {
+    void runRoundAction(index, () => session.refreshSlot(index));
+  }
+
+  function handleTargetChange(next: BracketTarget) {
+    setTarget(next);
+    session.setBracketTarget(next);
+  }
+
+  async function handleCopy() {
+    await navigator.clipboard.writeText(session.exportText());
+    setCopied(true);
+    if (copyTimer.current) clearTimeout(copyTimer.current);
+    copyTimer.current = setTimeout(() => setCopied(false), 1500);
+  }
+
+  function handleSave() {
+    const name = saveName.trim() || session.commander?.name || t("editor.untitled");
+    onSave(session.toSavedDeck(name));
+  }
+
+  const totalCards = session.commanders.length + session.mainboard.length;
+
+  if (session.phase === "commander-selection") {
+    return (
+      <DraftCommanderPanel
+        session={session}
+        roundBusy={roundBusy}
+        roundError={roundError}
+        onPick={handlePick}
+        onRefresh={handleRefresh}
+        onExit={onExit}
+      />
+    );
+  }
+
+  return (
+    <div>
+      <DraftSummaryPanel
+        session={session}
+        target={target}
+        totalCards={totalCards}
+        archetype={archetype}
+        bracket={bracket}
+        measuresLoading={measuresLoading}
+        onTargetChange={handleTargetChange}
+        onExit={onExit}
+      />
+      <DraftRoundPanel
+        session={session}
+        roundBusy={roundBusy}
+        roundError={roundError}
+        onAdd={handleAdd}
+        onRefresh={handleRefresh}
+      />
+      <DraftLeavePanel
+        session={session}
+        totalCards={totalCards}
+        saveName={saveName}
+        setSaveName={setSaveName}
+        copied={copied}
+        onCopy={() => void handleCopy()}
+        onSave={handleSave}
+        onExit={onExit}
+      />
+    </div>
+  );
+}
+
+/** Assisted deck draft (`draft-a-deck`): seed cards, a commander step, then suggestion rounds. */
+export function DraftView({
+  onSave,
+  onExit,
+}: {
+  onSave: (deck: SavedDeck) => void;
+  onExit: () => void;
+}) {
+  const sessionRef = useRef<DraftSession | null>(null);
+  const [started, setStarted] = useState(false);
+
+  async function handleStart(
+    names: string[],
+    commanderName: string | null,
+    target: BracketTarget,
+  ) {
+    const session = new DraftSession({
+      engine: engineDraftEngine,
+      resolver: scryfallCardResolver,
+    });
+    await session.start(names, commanderName, target);
+    sessionRef.current = session;
+    setStarted(true);
+  }
+
+  if (!started || !sessionRef.current) {
+    return <DraftEntry onStart={handleStart} onCancel={onExit} />;
+  }
+
+  return (
+    <DraftSessionView session={sessionRef.current} onExit={onExit} onSave={onSave} />
+  );
+}

--- a/src/draft/bracket.test.ts
+++ b/src/draft/bracket.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { bracketTilt } from "./bracket";
+import type { BracketEstimate } from "../engine/draftQueries";
+
+function estimate(tier: string): BracketEstimate {
+  return {
+    tier,
+    axes: {},
+    axis_caps_at_tier: {},
+    contributing: {},
+    violations: {},
+    data_version: "test",
+  };
+}
+
+describe("bracketTilt", () => {
+  it("is 0 when there is no estimate", () => {
+    expect(bracketTilt(null, "focused")).toBe(0);
+  });
+
+  it("is 0 when the estimate is exactly at the target tier", () => {
+    expect(bracketTilt(estimate("upgraded"), "focused")).toBe(0);
+  });
+
+  it("is 0 when the estimate is below the target tier", () => {
+    expect(bracketTilt(estimate("exhibition"), "focused")).toBe(0);
+  });
+
+  it("is negative and grows with each tier past the target", () => {
+    const oneOver = bracketTilt(estimate("optimized"), "focused");
+    const twoOver = bracketTilt(estimate("cedh"), "focused");
+    expect(oneOver).toBeLessThan(0);
+    expect(twoOver).toBeLessThan(oneOver);
+  });
+
+  it("treats an unrecognized tier as at-target rather than penalizing", () => {
+    expect(bracketTilt(estimate("some-future-tier"), "focused")).toBe(0);
+  });
+
+  it("is 0 at every tier when the target is cEDH", () => {
+    expect(bracketTilt(estimate("cedh"), "cedh")).toBe(0);
+    expect(bracketTilt(estimate("optimized"), "cedh")).toBe(0);
+  });
+});

--- a/src/draft/bracket.ts
+++ b/src/draft/bracket.ts
@@ -1,0 +1,75 @@
+import type { BracketEstimate } from "../engine/draftQueries";
+
+/**
+ * The engine's own tier vocabulary, confirmed by runtime introspection
+ * (`estimate_bracket_for_deck(...).tier`) — see `deck-draft/ADR-0001`. Ordered
+ * lowest to highest power.
+ */
+export type EngineBracketTier =
+  | "exhibition"
+  | "core"
+  | "upgraded"
+  | "optimized"
+  | "cedh";
+
+const TIER_ORDER: EngineBracketTier[] = [
+  "exhibition",
+  "core",
+  "upgraded",
+  "optimized",
+  "cedh",
+];
+
+/**
+ * The user-facing bracket target set (glossary: "Exhibition, Core,
+ * Upgraded/Focused, Optimized, cEDH"). "Focused" is the label shown to the
+ * user for the engine's `upgraded` tier and is the default.
+ */
+export type BracketTarget =
+  | "exhibition"
+  | "core"
+  | "focused"
+  | "optimized"
+  | "cedh";
+
+export const BRACKET_TARGETS: BracketTarget[] = [
+  "exhibition",
+  "core",
+  "focused",
+  "optimized",
+  "cedh",
+];
+
+export const DEFAULT_BRACKET_TARGET: BracketTarget = "focused";
+
+const TARGET_TO_TIER: Record<BracketTarget, EngineBracketTier> = {
+  exhibition: "exhibition",
+  core: "core",
+  focused: "upgraded",
+  optimized: "optimized",
+  cedh: "cedh",
+};
+
+/** How much a candidate is pushed down for each tier it pushes the deck past target. */
+const PENALTY_PER_TIER_OVER = 2;
+
+/**
+ * Bracket tilt for a candidate: 0 when the deck-with-candidate is at or below
+ * the bracket target, and a penalty that grows with each tier past it. A card
+ * that would push the deck past the target is pushed down in the ranking, not
+ * hidden (`draft-a-deck`, `deck-draft/ADR-0001`).
+ */
+export function bracketTilt(
+  estimate: BracketEstimate | null,
+  target: BracketTarget,
+): number {
+  if (!estimate) return 0;
+  const targetIndex = TIER_ORDER.indexOf(TARGET_TO_TIER[target]);
+  const estimateIndex = TIER_ORDER.indexOf(estimate.tier as EngineBracketTier);
+  // An unrecognized tier (future engine vocabulary drift) is treated as "at
+  // target" rather than penalized, so ranking degrades gracefully.
+  if (estimateIndex === -1) return 0;
+  const tiersOver = estimateIndex - targetIndex;
+  if (tiersOver <= 0) return 0;
+  return -tiersOver * PENALTY_PER_TIER_OVER;
+}

--- a/src/draft/candidates.test.ts
+++ b/src/draft/candidates.test.ts
@@ -67,6 +67,7 @@ describe("suggestCandidates", () => {
         rankedInputs.push(input);
         return selected.map(({ name }) => ({ name, bracketTilt: 0 }));
       },
+      resolveCards: async () => [],
     };
     const results = await suggestCandidates(deck, profile, {
       engine,
@@ -94,6 +95,7 @@ describe("suggestCandidates", () => {
         { name: "In Identity Elf", bracketTilt: 0 },
         { name: "Bracket Heavy Elf", bracketTilt: -4 },
       ],
+      resolveCards: async () => [],
     };
     const results = await suggestCandidates(deck, profile, {
       engine,
@@ -124,6 +126,7 @@ describe("suggestCommanders", () => {
     return {
       commanderCandidates: async () => commanderPool.map(commanderData),
       rankCardCandidates: async () => [],
+      resolveCards: async () => [],
     };
   }
 
@@ -157,6 +160,7 @@ describe("suggestCommanders", () => {
     const engine: DraftEngine = {
       commanderCandidates: async () => candidates.map(commanderData),
       rankCardCandidates: async () => [],
+      resolveCards: async () => [],
     };
     const results = await suggestCommanders(baseCards, {
       engine,
@@ -188,6 +192,7 @@ describe("suggestCommanders", () => {
     const engine: DraftEngine = {
       commanderCandidates: async () => [broad, exact].map(commanderData),
       rankCardCandidates: async () => [],
+      resolveCards: async () => [],
     };
     const results = await suggestCommanders([...baseCards, blueBase], {
       engine,
@@ -214,6 +219,7 @@ describe("suggestCommanders color identity coverage", () => {
     return {
       commanderCandidates: async () => cards.map(commanderData),
       rankCardCandidates: async () => [],
+      resolveCards: async () => [],
     };
   }
 

--- a/src/draft/candidates.test.ts
+++ b/src/draft/candidates.test.ts
@@ -6,6 +6,7 @@ import type { Card } from "../lib/types";
 import type {
   BracketDeckInput,
   BracketEstimate,
+  CommanderCandidateData,
   SearchCardRow,
   SearchCardsResult,
 } from "../engine/draftQueries";
@@ -32,6 +33,16 @@ function row(overrides: Partial<SearchCardRow> = {}): SearchCardRow {
     color_identity: ["G"],
     legalities: { commander: "legal" },
     ...overrides,
+  };
+}
+
+function commanderData(candidate: Card): CommanderCandidateData {
+  return {
+    name: candidate.name,
+    manaValue: candidate.manaValue,
+    typeLine: candidate.typeLine,
+    oracleText: candidate.oracleText,
+    colorIdentity: candidate.colorIdentity,
   };
 }
 
@@ -81,7 +92,6 @@ describe("suggestCandidates", () => {
           data_version: "test",
         };
       },
-      isCommanderEligible: async () => false,
       commanderCandidates: async () => [],
     };
   }
@@ -148,39 +158,27 @@ describe("suggestCommanders", () => {
     card({ name: "Base Elf Three" }),
   ];
 
-  const rows: SearchCardRow[] = [
-    row({ name: "Eligible Elf Lord" }),
-    row({ name: "Ineligible Elf" }),
-    row({ name: "Banned Legendary Elf", legalities: { commander: "banned" } }),
-    row({ name: "Base Elf One" }), // should never be offered — it's a base card
+  const commanderPool = [
+    card({ name: "Eligible Elf Lord", typeLine: "Legendary Creature — Elf" }),
+    card({ name: "Base Elf One", typeLine: "Legendary Creature — Elf" }),
   ];
 
   function makeEngine(): DraftEngine {
     return {
-      searchCards: async (): Promise<SearchCardsResult> => ({ results: rows, total: rows.length }),
+      searchCards: async (): Promise<SearchCardsResult> => ({ results: [], total: 0 }),
       estimateBracket: async (): Promise<BracketEstimate | null> => null,
-      isCommanderEligible: async (name: string) =>
-        name === "Eligible Elf Lord" || name === "Banned Legendary Elf",
-      commanderCandidates: async () => [],
+      commanderCandidates: async () => commanderPool.map(commanderData),
     };
   }
 
-  const resolver = makeResolver([
-    ...baseCards,
-    card({ name: "Eligible Elf Lord", typeLine: "Legendary Creature — Elf" }),
-    card({ name: "Ineligible Elf" }),
-    card({ name: "Banned Legendary Elf", typeLine: "Legendary Creature — Elf" }),
-  ]);
+  const resolver = makeResolver([...baseCards, ...commanderPool]);
 
-  it("offers only commander-eligible, Commander-legal candidates", async () => {
+  it("offers candidates from the engine's legal commander pool", async () => {
     const results = await suggestCommanders(baseCards, {
       engine: makeEngine(),
       resolver,
     });
-    const names = results.map((r) => r.card.name);
-    expect(names).toContain("Eligible Elf Lord");
-    expect(names).not.toContain("Ineligible Elf");
-    expect(names).not.toContain("Banned Legendary Elf");
+    expect(results.map((r) => r.card.name)).toContain("Eligible Elf Lord");
   });
 
   it("never offers one of the base cards as a commander candidate", async () => {
@@ -191,37 +189,59 @@ describe("suggestCommanders", () => {
     expect(results.map((r) => r.card.name)).not.toContain("Base Elf One");
   });
 
-  it("fills the commander round from the full eligible pool when themed search finds fewer than three", async () => {
-    const fallbackCards = [
-      card({ name: "Fallback Elf One", typeLine: "Legendary Creature — Elf" }),
-      card({ name: "Fallback Elf Two", typeLine: "Legendary Creature — Elf" }),
+  it("ranks the full local pool and resolves only the top three cards", async () => {
+    const candidates = [
+      card({ name: "Alpha Elf", typeLine: "Legendary Creature — Elf" }),
+      card({ name: "Beta Elf", typeLine: "Legendary Creature — Elf" }),
+      card({ name: "Gamma Elf", typeLine: "Legendary Creature — Elf" }),
+      card({ name: "Delta Elf", typeLine: "Legendary Creature — Elf" }),
     ];
-    const fallbackRows = fallbackCards.map((candidate) => row({ name: candidate.name }));
+    let resolvedNames: string[] = [];
+    const cardResolver = makeResolver([...baseCards, ...candidates]);
     const engine: DraftEngine = {
-      searchCards: async (): Promise<SearchCardsResult> => ({
-        results: [row({ name: "Eligible Elf Lord" })],
-        total: 1,
-      }),
+      searchCards: async (): Promise<SearchCardsResult> => ({ results: [], total: 0 }),
       estimateBracket: async (): Promise<BracketEstimate | null> => null,
-      isCommanderEligible: async () => true,
-      commanderCandidates: async () => [
-        row({ name: "Eligible Elf Lord" }),
-        ...fallbackRows,
-      ],
+      commanderCandidates: async () => candidates.map(commanderData),
     };
     const results = await suggestCommanders(baseCards, {
       engine,
-      resolver: makeResolver([
-        ...baseCards,
-        card({ name: "Eligible Elf Lord", typeLine: "Legendary Creature — Elf" }),
-        ...fallbackCards,
-      ]),
+      resolver: {
+        resolve: async (names) => {
+          resolvedNames = names;
+          return cardResolver.resolve(names);
+        },
+      },
     });
 
-    expect(results.map((candidate) => candidate.card.name)).toEqual([
-      "Eligible Elf Lord",
-      "Fallback Elf One",
-      "Fallback Elf Two",
+    expect(results).toHaveLength(3);
+    expect(resolvedNames).toHaveLength(3);
+    expect(resolvedNames).toEqual(results.map((candidate) => candidate.card.name));
+  });
+
+  it("prefers a tighter color identity when synergy scores are equal", async () => {
+    const exact = card({
+      name: "Exact Simic Elf",
+      typeLine: "Legendary Creature — Elf",
+      colorIdentity: ["G", "U"],
+    });
+    const broad = card({
+      name: "Five Color Elf",
+      typeLine: "Legendary Creature — Elf",
+      colorIdentity: ["W", "U", "B", "R", "G"],
+    });
+    const blueBase = card({ name: "Blue Base", colorIdentity: ["U"] });
+    const engine: DraftEngine = {
+      searchCards: async () => ({ results: [], total: 0 }),
+      estimateBracket: async () => null,
+      commanderCandidates: async () => [broad, exact].map(commanderData),
+    };
+    const results = await suggestCommanders([...baseCards, blueBase], {
+      engine,
+      resolver: makeResolver([broad, exact]),
+    });
+    expect(results.map(({ card }) => card.name)).toEqual([
+      "Exact Simic Elf",
+      "Five Color Elf",
     ]);
   });
 });
@@ -236,12 +256,11 @@ describe("suggestCommanders color identity coverage", () => {
     colorIdentity: ["U"],
   });
 
-  function makeEngine(rows: SearchCardRow[]): DraftEngine {
+  function makeEngine(cards: Card[]): DraftEngine {
     return {
-      searchCards: async (): Promise<SearchCardsResult> => ({ results: rows, total: rows.length }),
+      searchCards: async (): Promise<SearchCardsResult> => ({ results: [], total: 0 }),
       estimateBracket: async (): Promise<BracketEstimate | null> => null,
-      isCommanderEligible: async () => true,
-      commanderCandidates: async () => [],
+      commanderCandidates: async () => cards.map(commanderData),
     };
   }
 
@@ -257,11 +276,10 @@ describe("suggestCommanders color identity coverage", () => {
       typeLine: "Legendary Creature — Merfolk",
       colorIdentity: ["G", "U"],
     });
-    const rows = [row({ name: offColor.name }), row({ name: covering.name })];
     const resolver = makeResolver([...baseCards, offColor, covering]);
 
     const results = await suggestCommanders(baseCards, {
-      engine: makeEngine(rows),
+      engine: makeEngine([offColor, covering]),
       resolver,
     });
     const names = results.map((r) => r.card.name);
@@ -277,11 +295,10 @@ describe("suggestCommanders color identity coverage", () => {
       colorIdentity: ["G"],
       oracleText: "Choose a Background (You can have a Background as a second commander.)",
     });
-    const rows = [row({ name: partnerCommander.name })];
     const resolver = makeResolver([...baseCards, partnerCommander]);
 
     const results = await suggestCommanders(baseCards, {
-      engine: makeEngine(rows),
+      engine: makeEngine([partnerCommander]),
       resolver,
     });
     expect(results.map((r) => r.card.name)).toContain("Green Choose-a-Background Commander");
@@ -295,11 +312,10 @@ describe("suggestCommanders color identity coverage", () => {
       colorIdentity: ["B"],
       oracleText: "Choose a Background (You can have a Background as a second commander.)",
     });
-    const rows = [row({ name: offColorPartner.name })];
     const resolver = makeResolver([...baseCards, offColorPartner]);
 
     const results = await suggestCommanders(baseCards, {
-      engine: makeEngine(rows),
+      engine: makeEngine([offColorPartner]),
       resolver,
     });
     expect(results.map((r) => r.card.name)).not.toContain(
@@ -314,11 +330,10 @@ describe("suggestCommanders color identity coverage", () => {
       typeLine: "Legendary Creature — Elf",
       colorIdentity: ["G"],
     });
-    const rows = [row({ name: plainGreenCommander.name })];
     const resolver = makeResolver([...baseCards, plainGreenCommander]);
 
     const results = await suggestCommanders(baseCards, {
-      engine: makeEngine(rows),
+      engine: makeEngine([plainGreenCommander]),
       resolver,
     });
     expect(results.map((r) => r.card.name)).not.toContain("Plain Green Commander");

--- a/src/draft/candidates.test.ts
+++ b/src/draft/candidates.test.ts
@@ -17,6 +17,7 @@ function card(overrides: Partial<Card> = {}): Card {
     typeLine: "Creature — Elf",
     oracleText: "",
     colors: ["G"],
+    colorIdentity: ["G"],
     producedMana: [],
     roles: ["other"],
     ...overrides,
@@ -186,5 +187,103 @@ describe("suggestCommanders", () => {
       resolver,
     });
     expect(results.map((r) => r.card.name)).not.toContain("Base Elf One");
+  });
+});
+
+describe("suggestCommanders color identity coverage", () => {
+  // Union of the base cards' color identities: green + blue.
+  const greenCard = card({ name: "Green Base Card", colorIdentity: ["G"] });
+  const blueCard = card({ name: "Blue Base Card", colorIdentity: ["U"] });
+  const blueBackground = card({
+    name: "Blue Background",
+    typeLine: "Legendary Enchantment — Background",
+    colorIdentity: ["U"],
+  });
+
+  function makeEngine(rows: SearchCardRow[]): DraftEngine {
+    return {
+      searchCards: async (): Promise<SearchCardsResult> => ({ results: rows, total: rows.length }),
+      estimateBracket: async (): Promise<BracketEstimate | null> => null,
+      isCommanderEligible: async () => true,
+    };
+  }
+
+  it("excludes a candidate whose color identity doesn't cover the base cards", async () => {
+    const baseCards = [greenCard, blueCard];
+    const offColor = card({
+      name: "Mono Black Legendary",
+      typeLine: "Legendary Creature — Zombie",
+      colorIdentity: ["B"],
+    });
+    const covering = card({
+      name: "Simic Legendary",
+      typeLine: "Legendary Creature — Merfolk",
+      colorIdentity: ["G", "U"],
+    });
+    const rows = [row({ name: offColor.name }), row({ name: covering.name })];
+    const resolver = makeResolver([...baseCards, offColor, covering]);
+
+    const results = await suggestCommanders(baseCards, {
+      engine: makeEngine(rows),
+      resolver,
+    });
+    const names = results.map((r) => r.card.name);
+    expect(names).toContain("Simic Legendary");
+    expect(names).not.toContain("Mono Black Legendary");
+  });
+
+  it("includes a Choose-a-Background candidate when candidate + Background union covers the base cards", async () => {
+    const baseCards = [greenCard, blueBackground];
+    const partnerCommander = card({
+      name: "Green Choose-a-Background Commander",
+      typeLine: "Legendary Creature — Human",
+      colorIdentity: ["G"],
+      oracleText: "Choose a Background (You can have a Background as a second commander.)",
+    });
+    const rows = [row({ name: partnerCommander.name })];
+    const resolver = makeResolver([...baseCards, partnerCommander]);
+
+    const results = await suggestCommanders(baseCards, {
+      engine: makeEngine(rows),
+      resolver,
+    });
+    expect(results.map((r) => r.card.name)).toContain("Green Choose-a-Background Commander");
+  });
+
+  it("excludes a Choose-a-Background candidate when even the union with the Background doesn't cover", async () => {
+    const baseCards = [greenCard, blueBackground];
+    const offColorPartner = card({
+      name: "Black Choose-a-Background Commander",
+      typeLine: "Legendary Creature — Zombie",
+      colorIdentity: ["B"],
+      oracleText: "Choose a Background (You can have a Background as a second commander.)",
+    });
+    const rows = [row({ name: offColorPartner.name })];
+    const resolver = makeResolver([...baseCards, offColorPartner]);
+
+    const results = await suggestCommanders(baseCards, {
+      engine: makeEngine(rows),
+      resolver,
+    });
+    expect(results.map((r) => r.card.name)).not.toContain(
+      "Black Choose-a-Background Commander",
+    );
+  });
+
+  it("excludes a legendary lacking Choose a Background even when a Background base card is present", async () => {
+    const baseCards = [greenCard, blueBackground];
+    const plainGreenCommander = card({
+      name: "Plain Green Commander",
+      typeLine: "Legendary Creature — Elf",
+      colorIdentity: ["G"],
+    });
+    const rows = [row({ name: plainGreenCommander.name })];
+    const resolver = makeResolver([...baseCards, plainGreenCommander]);
+
+    const results = await suggestCommanders(baseCards, {
+      engine: makeEngine(rows),
+      resolver,
+    });
+    expect(results.map((r) => r.card.name)).not.toContain("Plain Green Commander");
   });
 });

--- a/src/draft/candidates.test.ts
+++ b/src/draft/candidates.test.ts
@@ -4,11 +4,8 @@ import type { DraftEngine, CardResolver, DraftDeckNames } from "./candidates";
 import { extractThemeProfile } from "./themes";
 import type { Card } from "../lib/types";
 import type {
-  BracketDeckInput,
-  BracketEstimate,
-  CommanderCandidateData,
-  SearchCardRow,
-  SearchCardsResult,
+  DraftCandidateData,
+  RankCardCandidatesInput,
 } from "../engine/draftQueries";
 
 function card(overrides: Partial<Card> = {}): Card {
@@ -25,18 +22,7 @@ function card(overrides: Partial<Card> = {}): Card {
   };
 }
 
-function row(overrides: Partial<SearchCardRow> = {}): SearchCardRow {
-  return {
-    name: "Row",
-    oracle_id: "id",
-    mana_value: 2,
-    color_identity: ["G"],
-    legalities: { commander: "legal" },
-    ...overrides,
-  };
-}
-
-function commanderData(candidate: Card): CommanderCandidateData {
+function commanderData(candidate: Card): DraftCandidateData {
   return {
     name: candidate.name,
     manaValue: candidate.manaValue,
@@ -63,91 +49,62 @@ function makeResolver(cards: Card[]): CardResolver {
 describe("suggestCandidates", () => {
   const commander = card({ name: "Commander Elf", typeLine: "Legendary Creature — Elf" });
   const profile = extractThemeProfile([commander], []);
-
-  const rows: SearchCardRow[] = [
-    row({ name: "In Identity Elf", color_identity: ["G"] }),
-    row({ name: "Off Identity Elf", color_identity: ["R", "G"] }),
-    row({ name: "Colorless Elf Artifact", color_identity: [] }),
-    row({ name: "Banned Elf", color_identity: ["G"], legalities: { commander: "banned" } }),
-    row({ name: "In Deck Elf", color_identity: ["G"] }),
-    row({ name: "Shown Elf", color_identity: ["G"] }),
-    row({ name: "Plain Elf", color_identity: ["G"] }),
-    row({ name: "Bracket Heavy Elf", color_identity: ["G"] }),
+  const selected = [
+    card({ name: "In Identity Elf" }),
+    card({ name: "Colorless Elf Artifact", colorIdentity: [] }),
+    card({ name: "Bracket Heavy Elf" }),
   ];
-
-  function makeEngine(opts?: { bracketFor?: (names: string[]) => BracketEstimate }): DraftEngine {
-    return {
-      searchCards: async (): Promise<SearchCardsResult> => ({
-        results: rows,
-        total: rows.length,
-      }),
-      estimateBracket: async (deck: BracketDeckInput): Promise<BracketEstimate | null> => {
-        if (opts?.bracketFor) return opts.bracketFor(deck.main_deck ?? []);
-        return {
-          tier: "exhibition",
-          axes: {},
-          axis_caps_at_tier: {},
-          contributing: {},
-          violations: {},
-          data_version: "test",
-        };
-      },
-      commanderCandidates: async () => [],
-    };
-  }
-
-  const allCards = rows.map((r) => card({ name: r.name }));
-  const resolver = makeResolver(allCards);
-
+  const resolver = makeResolver(selected);
   const deck: DraftDeckNames = { commanders: ["Commander Elf"], mainboard: ["In Deck Elf"] };
 
-  it("keeps in-identity and colorless candidates, and filters out identity/legality/dedupe violations", async () => {
+  it("resolves only the three names selected by local ranking", async () => {
+    const rankedInputs: RankCardCandidatesInput[] = [];
+    let resolvedNames: string[] = [];
+    const baseResolver = makeResolver(selected);
+    const engine: DraftEngine = {
+      commanderCandidates: async () => [],
+      rankCardCandidates: async (input) => {
+        rankedInputs.push(input);
+        return selected.map(({ name }) => ({ name, bracketTilt: 0 }));
+      },
+    };
     const results = await suggestCandidates(deck, profile, {
-      engine: makeEngine(),
-      resolver,
+      engine,
+      resolver: {
+        resolve: async (names) => {
+          resolvedNames = names;
+          return baseResolver.resolve(names);
+        },
+      },
       target: "focused",
       exclude: new Set(["Shown Elf"]),
     });
-    const names = results.map((r) => r.card.name);
-
-    // Kept: within the commander's color identity, or colorless (always allowed).
-    expect(names).toContain("In Identity Elf");
-    expect(names).toContain("Colorless Elf Artifact");
-
-    // Filtered: outside color identity, not Commander-legal, already in the
-    // deck, or already shown this round.
-    expect(names).not.toContain("Off Identity Elf");
-    expect(names).not.toContain("Banned Elf");
-    expect(names).not.toContain("In Deck Elf");
-    expect(names).not.toContain("Shown Elf");
+    expect(results).toHaveLength(3);
+    expect(resolvedNames).toEqual(selected.map(({ name }) => name));
+    expect(rankedInputs[0].exclude).toEqual(
+      expect.arrayContaining(["commander elf", "in deck elf", "shown elf"]),
+    );
+    expect(rankedInputs[0].profile.tokenWeights).toEqual([...profile.tokenWeights]);
   });
 
-  it("sinks a candidate that would push the deck past the bracket target below an equal-fit one at target", async () => {
-    const engine = makeEngine({
-      bracketFor: (names) => {
-        const overTarget = names.includes("Bracket Heavy Elf");
-        return {
-          tier: overTarget ? "cedh" : "exhibition",
-          axes: {},
-          axis_caps_at_tier: {},
-          contributing: {},
-          violations: {},
-          data_version: "test",
-        };
-      },
-    });
+  it("includes the locally computed bracket tilt in the displayed total", async () => {
+    const engine: DraftEngine = {
+      commanderCandidates: async () => [],
+      rankCardCandidates: async () => [
+        { name: "In Identity Elf", bracketTilt: 0 },
+        { name: "Bracket Heavy Elf", bracketTilt: -4 },
+      ],
+    };
     const results = await suggestCandidates(deck, profile, {
       engine,
       resolver,
       target: "focused",
-      exclude: new Set(["Shown Elf"]),
     });
-    const plain = results.find((r) => r.card.name === "Plain Elf")!;
+    const plain = results.find((r) => r.card.name === "In Identity Elf")!;
     const heavy = results.find((r) => r.card.name === "Bracket Heavy Elf")!;
-    expect(plain.score.total).toBe(heavy.score.total); // equal theme/curve/role fit
-    expect(heavy.bracketTilt).toBeLessThan(0);
-    expect(heavy.total).toBeLessThan(plain.total);
-    expect(results.indexOf(plain)).toBeLessThan(results.indexOf(heavy));
+    expect(heavy.bracketTilt).toBe(-4);
+    expect(heavy.total).toBe(heavy.score.total - 4);
+    expect(plain.total).toBe(plain.score.total);
   });
 });
 
@@ -165,9 +122,8 @@ describe("suggestCommanders", () => {
 
   function makeEngine(): DraftEngine {
     return {
-      searchCards: async (): Promise<SearchCardsResult> => ({ results: [], total: 0 }),
-      estimateBracket: async (): Promise<BracketEstimate | null> => null,
       commanderCandidates: async () => commanderPool.map(commanderData),
+      rankCardCandidates: async () => [],
     };
   }
 
@@ -199,9 +155,8 @@ describe("suggestCommanders", () => {
     let resolvedNames: string[] = [];
     const cardResolver = makeResolver([...baseCards, ...candidates]);
     const engine: DraftEngine = {
-      searchCards: async (): Promise<SearchCardsResult> => ({ results: [], total: 0 }),
-      estimateBracket: async (): Promise<BracketEstimate | null> => null,
       commanderCandidates: async () => candidates.map(commanderData),
+      rankCardCandidates: async () => [],
     };
     const results = await suggestCommanders(baseCards, {
       engine,
@@ -231,9 +186,8 @@ describe("suggestCommanders", () => {
     });
     const blueBase = card({ name: "Blue Base", colorIdentity: ["U"] });
     const engine: DraftEngine = {
-      searchCards: async () => ({ results: [], total: 0 }),
-      estimateBracket: async () => null,
       commanderCandidates: async () => [broad, exact].map(commanderData),
+      rankCardCandidates: async () => [],
     };
     const results = await suggestCommanders([...baseCards, blueBase], {
       engine,
@@ -258,9 +212,8 @@ describe("suggestCommanders color identity coverage", () => {
 
   function makeEngine(cards: Card[]): DraftEngine {
     return {
-      searchCards: async (): Promise<SearchCardsResult> => ({ results: [], total: 0 }),
-      estimateBracket: async (): Promise<BracketEstimate | null> => null,
       commanderCandidates: async () => cards.map(commanderData),
+      rankCardCandidates: async () => [],
     };
   }
 

--- a/src/draft/candidates.test.ts
+++ b/src/draft/candidates.test.ts
@@ -82,6 +82,7 @@ describe("suggestCandidates", () => {
         };
       },
       isCommanderEligible: async () => false,
+      commanderCandidates: async () => [],
     };
   }
 
@@ -160,6 +161,7 @@ describe("suggestCommanders", () => {
       estimateBracket: async (): Promise<BracketEstimate | null> => null,
       isCommanderEligible: async (name: string) =>
         name === "Eligible Elf Lord" || name === "Banned Legendary Elf",
+      commanderCandidates: async () => [],
     };
   }
 
@@ -188,6 +190,40 @@ describe("suggestCommanders", () => {
     });
     expect(results.map((r) => r.card.name)).not.toContain("Base Elf One");
   });
+
+  it("fills the commander round from the full eligible pool when themed search finds fewer than three", async () => {
+    const fallbackCards = [
+      card({ name: "Fallback Elf One", typeLine: "Legendary Creature — Elf" }),
+      card({ name: "Fallback Elf Two", typeLine: "Legendary Creature — Elf" }),
+    ];
+    const fallbackRows = fallbackCards.map((candidate) => row({ name: candidate.name }));
+    const engine: DraftEngine = {
+      searchCards: async (): Promise<SearchCardsResult> => ({
+        results: [row({ name: "Eligible Elf Lord" })],
+        total: 1,
+      }),
+      estimateBracket: async (): Promise<BracketEstimate | null> => null,
+      isCommanderEligible: async () => true,
+      commanderCandidates: async () => [
+        row({ name: "Eligible Elf Lord" }),
+        ...fallbackRows,
+      ],
+    };
+    const results = await suggestCommanders(baseCards, {
+      engine,
+      resolver: makeResolver([
+        ...baseCards,
+        card({ name: "Eligible Elf Lord", typeLine: "Legendary Creature — Elf" }),
+        ...fallbackCards,
+      ]),
+    });
+
+    expect(results.map((candidate) => candidate.card.name)).toEqual([
+      "Eligible Elf Lord",
+      "Fallback Elf One",
+      "Fallback Elf Two",
+    ]);
+  });
 });
 
 describe("suggestCommanders color identity coverage", () => {
@@ -205,6 +241,7 @@ describe("suggestCommanders color identity coverage", () => {
       searchCards: async (): Promise<SearchCardsResult> => ({ results: rows, total: rows.length }),
       estimateBracket: async (): Promise<BracketEstimate | null> => null,
       isCommanderEligible: async () => true,
+      commanderCandidates: async () => [],
     };
   }
 

--- a/src/draft/candidates.test.ts
+++ b/src/draft/candidates.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from "vitest";
+import { suggestCandidates, suggestCommanders } from "./candidates";
+import type { DraftEngine, CardResolver, DraftDeckNames } from "./candidates";
+import { extractThemeProfile } from "./themes";
+import type { Card } from "../lib/types";
+import type {
+  BracketDeckInput,
+  BracketEstimate,
+  SearchCardRow,
+  SearchCardsResult,
+} from "../engine/draftQueries";
+
+function card(overrides: Partial<Card> = {}): Card {
+  return {
+    name: "Test Card",
+    manaValue: 2,
+    typeLine: "Creature — Elf",
+    oracleText: "",
+    colors: ["G"],
+    producedMana: [],
+    roles: ["other"],
+    ...overrides,
+  };
+}
+
+function row(overrides: Partial<SearchCardRow> = {}): SearchCardRow {
+  return {
+    name: "Row",
+    oracle_id: "id",
+    mana_value: 2,
+    color_identity: ["G"],
+    legalities: { commander: "legal" },
+    ...overrides,
+  };
+}
+
+function makeResolver(cards: Card[]): CardResolver {
+  const byName = new Map(cards.map((c) => [c.name.toLowerCase(), c]));
+  return {
+    resolve: async (names) => {
+      const out = new Map<string, Card>();
+      for (const name of names) {
+        const found = byName.get(name.toLowerCase());
+        if (found) out.set(name.toLowerCase(), found);
+      }
+      return out;
+    },
+  };
+}
+
+describe("suggestCandidates", () => {
+  const commander = card({ name: "Commander Elf", typeLine: "Legendary Creature — Elf" });
+  const profile = extractThemeProfile([commander], []);
+
+  const rows: SearchCardRow[] = [
+    row({ name: "In Identity Elf", color_identity: ["G"] }),
+    row({ name: "Off Identity Elf", color_identity: ["R", "G"] }),
+    row({ name: "Colorless Elf Artifact", color_identity: [] }),
+    row({ name: "Banned Elf", color_identity: ["G"], legalities: { commander: "banned" } }),
+    row({ name: "In Deck Elf", color_identity: ["G"] }),
+    row({ name: "Shown Elf", color_identity: ["G"] }),
+    row({ name: "Plain Elf", color_identity: ["G"] }),
+    row({ name: "Bracket Heavy Elf", color_identity: ["G"] }),
+  ];
+
+  function makeEngine(opts?: { bracketFor?: (names: string[]) => BracketEstimate }): DraftEngine {
+    return {
+      searchCards: async (): Promise<SearchCardsResult> => ({
+        results: rows,
+        total: rows.length,
+      }),
+      estimateBracket: async (deck: BracketDeckInput): Promise<BracketEstimate | null> => {
+        if (opts?.bracketFor) return opts.bracketFor(deck.main_deck ?? []);
+        return {
+          tier: "exhibition",
+          axes: {},
+          axis_caps_at_tier: {},
+          contributing: {},
+          violations: {},
+          data_version: "test",
+        };
+      },
+      isCommanderEligible: async () => false,
+    };
+  }
+
+  const allCards = rows.map((r) => card({ name: r.name }));
+  const resolver = makeResolver(allCards);
+
+  const deck: DraftDeckNames = { commanders: ["Commander Elf"], mainboard: ["In Deck Elf"] };
+
+  it("keeps in-identity and colorless candidates, and filters out identity/legality/dedupe violations", async () => {
+    const results = await suggestCandidates(deck, profile, {
+      engine: makeEngine(),
+      resolver,
+      target: "focused",
+      exclude: new Set(["Shown Elf"]),
+    });
+    const names = results.map((r) => r.card.name);
+
+    // Kept: within the commander's color identity, or colorless (always allowed).
+    expect(names).toContain("In Identity Elf");
+    expect(names).toContain("Colorless Elf Artifact");
+
+    // Filtered: outside color identity, not Commander-legal, already in the
+    // deck, or already shown this round.
+    expect(names).not.toContain("Off Identity Elf");
+    expect(names).not.toContain("Banned Elf");
+    expect(names).not.toContain("In Deck Elf");
+    expect(names).not.toContain("Shown Elf");
+  });
+
+  it("sinks a candidate that would push the deck past the bracket target below an equal-fit one at target", async () => {
+    const engine = makeEngine({
+      bracketFor: (names) => {
+        const overTarget = names.includes("Bracket Heavy Elf");
+        return {
+          tier: overTarget ? "cedh" : "exhibition",
+          axes: {},
+          axis_caps_at_tier: {},
+          contributing: {},
+          violations: {},
+          data_version: "test",
+        };
+      },
+    });
+    const results = await suggestCandidates(deck, profile, {
+      engine,
+      resolver,
+      target: "focused",
+      exclude: new Set(["Shown Elf"]),
+    });
+    const plain = results.find((r) => r.card.name === "Plain Elf")!;
+    const heavy = results.find((r) => r.card.name === "Bracket Heavy Elf")!;
+    expect(plain.score.total).toBe(heavy.score.total); // equal theme/curve/role fit
+    expect(heavy.bracketTilt).toBeLessThan(0);
+    expect(heavy.total).toBeLessThan(plain.total);
+    expect(results.indexOf(plain)).toBeLessThan(results.indexOf(heavy));
+  });
+});
+
+describe("suggestCommanders", () => {
+  const baseCards = [
+    card({ name: "Base Elf One" }),
+    card({ name: "Base Elf Two" }),
+    card({ name: "Base Elf Three" }),
+  ];
+
+  const rows: SearchCardRow[] = [
+    row({ name: "Eligible Elf Lord" }),
+    row({ name: "Ineligible Elf" }),
+    row({ name: "Banned Legendary Elf", legalities: { commander: "banned" } }),
+    row({ name: "Base Elf One" }), // should never be offered — it's a base card
+  ];
+
+  function makeEngine(): DraftEngine {
+    return {
+      searchCards: async (): Promise<SearchCardsResult> => ({ results: rows, total: rows.length }),
+      estimateBracket: async (): Promise<BracketEstimate | null> => null,
+      isCommanderEligible: async (name: string) =>
+        name === "Eligible Elf Lord" || name === "Banned Legendary Elf",
+    };
+  }
+
+  const resolver = makeResolver([
+    ...baseCards,
+    card({ name: "Eligible Elf Lord", typeLine: "Legendary Creature — Elf" }),
+    card({ name: "Ineligible Elf" }),
+    card({ name: "Banned Legendary Elf", typeLine: "Legendary Creature — Elf" }),
+  ]);
+
+  it("offers only commander-eligible, Commander-legal candidates", async () => {
+    const results = await suggestCommanders(baseCards, {
+      engine: makeEngine(),
+      resolver,
+    });
+    const names = results.map((r) => r.card.name);
+    expect(names).toContain("Eligible Elf Lord");
+    expect(names).not.toContain("Ineligible Elf");
+    expect(names).not.toContain("Banned Legendary Elf");
+  });
+
+  it("never offers one of the base cards as a commander candidate", async () => {
+    const results = await suggestCommanders(baseCards, {
+      engine: makeEngine(),
+      resolver,
+    });
+    expect(results.map((r) => r.card.name)).not.toContain("Base Elf One");
+  });
+});

--- a/src/draft/candidates.ts
+++ b/src/draft/candidates.ts
@@ -1,25 +1,20 @@
 import type { Card } from "../lib/types";
 import type {
-  BracketDeckInput,
-  BracketEstimate,
-  CommanderCandidateData,
-  SearchCardRow,
-  SearchCardsQuery,
-  SearchCardsResult,
+  DraftCandidateData,
+  RankCardCandidatesInput,
+  RankedCardName,
 } from "../engine/draftQueries";
 import { getEngine } from "../engine/EngineClient";
 import { fetchCardsCached } from "../lib/scryfallCache";
-import { frontFace } from "../lib/cardName";
-import { classifyRoles } from "../lib/roles";
 import { extractThemeProfile, type ThemeProfile } from "./themes";
 import { scoreCandidate, type CandidateScore } from "./scoring";
-import { bracketTilt, type BracketTarget } from "./bracket";
+import type { BracketTarget } from "./bracket";
+import { draftCandidateCard } from "./localCandidates";
 
 /** The engine calls the draft pipeline needs — narrow enough to fake in tests. */
 export interface DraftEngine {
-  searchCards(query: SearchCardsQuery): Promise<SearchCardsResult>;
-  estimateBracket(deck: BracketDeckInput): Promise<BracketEstimate | null>;
-  commanderCandidates(): Promise<CommanderCandidateData[]>;
+  commanderCandidates(): Promise<DraftCandidateData[]>;
+  rankCardCandidates(input: RankCardCandidatesInput): Promise<RankedCardName[]>;
 }
 
 /** Card-name resolution the draft pipeline needs — narrow enough to fake in tests. */
@@ -29,9 +24,8 @@ export interface CardResolver {
 
 /** Real `DraftEngine`, wrapping the shared engine worker client. */
 export const engineDraftEngine: DraftEngine = {
-  searchCards: (query) => getEngine().searchCards(query),
-  estimateBracket: (deck) => getEngine().estimateBracket(deck),
   commanderCandidates: () => getEngine().commanderCandidates(),
+  rankCardCandidates: (input) => getEngine().rankCardCandidates(input),
 };
 
 /** Real `CardResolver`, wrapping the Scryfall localStorage cache. */
@@ -52,46 +46,12 @@ export interface DraftDeckNames {
   mainboard: string[];
 }
 
-const TOP_TOKEN_COUNT = 8;
-const SEARCH_LIMIT_PER_TOKEN = 40;
-const PRE_RANK_LIMIT = 40;
-const BRACKET_SHORTLIST_SIZE = 12;
 const COMMANDER_ROUND_SIZE = 3;
 const EXTRA_COMMANDER_COLOR_PENALTY = 2;
-
-/** Per-session cache of `search_cards_js` rows by token — the card database is static. */
-export type TokenSearchCache = Map<string, SearchCardRow[]>;
-
-export function createTokenSearchCache(): TokenSearchCache {
-  return new Map();
-}
-
-function topTokens(tokenWeights: Map<string, number>, count: number): string[] {
-  return [...tokenWeights.entries()]
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, count)
-    .map(([token]) => token);
-}
-
-async function searchToken(
-  engine: DraftEngine,
-  cache: TokenSearchCache,
-  token: string,
-): Promise<SearchCardRow[]> {
-  const cached = cache.get(token);
-  if (cached) return cached;
-  const result = await engine.searchCards({ text: token, limit: SEARCH_LIMIT_PER_TOKEN });
-  cache.set(token, result.results);
-  return result.results;
-}
 
 /** Every letter of `identity` is in `allowed`; colorless (`[]`) always passes. */
 function isWithinColorIdentity(identity: string[], allowed: string[]): boolean {
   return identity.every((color) => allowed.includes(color));
-}
-
-function isCommanderLegal(row: SearchCardRow): boolean {
-  return row.legalities?.commander === "legal";
 }
 
 /** A legendary Background (e.g. "Legendary Enchantment — Background"). */
@@ -110,92 +70,12 @@ export function singleBackgroundAmong(cards: Card[]): Card | null {
   return backgrounds.length === 1 ? backgrounds[0] : null;
 }
 
-interface CandidatePool {
-  /** Row + summed weight of the tokens whose queries surfaced it, by lowercase name. */
-  rows: Map<string, { row: SearchCardRow; weight: number }>;
-}
-
-async function collectCandidateRows(
-  engine: DraftEngine,
-  cache: TokenSearchCache,
-  tokens: string[],
-  tokenWeights: Map<string, number>,
-  isAllowed: (row: SearchCardRow) => boolean,
-): Promise<CandidatePool> {
-  const rows = new Map<string, { row: SearchCardRow; weight: number }>();
-  for (const token of tokens) {
-    const weight = tokenWeights.get(token) ?? 0;
-    const results = await searchToken(engine, cache, token);
-    for (const row of results) {
-      if (!isAllowed(row)) continue;
-      const key = row.name.toLowerCase();
-      const existing = rows.get(key);
-      if (existing) existing.weight += weight;
-      else rows.set(key, { row, weight });
-    }
-  }
-  return { rows };
-}
-
-function preRankSlice(
-  pool: CandidatePool,
-  excluded: Set<string>,
-  limit: number,
-): SearchCardRow[] {
-  return [...pool.rows.values()]
-    .filter(({ row }) => !excluded.has(row.name.toLowerCase()))
-    .sort((a, b) => b.weight - a.weight)
-    .slice(0, limit)
-    .map(({ row }) => row);
-}
-
-async function enrichAndScore(
-  resolver: CardResolver,
-  rows: SearchCardRow[],
-  profile: ThemeProfile,
-): Promise<Array<{ card: Card; score: CandidateScore }>> {
-  const resolved = await resolver.resolve(rows.map((row) => row.name));
-  const out: Array<{ card: Card; score: CandidateScore }> = [];
-  for (const row of rows) {
-    const card = resolved.get(row.name.toLowerCase());
-    if (!card) continue;
-    out.push({ card, score: scoreCandidate(card, profile) });
-  }
-  return out;
-}
-
-async function withBracketTilt(
-  engine: DraftEngine,
-  deck: DraftDeckNames,
-  target: BracketTarget,
-  scored: Array<{ card: Card; score: CandidateScore }>,
-): Promise<RankedCandidate[]> {
-  const byTheme = [...scored].sort((a, b) => b.score.total - a.score.total);
-  const shortlist = byTheme.slice(0, BRACKET_SHORTLIST_SIZE);
-  const rest = byTheme.slice(BRACKET_SHORTLIST_SIZE);
-
-  const ranked: RankedCandidate[] = [];
-  for (const { card, score } of shortlist) {
-    const estimate = await engine.estimateBracket({
-      commander: deck.commanders.map(frontFace),
-      main_deck: [...deck.mainboard, card.name].map(frontFace),
-    });
-    const tilt = bracketTilt(estimate, target);
-    ranked.push({ card, score, bracketTilt: tilt, total: score.total + tilt });
-  }
-  for (const { card, score } of rest) {
-    ranked.push({ card, score, bracketTilt: 0, total: score.total });
-  }
-  return ranked.sort((a, b) => b.total - a.total);
-}
-
 export interface SuggestCandidatesOptions {
   engine: DraftEngine;
   resolver: CardResolver;
   target: BracketTarget;
   /** Names to leave out beyond the deck's own cards (e.g. shown-this-round), lowercase or not. */
   exclude?: Set<string>;
-  tokenCache?: TokenSearchCache;
 }
 
 /**
@@ -210,26 +90,28 @@ export async function suggestCandidates(
   opts: SuggestCandidatesOptions,
 ): Promise<RankedCandidate[]> {
   const { engine, resolver, target } = opts;
-  const cache = opts.tokenCache ?? createTokenSearchCache();
   const excluded = new Set(
     [...deck.commanders, ...deck.mainboard, ...(opts.exclude ?? [])].map((n) =>
       n.toLowerCase(),
     ),
   );
-
-  const tokens = topTokens(profile.tokenWeights, TOP_TOKEN_COUNT);
-  const pool = await collectCandidateRows(
-    engine,
-    cache,
-    tokens,
-    profile.tokenWeights,
-    (row) =>
-      isWithinColorIdentity(row.color_identity, profile.colorIdentity) &&
-      isCommanderLegal(row),
-  );
-  const slice = preRankSlice(pool, excluded, PRE_RANK_LIMIT);
-  const scored = await enrichAndScore(resolver, slice, profile);
-  return withBracketTilt(engine, deck, target, scored);
+  const ranked = await engine.rankCardCandidates({
+    commanders: deck.commanders,
+    mainboard: deck.mainboard,
+    profile: {
+      ...profile,
+      tokenWeights: [...profile.tokenWeights],
+    },
+    target,
+    exclude: [...excluded],
+  });
+  const resolved = await resolver.resolve(ranked.map(({ name }) => name));
+  return ranked.flatMap(({ name, bracketTilt }) => {
+    const card = resolved.get(name.toLowerCase());
+    if (!card) return [];
+    const score = scoreCandidate(card, profile);
+    return [{ card, score, bracketTilt, total: score.total + bracketTilt }];
+  });
 }
 
 export interface SuggestCommandersOptions {
@@ -275,7 +157,7 @@ export async function suggestCommanders(
   };
 
   const ranked = (await engine.commanderCandidates())
-    .map(commanderCandidateCard)
+    .map(draftCandidateCard)
     .filter(
       (card) => !excluded.has(card.name.toLowerCase()) && coversBaseCards(card),
     )
@@ -303,22 +185,6 @@ export async function suggestCommanders(
     const card = resolved.get(candidate.card.name.toLowerCase());
     return card ? [{ ...candidate, card }] : [];
   });
-}
-
-function commanderCandidateCard(candidate: CommanderCandidateData): Card {
-  const input = {
-    typeLine: candidate.typeLine,
-    oracleText: candidate.oracleText,
-    manaValue: candidate.manaValue,
-    producedMana: [],
-  };
-  return {
-    name: candidate.name,
-    ...input,
-    colors: [],
-    colorIdentity: candidate.colorIdentity,
-    roles: classifyRoles(input),
-  };
 }
 
 function profileFromBaseCards(baseCards: Card[]): ThemeProfile {

--- a/src/draft/candidates.ts
+++ b/src/draft/candidates.ts
@@ -15,6 +15,7 @@ import { draftCandidateCard } from "./localCandidates";
 export interface DraftEngine {
   commanderCandidates(): Promise<DraftCandidateData[]>;
   rankCardCandidates(input: RankCardCandidatesInput): Promise<RankedCardName[]>;
+  resolveCards(names: string[]): Promise<DraftCandidateData[]>;
 }
 
 /** Card-name resolution the draft pipeline needs — narrow enough to fake in tests. */
@@ -26,6 +27,7 @@ export interface CardResolver {
 export const engineDraftEngine: DraftEngine = {
   commanderCandidates: () => getEngine().commanderCandidates(),
   rankCardCandidates: (input) => getEngine().rankCardCandidates(input),
+  resolveCards: (names) => getEngine().resolveCards(names),
 };
 
 /** Real `CardResolver`, wrapping the Scryfall localStorage cache. */

--- a/src/draft/candidates.ts
+++ b/src/draft/candidates.ts
@@ -2,6 +2,7 @@ import type { Card } from "../lib/types";
 import type {
   BracketDeckInput,
   BracketEstimate,
+  CommanderCandidateData,
   SearchCardRow,
   SearchCardsQuery,
   SearchCardsResult,
@@ -9,6 +10,7 @@ import type {
 import { getEngine } from "../engine/EngineClient";
 import { fetchCardsCached } from "../lib/scryfallCache";
 import { frontFace } from "../lib/cardName";
+import { classifyRoles } from "../lib/roles";
 import { extractThemeProfile, type ThemeProfile } from "./themes";
 import { scoreCandidate, type CandidateScore } from "./scoring";
 import { bracketTilt, type BracketTarget } from "./bracket";
@@ -17,8 +19,7 @@ import { bracketTilt, type BracketTarget } from "./bracket";
 export interface DraftEngine {
   searchCards(query: SearchCardsQuery): Promise<SearchCardsResult>;
   estimateBracket(deck: BracketDeckInput): Promise<BracketEstimate | null>;
-  isCommanderEligible(name: string): Promise<boolean>;
-  commanderCandidates(): Promise<SearchCardRow[]>;
+  commanderCandidates(): Promise<CommanderCandidateData[]>;
 }
 
 /** Card-name resolution the draft pipeline needs — narrow enough to fake in tests. */
@@ -30,7 +31,6 @@ export interface CardResolver {
 export const engineDraftEngine: DraftEngine = {
   searchCards: (query) => getEngine().searchCards(query),
   estimateBracket: (deck) => getEngine().estimateBracket(deck),
-  isCommanderEligible: (name) => getEngine().isCommanderEligible(name),
   commanderCandidates: () => getEngine().commanderCandidates(),
 };
 
@@ -57,6 +57,7 @@ const SEARCH_LIMIT_PER_TOKEN = 40;
 const PRE_RANK_LIMIT = 40;
 const BRACKET_SHORTLIST_SIZE = 12;
 const COMMANDER_ROUND_SIZE = 3;
+const EXTRA_COMMANDER_COLOR_PENALTY = 2;
 
 /** Per-session cache of `search_cards_js` rows by token — the card database is static. */
 export type TokenSearchCache = Map<string, SearchCardRow[]>;
@@ -235,7 +236,6 @@ export interface SuggestCommandersOptions {
   engine: DraftEngine;
   resolver: CardResolver;
   exclude?: Set<string>;
-  tokenCache?: TokenSearchCache;
 }
 
 /**
@@ -253,7 +253,6 @@ export async function suggestCommanders(
   opts: SuggestCommandersOptions,
 ): Promise<RankedCandidate[]> {
   const { engine, resolver } = opts;
-  const cache = opts.tokenCache ?? createTokenSearchCache();
   const excluded = new Set(
     [...baseCards.map((c) => c.name), ...(opts.exclude ?? [])].map((n) =>
       n.toLowerCase(),
@@ -261,21 +260,6 @@ export async function suggestCommanders(
   );
 
   const profile = profileFromBaseCards(baseCards);
-  const tokens = topTokens(profile.tokenWeights, TOP_TOKEN_COUNT);
-  const pool = await collectCandidateRows(
-    engine,
-    cache,
-    tokens,
-    profile.tokenWeights,
-    isCommanderLegal,
-  );
-  const slice = preRankSlice(pool, excluded, PRE_RANK_LIMIT);
-
-  const eligible: SearchCardRow[] = [];
-  for (const row of slice) {
-    if (await engine.isCommanderEligible(row.name)) eligible.push(row);
-  }
-
   const requiredIdentity = [...new Set(baseCards.flatMap((c) => c.colorIdentity))];
   const background = singleBackgroundAmong(baseCards);
   const coversBaseCards = (card: Card) => {
@@ -290,29 +274,51 @@ export async function suggestCommanders(
     );
   };
 
-  const scored = await enrichAndScore(resolver, eligible, profile);
-  const covering = scored.filter(({ card }) => coversBaseCards(card));
+  const ranked = (await engine.commanderCandidates())
+    .map(commanderCandidateCard)
+    .filter(
+      (card) => !excluded.has(card.name.toLowerCase()) && coversBaseCards(card),
+    )
+    .map((card) => {
+      const score = scoreCandidate(card, profile);
+      const identity =
+        background !== null && hasChooseABackground(card)
+          ? [...new Set([...card.colorIdentity, ...background.colorIdentity])]
+          : card.colorIdentity;
+      const extraColors = identity.filter(
+        (color) => !requiredIdentity.includes(color),
+      ).length;
+      return {
+        card,
+        score,
+        bracketTilt: 0,
+        total: score.total - extraColors * EXTRA_COMMANDER_COLOR_PENALTY,
+      };
+    })
+    .sort((a, b) => b.total - a.total)
+    .slice(0, COMMANDER_ROUND_SIZE);
 
-  if (covering.length < COMMANDER_ROUND_SIZE) {
-    const themedNames = new Set(covering.map(({ card }) => card.name.toLowerCase()));
-    const fallbackRows = (await engine.commanderCandidates()).filter(
-      (row) =>
-        !excluded.has(row.name.toLowerCase()) &&
-        !themedNames.has(row.name.toLowerCase()) &&
-        (isWithinColorIdentity(requiredIdentity, row.color_identity) ||
-          (background !== null &&
-            isWithinColorIdentity(requiredIdentity, [
-              ...row.color_identity,
-              ...background.colorIdentity,
-            ]))),
-    );
-    const fallback = await enrichAndScore(resolver, fallbackRows, profile);
-    covering.push(...fallback.filter(({ card }) => coversBaseCards(card)));
-  }
+  const resolved = await resolver.resolve(ranked.map(({ card }) => card.name));
+  return ranked.flatMap((candidate) => {
+    const card = resolved.get(candidate.card.name.toLowerCase());
+    return card ? [{ ...candidate, card }] : [];
+  });
+}
 
-  return covering
-    .map(({ card, score }) => ({ card, score, bracketTilt: 0, total: score.total }))
-    .sort((a, b) => b.total - a.total);
+function commanderCandidateCard(candidate: CommanderCandidateData): Card {
+  const input = {
+    typeLine: candidate.typeLine,
+    oracleText: candidate.oracleText,
+    manaValue: candidate.manaValue,
+    producedMana: [],
+  };
+  return {
+    name: candidate.name,
+    ...input,
+    colors: [],
+    colorIdentity: candidate.colorIdentity,
+    roles: classifyRoles(input),
+  };
 }
 
 function profileFromBaseCards(baseCards: Card[]): ThemeProfile {

--- a/src/draft/candidates.ts
+++ b/src/draft/candidates.ts
@@ -1,0 +1,263 @@
+import type { Card } from "../lib/types";
+import type {
+  BracketDeckInput,
+  BracketEstimate,
+  SearchCardRow,
+  SearchCardsQuery,
+  SearchCardsResult,
+} from "../engine/draftQueries";
+import { getEngine } from "../engine/EngineClient";
+import { fetchCardsCached } from "../lib/scryfallCache";
+import { frontFace } from "../lib/cardName";
+import { extractThemeProfile, type ThemeProfile } from "./themes";
+import { scoreCandidate, type CandidateScore } from "./scoring";
+import { bracketTilt, type BracketTarget } from "./bracket";
+
+/** The engine calls the draft pipeline needs — narrow enough to fake in tests. */
+export interface DraftEngine {
+  searchCards(query: SearchCardsQuery): Promise<SearchCardsResult>;
+  estimateBracket(deck: BracketDeckInput): Promise<BracketEstimate | null>;
+  isCommanderEligible(name: string): Promise<boolean>;
+}
+
+/** Card-name resolution the draft pipeline needs — narrow enough to fake in tests. */
+export interface CardResolver {
+  resolve(names: string[]): Promise<Map<string, Card>>;
+}
+
+/** Real `DraftEngine`, wrapping the shared engine worker client. */
+export const engineDraftEngine: DraftEngine = {
+  searchCards: (query) => getEngine().searchCards(query),
+  estimateBracket: (deck) => getEngine().estimateBracket(deck),
+  isCommanderEligible: (name) => getEngine().isCommanderEligible(name),
+};
+
+/** Real `CardResolver`, wrapping the Scryfall localStorage cache. */
+export const scryfallCardResolver: CardResolver = {
+  resolve: async (names) => (await fetchCardsCached(names)).cards,
+};
+
+export interface RankedCandidate {
+  card: Card;
+  score: CandidateScore;
+  bracketTilt: number;
+  total: number;
+}
+
+/** The deck-so-far's card names, for exclusion and bracket-estimate calls. */
+export interface DraftDeckNames {
+  commanders: string[];
+  mainboard: string[];
+}
+
+const TOP_TOKEN_COUNT = 8;
+const SEARCH_LIMIT_PER_TOKEN = 40;
+const PRE_RANK_LIMIT = 40;
+const BRACKET_SHORTLIST_SIZE = 12;
+
+/** Per-session cache of `search_cards_js` rows by token — the card database is static. */
+export type TokenSearchCache = Map<string, SearchCardRow[]>;
+
+export function createTokenSearchCache(): TokenSearchCache {
+  return new Map();
+}
+
+function topTokens(tokenWeights: Map<string, number>, count: number): string[] {
+  return [...tokenWeights.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, count)
+    .map(([token]) => token);
+}
+
+async function searchToken(
+  engine: DraftEngine,
+  cache: TokenSearchCache,
+  token: string,
+): Promise<SearchCardRow[]> {
+  const cached = cache.get(token);
+  if (cached) return cached;
+  const result = await engine.searchCards({ text: token, limit: SEARCH_LIMIT_PER_TOKEN });
+  cache.set(token, result.results);
+  return result.results;
+}
+
+/** Every letter of `identity` is in `allowed`; colorless (`[]`) always passes. */
+function isWithinColorIdentity(identity: string[], allowed: string[]): boolean {
+  return identity.every((color) => allowed.includes(color));
+}
+
+function isCommanderLegal(row: SearchCardRow): boolean {
+  return row.legalities?.commander === "legal";
+}
+
+interface CandidatePool {
+  /** Row + summed weight of the tokens whose queries surfaced it, by lowercase name. */
+  rows: Map<string, { row: SearchCardRow; weight: number }>;
+}
+
+async function collectCandidateRows(
+  engine: DraftEngine,
+  cache: TokenSearchCache,
+  tokens: string[],
+  tokenWeights: Map<string, number>,
+  isAllowed: (row: SearchCardRow) => boolean,
+): Promise<CandidatePool> {
+  const rows = new Map<string, { row: SearchCardRow; weight: number }>();
+  for (const token of tokens) {
+    const weight = tokenWeights.get(token) ?? 0;
+    const results = await searchToken(engine, cache, token);
+    for (const row of results) {
+      if (!isAllowed(row)) continue;
+      const key = row.name.toLowerCase();
+      const existing = rows.get(key);
+      if (existing) existing.weight += weight;
+      else rows.set(key, { row, weight });
+    }
+  }
+  return { rows };
+}
+
+function preRankSlice(
+  pool: CandidatePool,
+  excluded: Set<string>,
+  limit: number,
+): SearchCardRow[] {
+  return [...pool.rows.values()]
+    .filter(({ row }) => !excluded.has(row.name.toLowerCase()))
+    .sort((a, b) => b.weight - a.weight)
+    .slice(0, limit)
+    .map(({ row }) => row);
+}
+
+async function enrichAndScore(
+  resolver: CardResolver,
+  rows: SearchCardRow[],
+  profile: ThemeProfile,
+): Promise<Array<{ card: Card; score: CandidateScore }>> {
+  const resolved = await resolver.resolve(rows.map((row) => row.name));
+  const out: Array<{ card: Card; score: CandidateScore }> = [];
+  for (const row of rows) {
+    const card = resolved.get(row.name.toLowerCase());
+    if (!card) continue;
+    out.push({ card, score: scoreCandidate(card, profile) });
+  }
+  return out;
+}
+
+async function withBracketTilt(
+  engine: DraftEngine,
+  deck: DraftDeckNames,
+  target: BracketTarget,
+  scored: Array<{ card: Card; score: CandidateScore }>,
+): Promise<RankedCandidate[]> {
+  const byTheme = [...scored].sort((a, b) => b.score.total - a.score.total);
+  const shortlist = byTheme.slice(0, BRACKET_SHORTLIST_SIZE);
+  const rest = byTheme.slice(BRACKET_SHORTLIST_SIZE);
+
+  const ranked: RankedCandidate[] = [];
+  for (const { card, score } of shortlist) {
+    const estimate = await engine.estimateBracket({
+      commander: deck.commanders.map(frontFace),
+      main_deck: [...deck.mainboard, card.name].map(frontFace),
+    });
+    const tilt = bracketTilt(estimate, target);
+    ranked.push({ card, score, bracketTilt: tilt, total: score.total + tilt });
+  }
+  for (const { card, score } of rest) {
+    ranked.push({ card, score, bracketTilt: 0, total: score.total });
+  }
+  return ranked.sort((a, b) => b.total - a.total);
+}
+
+export interface SuggestCandidatesOptions {
+  engine: DraftEngine;
+  resolver: CardResolver;
+  target: BracketTarget;
+  /** Names to leave out beyond the deck's own cards (e.g. shown-this-round), lowercase or not. */
+  exclude?: Set<string>;
+  tokenCache?: TokenSearchCache;
+}
+
+/**
+ * Rank candidates for the deck's 99: engine search on the deck's top theme
+ * tokens, filtered to the commander's color identity and Commander legality,
+ * pre-ranked by matched-token weight, then scored and bracket-tilted for a
+ * bounded shortlist. Sorted highest-fit first.
+ */
+export async function suggestCandidates(
+  deck: DraftDeckNames,
+  profile: ThemeProfile,
+  opts: SuggestCandidatesOptions,
+): Promise<RankedCandidate[]> {
+  const { engine, resolver, target } = opts;
+  const cache = opts.tokenCache ?? createTokenSearchCache();
+  const excluded = new Set(
+    [...deck.commanders, ...deck.mainboard, ...(opts.exclude ?? [])].map((n) =>
+      n.toLowerCase(),
+    ),
+  );
+
+  const tokens = topTokens(profile.tokenWeights, TOP_TOKEN_COUNT);
+  const pool = await collectCandidateRows(
+    engine,
+    cache,
+    tokens,
+    profile.tokenWeights,
+    (row) =>
+      isWithinColorIdentity(row.color_identity, profile.colorIdentity) &&
+      isCommanderLegal(row),
+  );
+  const slice = preRankSlice(pool, excluded, PRE_RANK_LIMIT);
+  const scored = await enrichAndScore(resolver, slice, profile);
+  return withBracketTilt(engine, deck, target, scored);
+}
+
+export interface SuggestCommandersOptions {
+  engine: DraftEngine;
+  resolver: CardResolver;
+  exclude?: Set<string>;
+  tokenCache?: TokenSearchCache;
+}
+
+/**
+ * Rank commander-eligible candidates for a seed of base cards (no color
+ * identity is known yet, since no commander has been chosen). Sorted highest
+ * fit to the base cards first.
+ */
+export async function suggestCommanders(
+  baseCards: Card[],
+  opts: SuggestCommandersOptions,
+): Promise<RankedCandidate[]> {
+  const { engine, resolver } = opts;
+  const cache = opts.tokenCache ?? createTokenSearchCache();
+  const excluded = new Set(
+    [...baseCards.map((c) => c.name), ...(opts.exclude ?? [])].map((n) =>
+      n.toLowerCase(),
+    ),
+  );
+
+  const profile = profileFromBaseCards(baseCards);
+  const tokens = topTokens(profile.tokenWeights, TOP_TOKEN_COUNT);
+  const pool = await collectCandidateRows(
+    engine,
+    cache,
+    tokens,
+    profile.tokenWeights,
+    isCommanderLegal,
+  );
+  const slice = preRankSlice(pool, excluded, PRE_RANK_LIMIT);
+
+  const eligible: SearchCardRow[] = [];
+  for (const row of slice) {
+    if (await engine.isCommanderEligible(row.name)) eligible.push(row);
+  }
+
+  const scored = await enrichAndScore(resolver, eligible, profile);
+  return scored
+    .map(({ card, score }) => ({ card, score, bracketTilt: 0, total: score.total }))
+    .sort((a, b) => b.total - a.total);
+}
+
+function profileFromBaseCards(baseCards: Card[]): ThemeProfile {
+  return extractThemeProfile([], baseCards);
+}

--- a/src/draft/candidates.ts
+++ b/src/draft/candidates.ts
@@ -90,6 +90,22 @@ function isCommanderLegal(row: SearchCardRow): boolean {
   return row.legalities?.commander === "legal";
 }
 
+/** A legendary Background (e.g. "Legendary Enchantment — Background"). */
+export function isBackground(card: Card): boolean {
+  return /\bBackground\b/.test(card.typeLine);
+}
+
+/** Carries the "Choose a Background" keyword, printed verbatim on the card. */
+export function hasChooseABackground(card: Card): boolean {
+  return /\bchoose a background\b/i.test(card.oracleText);
+}
+
+/** The one Background among `cards`, or null if there are zero or several (ambiguous). */
+export function singleBackgroundAmong(cards: Card[]): Card | null {
+  const backgrounds = cards.filter(isBackground);
+  return backgrounds.length === 1 ? backgrounds[0] : null;
+}
+
 interface CandidatePool {
   /** Row + summed weight of the tokens whose queries surfaced it, by lowercase name. */
   rows: Map<string, { row: SearchCardRow; weight: number }>;
@@ -221,8 +237,13 @@ export interface SuggestCommandersOptions {
 
 /**
  * Rank commander-eligible candidates for a seed of base cards (no color
- * identity is known yet, since no commander has been chosen). Sorted highest
- * fit to the base cards first.
+ * identity is known yet, since no commander has been chosen). A candidate is
+ * only offered if the union of the base cards' color identities fits inside
+ * its own — the same hard rule that governs a real Commander deck — unless
+ * exactly one base card is a Background and the candidate has "Choose a
+ * Background", in which case the candidate's identity may union with the
+ * Background's to cover the base cards. Sorted highest fit to the base cards
+ * first.
  */
 export async function suggestCommanders(
   baseCards: Card[],
@@ -253,7 +274,22 @@ export async function suggestCommanders(
   }
 
   const scored = await enrichAndScore(resolver, eligible, profile);
-  return scored
+
+  const requiredIdentity = [...new Set(baseCards.flatMap((c) => c.colorIdentity))];
+  const background = singleBackgroundAmong(baseCards);
+  const covering = scored.filter(({ card }) => {
+    if (isWithinColorIdentity(requiredIdentity, card.colorIdentity)) return true;
+    return (
+      background !== null &&
+      hasChooseABackground(card) &&
+      isWithinColorIdentity(requiredIdentity, [
+        ...card.colorIdentity,
+        ...background.colorIdentity,
+      ])
+    );
+  });
+
+  return covering
     .map(({ card, score }) => ({ card, score, bracketTilt: 0, total: score.total }))
     .sort((a, b) => b.total - a.total);
 }

--- a/src/draft/candidates.ts
+++ b/src/draft/candidates.ts
@@ -18,6 +18,7 @@ export interface DraftEngine {
   searchCards(query: SearchCardsQuery): Promise<SearchCardsResult>;
   estimateBracket(deck: BracketDeckInput): Promise<BracketEstimate | null>;
   isCommanderEligible(name: string): Promise<boolean>;
+  commanderCandidates(): Promise<SearchCardRow[]>;
 }
 
 /** Card-name resolution the draft pipeline needs — narrow enough to fake in tests. */
@@ -30,6 +31,7 @@ export const engineDraftEngine: DraftEngine = {
   searchCards: (query) => getEngine().searchCards(query),
   estimateBracket: (deck) => getEngine().estimateBracket(deck),
   isCommanderEligible: (name) => getEngine().isCommanderEligible(name),
+  commanderCandidates: () => getEngine().commanderCandidates(),
 };
 
 /** Real `CardResolver`, wrapping the Scryfall localStorage cache. */
@@ -54,6 +56,7 @@ const TOP_TOKEN_COUNT = 8;
 const SEARCH_LIMIT_PER_TOKEN = 40;
 const PRE_RANK_LIMIT = 40;
 const BRACKET_SHORTLIST_SIZE = 12;
+const COMMANDER_ROUND_SIZE = 3;
 
 /** Per-session cache of `search_cards_js` rows by token — the card database is static. */
 export type TokenSearchCache = Map<string, SearchCardRow[]>;
@@ -273,11 +276,9 @@ export async function suggestCommanders(
     if (await engine.isCommanderEligible(row.name)) eligible.push(row);
   }
 
-  const scored = await enrichAndScore(resolver, eligible, profile);
-
   const requiredIdentity = [...new Set(baseCards.flatMap((c) => c.colorIdentity))];
   const background = singleBackgroundAmong(baseCards);
-  const covering = scored.filter(({ card }) => {
+  const coversBaseCards = (card: Card) => {
     if (isWithinColorIdentity(requiredIdentity, card.colorIdentity)) return true;
     return (
       background !== null &&
@@ -287,7 +288,27 @@ export async function suggestCommanders(
         ...background.colorIdentity,
       ])
     );
-  });
+  };
+
+  const scored = await enrichAndScore(resolver, eligible, profile);
+  const covering = scored.filter(({ card }) => coversBaseCards(card));
+
+  if (covering.length < COMMANDER_ROUND_SIZE) {
+    const themedNames = new Set(covering.map(({ card }) => card.name.toLowerCase()));
+    const fallbackRows = (await engine.commanderCandidates()).filter(
+      (row) =>
+        !excluded.has(row.name.toLowerCase()) &&
+        !themedNames.has(row.name.toLowerCase()) &&
+        (isWithinColorIdentity(requiredIdentity, row.color_identity) ||
+          (background !== null &&
+            isWithinColorIdentity(requiredIdentity, [
+              ...row.color_identity,
+              ...background.colorIdentity,
+            ]))),
+    );
+    const fallback = await enrichAndScore(resolver, fallbackRows, profile);
+    covering.push(...fallback.filter(({ card }) => coversBaseCards(card)));
+  }
 
   return covering
     .map(({ card, score }) => ({ card, score, bracketTilt: 0, total: score.total }))

--- a/src/draft/cardLegality.test.ts
+++ b/src/draft/cardLegality.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { isCommanderLegal, isLegendaryCreature, isCommanderEligible } from "./cardLegality";
+import type { SearchCardRow, CardFaceData } from "../engine/draftQueries";
+
+function row(commander: string | undefined): SearchCardRow {
+  return {
+    name: "X",
+    oracle_id: "x",
+    mana_value: 0,
+    color_identity: [],
+    legalities: commander === undefined ? {} : { commander },
+  };
+}
+
+function face(supertypes: string[], coreTypes: string[]): CardFaceData {
+  return { name: "X", card_type: { supertypes, core_types: coreTypes } };
+}
+
+describe("isCommanderLegal", () => {
+  it("is true only for an explicit legal", () => {
+    expect(isCommanderLegal(row("legal"))).toBe(true);
+    expect(isCommanderLegal(row("banned"))).toBe(false);
+    expect(isCommanderLegal(row(undefined))).toBe(false);
+    expect(isCommanderLegal(undefined)).toBe(false);
+  });
+});
+
+describe("isLegendaryCreature", () => {
+  it("needs both Legendary and Creature", () => {
+    expect(isLegendaryCreature(face(["Legendary"], ["Creature"]))).toBe(true);
+    expect(isLegendaryCreature(face([], ["Creature"]))).toBe(false);
+    expect(isLegendaryCreature(face(["Legendary"], ["Artifact"]))).toBe(false);
+    expect(isLegendaryCreature(null)).toBe(false);
+  });
+});
+
+describe("isCommanderEligible", () => {
+  it("accepts an engine-eligible card even without a legendary-creature face", () => {
+    expect(isCommanderEligible(true, null)).toBe(true);
+  });
+
+  it("accepts a legendary creature the engine util misses", () => {
+    // Ancient Copper Dragon: a real legendary creature the engine returns false for.
+    expect(isCommanderEligible(false, face(["Legendary"], ["Creature"]))).toBe(true);
+  });
+
+  it("rejects a non-legendary creature", () => {
+    expect(isCommanderEligible(false, face([], ["Creature"]))).toBe(false);
+  });
+});

--- a/src/draft/cardLegality.ts
+++ b/src/draft/cardLegality.ts
@@ -1,0 +1,27 @@
+import type { SearchCardRow, CardFaceData } from "../engine/draftQueries";
+
+/** A card is Commander-legal only when the engine marks it exactly "legal". */
+export function isCommanderLegal(row: SearchCardRow | undefined): boolean {
+  return row?.legalities?.commander === "legal";
+}
+
+/** A legendary creature, read from an engine card face's type. */
+export function isLegendaryCreature(face: CardFaceData | null | undefined): boolean {
+  const type = face?.card_type;
+  if (!type) return false;
+  return (
+    (type.supertypes ?? []).includes("Legendary") &&
+    (type.core_types ?? []).includes("Creature")
+  );
+}
+
+/**
+ * Whether a card may be a commander. The engine's `is_card_commander_eligible`
+ * is the main signal but has false negatives — it rejects some legitimate
+ * legendary creatures (e.g. Ancient Copper Dragon) — so a legendary-creature
+ * type line also qualifies. The union keeps either gap from blocking a valid
+ * commander while still rejecting non-legendary creatures, planeswalkers, etc.
+ */
+export function isCommanderEligible(engineEligible: boolean, face: CardFaceData | null): boolean {
+  return engineEligible || isLegendaryCreature(face);
+}

--- a/src/draft/cardNameSuggest.test.ts
+++ b/src/draft/cardNameSuggest.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { rankNameSuggestions } from "./cardNameSuggest";
+import type { SearchCardRow } from "../engine/draftQueries";
+
+/** A minimal search row — only `name` matters to the ranker. */
+function row(name: string): SearchCardRow {
+  return { name, oracle_id: name, mana_value: 0, color_identity: [], legalities: {} };
+}
+
+describe("rankNameSuggestions", () => {
+  it("drops rows that match only in oracle text, keeping name matches", () => {
+    // "sol" appears in the name of some and (imagine) the oracle text of others;
+    // the search hands back both, we keep only the name matches.
+    const rows = [row("Sol Ring"), row("Lightning Bolt"), row("Solemn Simulacrum")];
+    expect(rankNameSuggestions(rows, "sol")).toEqual(["Sol Ring", "Solemn Simulacrum"]);
+  });
+
+  it("ranks exact, then prefix, then word-start, then interior matches", () => {
+    const rows = [
+      row("Absolute Grace"), // interior "sol"
+      row("Krenko, Sol Boss"), // word-start "sol"
+      row("Sol"), // exact
+      row("Sol Ring"), // prefix
+    ];
+    expect(rankNameSuggestions(rows, "sol")).toEqual([
+      "Sol",
+      "Sol Ring",
+      "Krenko, Sol Boss",
+      "Absolute Grace",
+    ]);
+  });
+
+  it("skips Alchemy A- rebalances and de-duplicates names", () => {
+    const rows = [row("A-Krenko, Mob Boss"), row("Krenko, Mob Boss"), row("Krenko, Mob Boss")];
+    expect(rankNameSuggestions(rows, "krenko")).toEqual(["Krenko, Mob Boss"]);
+  });
+
+  it("returns nothing for queries shorter than two characters", () => {
+    expect(rankNameSuggestions([row("Sol Ring")], "s")).toEqual([]);
+  });
+});

--- a/src/draft/cardNameSuggest.ts
+++ b/src/draft/cardNameSuggest.ts
@@ -1,0 +1,36 @@
+import type { SearchCardRow } from "../engine/draftQueries";
+
+const NAME_SUGGEST_LIMIT = 15;
+
+/** How well a card name matches the query: lower is a stronger match. */
+function nameMatchRank(lowerName: string, query: string): number | null {
+  const idx = lowerName.indexOf(query);
+  if (idx < 0) return null;
+  if (lowerName === query) return 0;
+  if (idx === 0) return 1;
+  return /[a-z0-9]/.test(lowerName[idx - 1]) ? 3 : 2;
+}
+
+/**
+ * Turn raw `search_cards_js` rows into card-name suggestions. That search
+ * matches name *and* oracle text and sorts alphabetically, so a raw call is a
+ * poor name autocomplete ("sol" buries "Sol Ring" under A-Sizzling-Soloist-style
+ * hits). Keep only rows whose *name* contains the query, drop Alchemy "A-"
+ * rebalances, and re-rank so exact, then prefix, then word-start names come
+ * first (alphabetical within a tier).
+ */
+export function rankNameSuggestions(rows: SearchCardRow[], rawQuery: string): string[] {
+  const query = rawQuery.trim().toLowerCase();
+  if (query.length < 2) return [];
+  const ranked: Array<{ name: string; rank: number }> = [];
+  const seen = new Set<string>();
+  for (const row of rows) {
+    if (row.name.startsWith("A-") || seen.has(row.name)) continue;
+    const rank = nameMatchRank(row.name.toLowerCase(), query);
+    if (rank === null) continue;
+    seen.add(row.name);
+    ranked.push({ name: row.name, rank });
+  }
+  ranked.sort((a, b) => a.rank - b.rank || a.name.localeCompare(b.name));
+  return ranked.slice(0, NAME_SUGGEST_LIMIT).map((r) => r.name);
+}

--- a/src/draft/draftSession.test.ts
+++ b/src/draft/draftSession.test.ts
@@ -16,6 +16,7 @@ function card(overrides: Partial<Card> = {}): Card {
     typeLine: "Creature — Bear",
     oracleText: "",
     colors: ["G"],
+    colorIdentity: ["G"],
     producedMana: [],
     roles: ["other"],
     ...overrides,
@@ -222,5 +223,106 @@ describe("DraftSession", () => {
     expect(deck.commanders).toEqual(session.commanders);
     expect(deck.mainboard).toEqual(session.mainboard);
     expect(typeof deck.id).toBe("string");
+  });
+});
+
+describe("DraftSession Choose-a-Background pairing", () => {
+  const background = card({
+    name: "Blue Background",
+    typeLine: "Legendary Enchantment — Background",
+    colorIdentity: ["U"],
+  });
+  const partnerCommander = card({
+    name: "Green Choose-a-Background Commander",
+    typeLine: "Legendary Creature — Human",
+    colorIdentity: ["G"],
+    oracleText: "Choose a Background (You can have a Background as a second commander.)",
+  });
+  const otherGreenCard = card({ name: "Other Green Card", colorIdentity: ["G"] });
+  const thirdGreenCard = card({ name: "Third Green Card", colorIdentity: ["G"] });
+
+  function makeBgEngine(rows: SearchCardRow[], eligible: Set<string>): DraftEngine {
+    return {
+      searchCards: async (): Promise<SearchCardsResult> => ({ results: rows, total: rows.length }),
+      estimateBracket: async (): Promise<BracketEstimate | null> => ({
+        tier: "exhibition",
+        axes: {},
+        axis_caps_at_tier: {},
+        contributing: {},
+        violations: {},
+        data_version: "test",
+      }),
+      isCommanderEligible: async (name: string) => eligible.has(name),
+    };
+  }
+
+  function makeBgResolver(cards: Card[]): CardResolver {
+    const byName = new Map(cards.map((c) => [c.name.toLowerCase(), c]));
+    return {
+      resolve: async (names) => {
+        const out = new Map<string, Card>();
+        for (const name of names) {
+          const found = byName.get(name.trim().toLowerCase());
+          if (found) out.set(name.trim().toLowerCase(), found);
+        }
+        return out;
+      },
+    };
+  }
+
+  it("start() pairs a flagged Choose-a-Background commander with the base cards' Background", async () => {
+    const baseCards = [partnerCommander, background, otherGreenCard];
+    const session = new DraftSession({
+      engine: makeBgEngine([], new Set()),
+      resolver: makeBgResolver(baseCards),
+    });
+
+    await session.start(
+      baseCards.map((c) => c.name),
+      partnerCommander.name,
+    );
+
+    expect(session.phase).toBe("drafting");
+    expect(session.commander?.name).toBe(partnerCommander.name);
+    expect(session.background?.name).toBe(background.name);
+    expect(session.commanders.map((e) => e.name).sort()).toEqual(
+      [partnerCommander.name, background.name].sort(),
+    );
+    // The Background is a commander now, not a mainboard card.
+    expect(session.mainboard.map((e) => e.name)).toEqual([otherGreenCard.name]);
+    expect(session.profile.colorIdentity).toEqual(["G", "U"]);
+  });
+
+  it("pickCommander() pairs a picked Choose-a-Background commander with the base cards' Background", async () => {
+    const baseCards = [background, otherGreenCard, thirdGreenCard];
+    const pool = [partnerCommander];
+    const rows = pool.map((c) => row(c.name, c.colorIdentity));
+    const session = new DraftSession({
+      engine: makeBgEngine(
+        rows,
+        new Set(pool.map((c) => c.name)),
+      ),
+      resolver: makeBgResolver([...baseCards, ...pool]),
+    });
+
+    await session.start(
+      baseCards.map((c) => c.name),
+      null,
+    );
+    expect(session.phase).toBe("commander-selection");
+    expect(session.round.map((c) => c.card.name)).toContain(partnerCommander.name);
+
+    await session.pickCommander(partnerCommander.name);
+
+    expect(session.phase).toBe("drafting");
+    expect(session.commander?.name).toBe(partnerCommander.name);
+    expect(session.background?.name).toBe(background.name);
+    expect(session.commanders.map((e) => e.name).sort()).toEqual(
+      [partnerCommander.name, background.name].sort(),
+    );
+    expect(session.mainboard.map((e) => e.name).sort()).toEqual(
+      [otherGreenCard.name, thirdGreenCard.name].sort(),
+    );
+    expect(session.profile.colorIdentity).toEqual(["G", "U"]);
   });
 });

--- a/src/draft/draftSession.test.ts
+++ b/src/draft/draftSession.test.ts
@@ -67,6 +67,7 @@ function makeEngine(): DraftEngine {
       data_version: "test",
     }),
     isCommanderEligible: async (name: string) => ELIGIBLE_COMMANDERS.has(name),
+    commanderCandidates: async () => POOL_ROWS,
   };
 }
 
@@ -253,6 +254,7 @@ describe("DraftSession Choose-a-Background pairing", () => {
         data_version: "test",
       }),
       isCommanderEligible: async (name: string) => eligible.has(name),
+      commanderCandidates: async () => rows,
     };
   }
 

--- a/src/draft/draftSession.test.ts
+++ b/src/draft/draftSession.test.ts
@@ -3,12 +3,7 @@ import { DraftSession, DraftSessionError } from "./draftSession";
 import type { DraftEngine, CardResolver } from "./candidates";
 import type { Card } from "../lib/types";
 import { parseDecklist } from "../lib/decklist";
-import type {
-  BracketEstimate,
-  CommanderCandidateData,
-  SearchCardRow,
-  SearchCardsResult,
-} from "../engine/draftQueries";
+import type { DraftCandidateData } from "../engine/draftQueries";
 
 function card(overrides: Partial<Card> = {}): Card {
   return {
@@ -24,17 +19,7 @@ function card(overrides: Partial<Card> = {}): Card {
   };
 }
 
-function row(name: string, colorIdentity: string[] = ["G"]): SearchCardRow {
-  return {
-    name,
-    oracle_id: name,
-    mana_value: 3,
-    color_identity: colorIdentity,
-    legalities: { commander: "legal" },
-  };
-}
-
-function commanderData(candidate: Card): CommanderCandidateData {
+function commanderData(candidate: Card): DraftCandidateData {
   return {
     name: candidate.name,
     manaValue: candidate.manaValue,
@@ -60,23 +45,13 @@ const POOL_CARDS: Card[] = [
   card({ name: "Craterhoof Behemoth", typeLine: "Legendary Creature — Elemental" }),
 ];
 
-const POOL_ROWS: SearchCardRow[] = POOL_CARDS.map((c) => row(c.name));
-
 function makeEngine(): DraftEngine {
   return {
-    searchCards: async (): Promise<SearchCardsResult> => ({
-      results: POOL_ROWS,
-      total: POOL_ROWS.length,
-    }),
-    estimateBracket: async (): Promise<BracketEstimate | null> => ({
-      tier: "exhibition",
-      axes: {},
-      axis_caps_at_tier: {},
-      contributing: {},
-      violations: {},
-      data_version: "test",
-    }),
     commanderCandidates: async () => POOL_CARDS.map(commanderData),
+    rankCardCandidates: async ({ exclude }) =>
+      POOL_CARDS.filter((candidate) => !exclude.includes(candidate.name.toLowerCase()))
+        .slice(0, 3)
+        .map(({ name }) => ({ name, bracketTilt: 0 })),
   };
 }
 
@@ -201,6 +176,30 @@ describe("DraftSession", () => {
     expect(session.round.some((c) => stillAvailable.includes(c.card.name))).toBe(true);
   });
 
+  it("uses the updated deck and theme profile for the next round", async () => {
+    const inputs: Array<Parameters<DraftEngine["rankCardCandidates"]>[0]> = [];
+    const picks = ["Imperious Perfect", "Elvish Clancaller"];
+    const engine: DraftEngine = {
+      commanderCandidates: async () => POOL_CARDS.map(commanderData),
+      rankCardCandidates: async (input) => {
+        inputs.push(input);
+        return [{ name: picks[inputs.length - 1], bracketTilt: 0 }];
+      },
+    };
+    const session = new DraftSession({ engine, resolver: makeResolver() });
+    await session.start(
+      ["Elvish Champion", "Timberwatch Elf", "Elvish Archer"],
+      "Elvish Champion",
+    );
+    await session.addCard(0);
+
+    expect(inputs).toHaveLength(2);
+    expect(inputs[1].mainboard).toContain("Imperious Perfect");
+    const firstElfWeight = new Map(inputs[0].profile.tokenWeights).get("elf") ?? 0;
+    const nextElfWeight = new Map(inputs[1].profile.tokenWeights).get("elf") ?? 0;
+    expect(nextElfWeight).toBe(firstElfWeight + 1);
+  });
+
   it("setBracketTarget updates the target used for subsequent rounds", async () => {
     const session = makeSession();
     await session.start(BASE_NAMES, null);
@@ -252,18 +251,9 @@ describe("DraftSession Choose-a-Background pairing", () => {
   const thirdGreenCard = card({ name: "Third Green Card", colorIdentity: ["G"] });
 
   function makeBgEngine(cards: Card[]): DraftEngine {
-    const rows = cards.map((candidate) => row(candidate.name, candidate.colorIdentity));
     return {
-      searchCards: async (): Promise<SearchCardsResult> => ({ results: rows, total: rows.length }),
-      estimateBracket: async (): Promise<BracketEstimate | null> => ({
-        tier: "exhibition",
-        axes: {},
-        axis_caps_at_tier: {},
-        contributing: {},
-        violations: {},
-        data_version: "test",
-      }),
       commanderCandidates: async () => cards.map(commanderData),
+      rankCardCandidates: async () => [],
     };
   }
 

--- a/src/draft/draftSession.test.ts
+++ b/src/draft/draftSession.test.ts
@@ -5,6 +5,7 @@ import type { Card } from "../lib/types";
 import { parseDecklist } from "../lib/decklist";
 import type {
   BracketEstimate,
+  CommanderCandidateData,
   SearchCardRow,
   SearchCardsResult,
 } from "../engine/draftQueries";
@@ -33,6 +34,16 @@ function row(name: string, colorIdentity: string[] = ["G"]): SearchCardRow {
   };
 }
 
+function commanderData(candidate: Card): CommanderCandidateData {
+  return {
+    name: candidate.name,
+    manaValue: candidate.manaValue,
+    typeLine: candidate.typeLine,
+    oracleText: candidate.oracleText,
+    colorIdentity: candidate.colorIdentity,
+  };
+}
+
 // A small deterministic elf-tribal card pool the fake engine/resolver share.
 const BASE_CARDS: Card[] = [
   card({ name: "Timberwatch Elf", typeLine: "Creature — Elf", manaValue: 2 }),
@@ -50,7 +61,6 @@ const POOL_CARDS: Card[] = [
 ];
 
 const POOL_ROWS: SearchCardRow[] = POOL_CARDS.map((c) => row(c.name));
-const ELIGIBLE_COMMANDERS = new Set(POOL_CARDS.map((c) => c.name));
 
 function makeEngine(): DraftEngine {
   return {
@@ -66,8 +76,7 @@ function makeEngine(): DraftEngine {
       violations: {},
       data_version: "test",
     }),
-    isCommanderEligible: async (name: string) => ELIGIBLE_COMMANDERS.has(name),
-    commanderCandidates: async () => POOL_ROWS,
+    commanderCandidates: async () => POOL_CARDS.map(commanderData),
   };
 }
 
@@ -242,7 +251,8 @@ describe("DraftSession Choose-a-Background pairing", () => {
   const otherGreenCard = card({ name: "Other Green Card", colorIdentity: ["G"] });
   const thirdGreenCard = card({ name: "Third Green Card", colorIdentity: ["G"] });
 
-  function makeBgEngine(rows: SearchCardRow[], eligible: Set<string>): DraftEngine {
+  function makeBgEngine(cards: Card[]): DraftEngine {
+    const rows = cards.map((candidate) => row(candidate.name, candidate.colorIdentity));
     return {
       searchCards: async (): Promise<SearchCardsResult> => ({ results: rows, total: rows.length }),
       estimateBracket: async (): Promise<BracketEstimate | null> => ({
@@ -253,8 +263,7 @@ describe("DraftSession Choose-a-Background pairing", () => {
         violations: {},
         data_version: "test",
       }),
-      isCommanderEligible: async (name: string) => eligible.has(name),
-      commanderCandidates: async () => rows,
+      commanderCandidates: async () => cards.map(commanderData),
     };
   }
 
@@ -275,7 +284,7 @@ describe("DraftSession Choose-a-Background pairing", () => {
   it("start() pairs a flagged Choose-a-Background commander with the base cards' Background", async () => {
     const baseCards = [partnerCommander, background, otherGreenCard];
     const session = new DraftSession({
-      engine: makeBgEngine([], new Set()),
+      engine: makeBgEngine([]),
       resolver: makeBgResolver(baseCards),
     });
 
@@ -298,12 +307,8 @@ describe("DraftSession Choose-a-Background pairing", () => {
   it("pickCommander() pairs a picked Choose-a-Background commander with the base cards' Background", async () => {
     const baseCards = [background, otherGreenCard, thirdGreenCard];
     const pool = [partnerCommander];
-    const rows = pool.map((c) => row(c.name, c.colorIdentity));
     const session = new DraftSession({
-      engine: makeBgEngine(
-        rows,
-        new Set(pool.map((c) => c.name)),
-      ),
+      engine: makeBgEngine(pool),
       resolver: makeBgResolver([...baseCards, ...pool]),
     });
 

--- a/src/draft/draftSession.test.ts
+++ b/src/draft/draftSession.test.ts
@@ -46,12 +46,20 @@ const POOL_CARDS: Card[] = [
 ];
 
 function makeEngine(): DraftEngine {
+  const byName = new Map(
+    [...BASE_CARDS, ...POOL_CARDS].map((c) => [c.name.toLowerCase(), c]),
+  );
   return {
     commanderCandidates: async () => POOL_CARDS.map(commanderData),
     rankCardCandidates: async ({ exclude }) =>
       POOL_CARDS.filter((candidate) => !exclude.includes(candidate.name.toLowerCase()))
         .slice(0, 3)
         .map(({ name }) => ({ name, bracketTilt: 0 })),
+    resolveCards: async (names) =>
+      names.flatMap((name) => {
+        const found = byName.get(name.trim().toLowerCase());
+        return found ? [commanderData(found)] : [];
+      }),
   };
 }
 
@@ -179,12 +187,20 @@ describe("DraftSession", () => {
   it("uses the updated deck and theme profile for the next round", async () => {
     const inputs: Array<Parameters<DraftEngine["rankCardCandidates"]>[0]> = [];
     const picks = ["Imperious Perfect", "Elvish Clancaller"];
+    const byName = new Map(
+      [...BASE_CARDS, ...POOL_CARDS].map((c) => [c.name.toLowerCase(), c]),
+    );
     const engine: DraftEngine = {
       commanderCandidates: async () => POOL_CARDS.map(commanderData),
       rankCardCandidates: async (input) => {
         inputs.push(input);
         return [{ name: picks[inputs.length - 1], bracketTilt: 0 }];
       },
+      resolveCards: async (names) =>
+        names.flatMap((name) => {
+          const found = byName.get(name.trim().toLowerCase());
+          return found ? [commanderData(found)] : [];
+        }),
     };
     const session = new DraftSession({ engine, resolver: makeResolver() });
     await session.start(
@@ -251,9 +267,20 @@ describe("DraftSession Choose-a-Background pairing", () => {
   const thirdGreenCard = card({ name: "Third Green Card", colorIdentity: ["G"] });
 
   function makeBgEngine(cards: Card[]): DraftEngine {
+    const byName = new Map(
+      [background, partnerCommander, otherGreenCard, thirdGreenCard, ...cards].map((c) => [
+        c.name.toLowerCase(),
+        c,
+      ]),
+    );
     return {
       commanderCandidates: async () => cards.map(commanderData),
       rankCardCandidates: async () => [],
+      resolveCards: async (names) =>
+        names.flatMap((name) => {
+          const found = byName.get(name.trim().toLowerCase());
+          return found ? [commanderData(found)] : [];
+        }),
     };
   }
 
@@ -321,5 +348,80 @@ describe("DraftSession Choose-a-Background pairing", () => {
       [otherGreenCard.name, thirdGreenCard.name].sort(),
     );
     expect(session.profile.colorIdentity).toEqual(["G", "U"]);
+  });
+});
+
+describe("DraftSession base card color identity", () => {
+  it("commander-selection uses the engine's color identity, not the resolver's", async () => {
+    const baseCardNames = ["Sylvan Base", "Aquatic Base", "Neutral Base"];
+    const engineIdentities: Record<string, string[]> = {
+      "sylvan base": ["G"],
+      "aquatic base": ["U"],
+      "neutral base": [],
+    };
+
+    const simicCommander = card({
+      name: "Simic Commander",
+      typeLine: "Legendary Creature — Merfolk",
+      colorIdentity: ["G", "U"],
+    });
+    const monoGreenCommander = card({
+      name: "Mono Green Commander",
+      typeLine: "Legendary Creature — Elf",
+      colorIdentity: ["G"],
+    });
+    const selesnyaCommander = card({
+      name: "Selesnya Commander",
+      typeLine: "Legendary Creature — Human",
+      colorIdentity: ["G", "W"],
+    });
+    const commanderPool = [simicCommander, monoGreenCommander, selesnyaCommander];
+
+    const engine: DraftEngine = {
+      commanderCandidates: async () => commanderPool.map(commanderData),
+      rankCardCandidates: async () => [],
+      resolveCards: async (names) =>
+        names.flatMap((name) => {
+          const identity = engineIdentities[name.trim().toLowerCase()];
+          return identity
+            ? [
+                {
+                  name,
+                  manaValue: 2,
+                  typeLine: "Creature — Bear",
+                  oracleText: "",
+                  colorIdentity: identity,
+                },
+              ]
+            : [];
+        }),
+    };
+
+    // Stands in for Scryfall resolving the base cards with empty color identity.
+    const commanderByName = new Map(commanderPool.map((c) => [c.name.toLowerCase(), c]));
+    const resolver: CardResolver = {
+      resolve: async (names) => {
+        const out = new Map<string, Card>();
+        for (const name of names) {
+          const key = name.trim().toLowerCase();
+          const commanderCard = commanderByName.get(key);
+          if (commanderCard) {
+            out.set(key, commanderCard);
+          } else if (key in engineIdentities) {
+            out.set(key, card({ name, colorIdentity: [] }));
+          }
+        }
+        return out;
+      },
+    };
+
+    const session = new DraftSession({ engine, resolver });
+    await session.start(baseCardNames, null);
+
+    expect(session.phase).toBe("commander-selection");
+    const names = session.round.map((c) => c.card.name);
+    expect(names).toContain("Simic Commander");
+    expect(names).not.toContain("Mono Green Commander");
+    expect(names).not.toContain("Selesnya Commander");
   });
 });

--- a/src/draft/draftSession.test.ts
+++ b/src/draft/draftSession.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect } from "vitest";
+import { DraftSession, DraftSessionError } from "./draftSession";
+import type { DraftEngine, CardResolver } from "./candidates";
+import type { Card } from "../lib/types";
+import { parseDecklist } from "../lib/decklist";
+import type {
+  BracketEstimate,
+  SearchCardRow,
+  SearchCardsResult,
+} from "../engine/draftQueries";
+
+function card(overrides: Partial<Card> = {}): Card {
+  return {
+    name: "Test Card",
+    manaValue: 3,
+    typeLine: "Creature — Bear",
+    oracleText: "",
+    colors: ["G"],
+    producedMana: [],
+    roles: ["other"],
+    ...overrides,
+  };
+}
+
+function row(name: string, colorIdentity: string[] = ["G"]): SearchCardRow {
+  return {
+    name,
+    oracle_id: name,
+    mana_value: 3,
+    color_identity: colorIdentity,
+    legalities: { commander: "legal" },
+  };
+}
+
+// A small deterministic elf-tribal card pool the fake engine/resolver share.
+const BASE_CARDS: Card[] = [
+  card({ name: "Timberwatch Elf", typeLine: "Creature — Elf", manaValue: 2 }),
+  card({ name: "Elvish Archer", typeLine: "Creature — Elf", manaValue: 2 }),
+  card({ name: "Wellwisher", typeLine: "Creature — Elf", manaValue: 1 }),
+];
+
+// Ordered so ties in score break predictably (stable sort preserves this order).
+const POOL_CARDS: Card[] = [
+  card({ name: "Elvish Champion", typeLine: "Legendary Creature — Elf" }),
+  card({ name: "Marwyn, the Nurturer", typeLine: "Legendary Creature — Elf Druid" }),
+  card({ name: "Imperious Perfect", typeLine: "Legendary Creature — Elf Warrior" }),
+  card({ name: "Elvish Clancaller", typeLine: "Legendary Creature — Elf" }),
+  card({ name: "Craterhoof Behemoth", typeLine: "Legendary Creature — Elemental" }),
+];
+
+const POOL_ROWS: SearchCardRow[] = POOL_CARDS.map((c) => row(c.name));
+const ELIGIBLE_COMMANDERS = new Set(POOL_CARDS.map((c) => c.name));
+
+function makeEngine(): DraftEngine {
+  return {
+    searchCards: async (): Promise<SearchCardsResult> => ({
+      results: POOL_ROWS,
+      total: POOL_ROWS.length,
+    }),
+    estimateBracket: async (): Promise<BracketEstimate | null> => ({
+      tier: "exhibition",
+      axes: {},
+      axis_caps_at_tier: {},
+      contributing: {},
+      violations: {},
+      data_version: "test",
+    }),
+    isCommanderEligible: async (name: string) => ELIGIBLE_COMMANDERS.has(name),
+  };
+}
+
+function makeResolver(): CardResolver {
+  const byName = new Map(
+    [...BASE_CARDS, ...POOL_CARDS].map((c) => [c.name.toLowerCase(), c]),
+  );
+  return {
+    resolve: async (names) => {
+      const out = new Map<string, Card>();
+      for (const name of names) {
+        const found = byName.get(name.trim().toLowerCase());
+        if (found) out.set(name.trim().toLowerCase(), found);
+      }
+      return out;
+    },
+  };
+}
+
+function makeSession(): DraftSession {
+  return new DraftSession({ engine: makeEngine(), resolver: makeResolver() });
+}
+
+const BASE_NAMES = BASE_CARDS.map((c) => c.name);
+
+describe("DraftSession", () => {
+  it("refuses fewer than three base cards", async () => {
+    const session = makeSession();
+    await expect(
+      session.start(["Timberwatch Elf", "Elvish Archer"], null),
+    ).rejects.toThrow(DraftSessionError);
+  });
+
+  it("opens with the base cards in the deck when a commander is flagged", async () => {
+    const session = makeSession();
+    await session.start(
+      ["Marwyn, the Nurturer", "Timberwatch Elf", "Elvish Archer"],
+      "Marwyn, the Nurturer",
+    );
+
+    expect(session.phase).toBe("drafting");
+    expect(session.commander?.name).toBe("Marwyn, the Nurturer");
+    expect(session.commanders).toEqual([{ quantity: 1, name: "Marwyn, the Nurturer" }]);
+    expect(session.mainboard.map((e) => e.name).sort()).toEqual(
+      ["Elvish Archer", "Timberwatch Elf"].sort(),
+    );
+    expect(session.profile.colorIdentity).toEqual(["G"]);
+  });
+
+  it("offers commander-eligible candidates first when no base card is flagged", async () => {
+    const session = makeSession();
+    await session.start(BASE_NAMES, null);
+
+    expect(session.phase).toBe("commander-selection");
+    expect(session.round.length).toBeLessThanOrEqual(3);
+    expect(session.round.map((c) => c.card.name)).toEqual([
+      "Elvish Champion",
+      "Marwyn, the Nurturer",
+      "Imperious Perfect",
+    ]);
+  });
+
+  it("picking a commander fixes color identity and opens the drafting round", async () => {
+    const session = makeSession();
+    await session.start(BASE_NAMES, null);
+    await session.pickCommander("Elvish Champion");
+
+    expect(session.phase).toBe("drafting");
+    expect(session.commander?.name).toBe("Elvish Champion");
+    expect(session.commanders).toEqual([{ quantity: 1, name: "Elvish Champion" }]);
+    expect(session.profile.colorIdentity).toEqual(["G"]);
+    expect(session.round.length).toBeGreaterThan(0);
+    expect(session.round.length).toBeLessThanOrEqual(3);
+    // Base cards stay in the deck; the drafting round never re-offers the commander.
+    expect(session.round.map((c) => c.card.name)).not.toContain("Elvish Champion");
+  });
+
+  it("a round never shows more than three cards", async () => {
+    const session = makeSession();
+    await session.start(BASE_NAMES, null);
+    expect(session.round.length).toBeLessThanOrEqual(3);
+
+    await session.pickCommander("Elvish Champion");
+    expect(session.round.length).toBeLessThanOrEqual(3);
+  });
+
+  it("refresh replaces a slot with the closest unshown candidate and never repeats within the round", async () => {
+    const session = makeSession();
+    await session.start(BASE_NAMES, null);
+    // round = [Champion, Marwyn{elf,druid}, Imperious]; unshown pool = [Clancaller{elf}, Craterhoof{elemental}]
+
+    await session.refreshSlot(1);
+    // Clancaller shares "elf" with Marwyn; Craterhoof shares nothing — Clancaller is closer.
+    expect(session.round[1].card.name).toBe("Elvish Clancaller");
+    expect(session.round.map((c) => c.card.name)).toEqual([
+      "Elvish Champion",
+      "Elvish Clancaller",
+      "Imperious Perfect",
+    ]);
+
+    await session.refreshSlot(1);
+    // Only Craterhoof is left unshown.
+    expect(session.round[1].card.name).toBe("Craterhoof Behemoth");
+
+    const names = session.round.map((c) => c.card.name);
+    expect(new Set(names).size).toBe(names.length);
+    expect(names).not.toContain("Marwyn, the Nurturer");
+  });
+
+  it("addCard ends the round and opens a fresh one where a previously shown card may recur", async () => {
+    const session = makeSession();
+    await session.start(BASE_NAMES, null);
+    await session.pickCommander("Elvish Champion");
+    const roundBefore = session.round.map((c) => c.card.name);
+
+    await session.addCard(0);
+
+    expect(session.mainboard.map((e) => e.name)).toContain(roundBefore[0]);
+    expect(session.round.length).toBeGreaterThan(0);
+    // A card offered in the previous round but not picked can reappear now.
+    const stillAvailable = roundBefore.slice(1);
+    expect(session.round.some((c) => stillAvailable.includes(c.card.name))).toBe(true);
+  });
+
+  it("setBracketTarget updates the target used for subsequent rounds", async () => {
+    const session = makeSession();
+    await session.start(BASE_NAMES, null);
+    session.setBracketTarget("cedh");
+    expect(session.target).toBe("cedh");
+  });
+
+  it("exportText round-trips through the decklist parser", async () => {
+    const session = makeSession();
+    await session.start(BASE_NAMES, null);
+    await session.pickCommander("Elvish Champion");
+    await session.addCard(0);
+
+    const text = session.exportText();
+    const parsed = parseDecklist(text);
+
+    expect(parsed.commanders).toEqual(session.commanders);
+    expect(parsed.mainboard.map((e) => e.name).sort()).toEqual(
+      session.mainboard.map((e) => e.name).sort(),
+    );
+  });
+
+  it("toSavedDeck builds a partial deck without enforcing 100 cards", async () => {
+    const session = makeSession();
+    await session.start(BASE_NAMES, null);
+    await session.pickCommander("Elvish Champion");
+
+    const deck = session.toSavedDeck("My Elf Draft");
+    expect(deck.name).toBe("My Elf Draft");
+    expect(deck.commanders).toEqual(session.commanders);
+    expect(deck.mainboard).toEqual(session.mainboard);
+    expect(typeof deck.id).toBe("string");
+  });
+});

--- a/src/draft/draftSession.ts
+++ b/src/draft/draftSession.ts
@@ -13,6 +13,7 @@ import {
   type RankedCandidate,
 } from "./candidates";
 import { DEFAULT_BRACKET_TARGET, type BracketTarget } from "./bracket";
+import { draftCandidateCard } from "./localCandidates";
 
 export type DraftPhase = "commander-selection" | "drafting";
 
@@ -164,12 +165,9 @@ export class DraftSession {
     }
 
     this.target = target;
-    const resolvedMap = await this.deps.resolver.resolve(uniqueNames);
-    this.rememberResolved(resolvedMap.values());
-
-    const baseCards = uniqueNames
-      .map((name) => resolvedMap.get(name.toLowerCase()))
-      .filter((c): c is Card => c !== undefined);
+    const resolved = await this.deps.engine.resolveCards(uniqueNames);
+    const baseCards = resolved.map(draftCandidateCard);
+    this.rememberResolved(baseCards);
 
     if (commanderName) {
       const key = commanderName.trim().toLowerCase();

--- a/src/draft/draftSession.ts
+++ b/src/draft/draftSession.ts
@@ -7,6 +7,8 @@ import {
   suggestCandidates,
   suggestCommanders,
   createTokenSearchCache,
+  hasChooseABackground,
+  singleBackgroundAmong,
   type DraftEngine,
   type CardResolver,
   type RankedCandidate,
@@ -48,6 +50,8 @@ export interface DraftSessionDeps {
 export class DraftSession {
   phase: DraftPhase = "commander-selection";
   commander: Card | null = null;
+  /** The Background paired with `commander` via "Choose a Background", if any. */
+  background: Card | null = null;
   target: BracketTarget = DEFAULT_BRACKET_TARGET;
   commanders: DecklistEntry[] = [];
   mainboard: DecklistEntry[] = [];
@@ -68,6 +72,11 @@ export class DraftSession {
     return this.mainboard
       .map((entry) => this.resolved.get(entry.name.toLowerCase()))
       .filter((c): c is Card => c !== undefined);
+  }
+
+  /** `commander` plus `background`, when paired — for `extractThemeProfile`. */
+  private commanderCards(): Card[] {
+    return [this.commander, this.background].filter((c): c is Card => c !== null);
   }
 
   private deckNames(): { commanders: string[]; mainboard: string[] } {
@@ -176,14 +185,26 @@ export class DraftSession {
       if (!commanderCard) throw new DraftSessionError("commander-not-in-base-cards");
 
       const others = baseCards.filter((c) => c !== commanderCard);
+      const background = hasChooseABackground(commanderCard)
+        ? singleBackgroundAmong(others)
+        : null;
+      const mainboardCards = background ? others.filter((c) => c !== background) : others;
+
       this.commander = commanderCard;
-      this.commanders = [{ quantity: 1, name: commanderCard.name }];
-      this.mainboard = others.map((c) => ({ quantity: 1, name: c.name }));
+      this.background = background;
+      this.commanders = background
+        ? [
+            { quantity: 1, name: commanderCard.name },
+            { quantity: 1, name: background.name },
+          ]
+        : [{ quantity: 1, name: commanderCard.name }];
+      this.mainboard = mainboardCards.map((c) => ({ quantity: 1, name: c.name }));
       this.phase = "drafting";
-      this.profile = extractThemeProfile([commanderCard], others);
+      this.profile = extractThemeProfile(this.commanderCards(), mainboardCards);
       await this.openRound();
     } else {
       this.commander = null;
+      this.background = null;
       this.commanders = [];
       this.mainboard = baseCards.map((c) => ({ quantity: 1, name: c.name }));
       this.phase = "commander-selection";
@@ -207,12 +228,27 @@ export class DraftSession {
       card = resolvedMap.get(key);
     }
     if (!card) throw new DraftSessionError("commander-not-found");
+    this.rememberResolved([card]);
+
+    const background = hasChooseABackground(card)
+      ? singleBackgroundAmong(this.mainboardCards())
+      : null;
 
     this.commander = card;
-    this.commanders = [{ quantity: 1, name: card.name }];
-    this.rememberResolved([card]);
+    this.background = background;
+    if (background) {
+      this.commanders = [
+        { quantity: 1, name: card.name },
+        { quantity: 1, name: background.name },
+      ];
+      this.mainboard = this.mainboard.filter(
+        (e) => e.name.toLowerCase() !== background.name.toLowerCase(),
+      );
+    } else {
+      this.commanders = [{ quantity: 1, name: card.name }];
+    }
     this.phase = "drafting";
-    this.profile = extractThemeProfile([card], this.mainboardCards());
+    this.profile = extractThemeProfile(this.commanderCards(), this.mainboardCards());
     await this.openRound();
   }
 
@@ -254,10 +290,7 @@ export class DraftSession {
     }
     const card = this.round[index].card;
     this.addToMainboard(card);
-    this.profile = extractThemeProfile(
-      this.commander ? [this.commander] : [],
-      this.mainboardCards(),
-    );
+    this.profile = extractThemeProfile(this.commanderCards(), this.mainboardCards());
     await this.openRound();
   }
 

--- a/src/draft/draftSession.ts
+++ b/src/draft/draftSession.ts
@@ -96,7 +96,7 @@ export class DraftSession {
     this.mainboard.push({ quantity: 1, name: card.name });
   }
 
-  /** Fetch a fresh round: clears shown-this-round and offers up to three cards. */
+  /** Fetch a fresh round: clears shown-this-round and offers three cards. */
   private async openRound(): Promise<void> {
     this.shown = new Set();
     const deckNames = this.deckNames();
@@ -104,10 +104,9 @@ export class DraftSession {
     this.pool =
       this.phase === "commander-selection"
         ? await suggestCommanders(this.mainboardCards(), {
-            engine: this.deps.engine,
-            resolver: this.deps.resolver,
-            tokenCache: this.tokenCache,
-          })
+          engine: this.deps.engine,
+          resolver: this.deps.resolver,
+        })
         : await suggestCandidates(deckNames, this.profile, {
             engine: this.deps.engine,
             resolver: this.deps.resolver,
@@ -135,7 +134,6 @@ export class DraftSession {
             engine: this.deps.engine,
             resolver: this.deps.resolver,
             exclude,
-            tokenCache: this.tokenCache,
           })
         : await suggestCandidates(deckNames, this.profile, {
             engine: this.deps.engine,

--- a/src/draft/draftSession.ts
+++ b/src/draft/draftSession.ts
@@ -1,0 +1,286 @@
+import type { Card, DecklistEntry } from "../lib/types";
+import type { SavedDeck } from "../deck/model";
+import { deckToText } from "../deck/model";
+import { extractThemeProfile, type ThemeProfile } from "./themes";
+import { cardSimilarity } from "./similarity";
+import {
+  suggestCandidates,
+  suggestCommanders,
+  createTokenSearchCache,
+  type DraftEngine,
+  type CardResolver,
+  type RankedCandidate,
+  type TokenSearchCache,
+} from "./candidates";
+import { DEFAULT_BRACKET_TARGET, type BracketTarget } from "./bracket";
+
+export type DraftPhase = "commander-selection" | "drafting";
+
+export type DraftSessionErrorKind =
+  | "too-few-base-cards"
+  | "commander-not-in-base-cards"
+  | "commander-not-found"
+  | "not-in-commander-selection"
+  | "not-in-drafting"
+  | "invalid-slot";
+
+export class DraftSessionError extends Error {
+  constructor(readonly kind: DraftSessionErrorKind) {
+    super(kind);
+    this.name = "DraftSessionError";
+  }
+}
+
+const MIN_BASE_CARDS = 3;
+const ROUND_SIZE = 3;
+
+export interface DraftSessionDeps {
+  engine: DraftEngine;
+  resolver: CardResolver;
+}
+
+/**
+ * The in-progress `draft session` state machine (`draft-a-deck`): base cards,
+ * commander, bracket target, the deck so far, and the current suggestion
+ * round. Engine/resolver access is injected so the whole pipeline runs
+ * offline against fakes in tests.
+ */
+export class DraftSession {
+  phase: DraftPhase = "commander-selection";
+  commander: Card | null = null;
+  target: BracketTarget = DEFAULT_BRACKET_TARGET;
+  commanders: DecklistEntry[] = [];
+  mainboard: DecklistEntry[] = [];
+  round: RankedCandidate[] = [];
+  profile: ThemeProfile = extractThemeProfile([], []);
+
+  /** Every card resolved so far this session, by lowercase name — avoids re-fetching. */
+  private resolved = new Map<string, Card>();
+  /** The current round's full ranked pool, for refreshes to draw from without a re-query. */
+  private pool: RankedCandidate[] = [];
+  /** Names shown in the current round (refreshes included) — never repeated within it. */
+  private shown = new Set<string>();
+  private readonly tokenCache: TokenSearchCache = createTokenSearchCache();
+
+  constructor(private readonly deps: DraftSessionDeps) {}
+
+  private mainboardCards(): Card[] {
+    return this.mainboard
+      .map((entry) => this.resolved.get(entry.name.toLowerCase()))
+      .filter((c): c is Card => c !== undefined);
+  }
+
+  private deckNames(): { commanders: string[]; mainboard: string[] } {
+    return {
+      commanders: this.commanders.map((e) => e.name),
+      mainboard: this.mainboard.map((e) => e.name),
+    };
+  }
+
+  private rememberResolved(cards: Iterable<Card>): void {
+    for (const card of cards) this.resolved.set(card.name.toLowerCase(), card);
+  }
+
+  private addToMainboard(card: Card): void {
+    const key = card.name.toLowerCase();
+    if (this.mainboard.some((e) => e.name.toLowerCase() === key)) return;
+    this.mainboard.push({ quantity: 1, name: card.name });
+  }
+
+  /** Fetch a fresh round: clears shown-this-round and offers up to three cards. */
+  private async openRound(): Promise<void> {
+    this.shown = new Set();
+    const deckNames = this.deckNames();
+
+    this.pool =
+      this.phase === "commander-selection"
+        ? await suggestCommanders(this.mainboardCards(), {
+            engine: this.deps.engine,
+            resolver: this.deps.resolver,
+            tokenCache: this.tokenCache,
+          })
+        : await suggestCandidates(deckNames, this.profile, {
+            engine: this.deps.engine,
+            resolver: this.deps.resolver,
+            target: this.target,
+            tokenCache: this.tokenCache,
+          });
+
+    this.rememberResolved(this.pool.map((c) => c.card));
+    this.round = this.pool.slice(0, ROUND_SIZE);
+    for (const candidate of this.round) this.shown.add(candidate.card.name.toLowerCase());
+  }
+
+  /** Re-fetch the ranked pool, excluding the deck and everything shown this round. */
+  private async refillPool(): Promise<void> {
+    const deckNames = this.deckNames();
+    const exclude = new Set([
+      ...deckNames.commanders,
+      ...deckNames.mainboard,
+      ...this.shown,
+    ]);
+
+    const fresh =
+      this.phase === "commander-selection"
+        ? await suggestCommanders(this.mainboardCards(), {
+            engine: this.deps.engine,
+            resolver: this.deps.resolver,
+            exclude,
+            tokenCache: this.tokenCache,
+          })
+        : await suggestCandidates(deckNames, this.profile, {
+            engine: this.deps.engine,
+            resolver: this.deps.resolver,
+            target: this.target,
+            exclude,
+            tokenCache: this.tokenCache,
+          });
+
+    this.rememberResolved(fresh.map((c) => c.card));
+    const seen = new Set(this.pool.map((c) => c.card.name.toLowerCase()));
+    for (const candidate of fresh) {
+      const key = candidate.card.name.toLowerCase();
+      if (!seen.has(key)) {
+        this.pool.push(candidate);
+        seen.add(key);
+      }
+    }
+  }
+
+  /**
+   * Start a draft from three or more base cards. If `commanderName` names one
+   * of them, its color identity is fixed immediately and drafting opens;
+   * otherwise the first round offers commander-eligible candidates.
+   */
+  async start(
+    baseCardNames: string[],
+    commanderName: string | null = null,
+    target: BracketTarget = DEFAULT_BRACKET_TARGET,
+  ): Promise<void> {
+    const uniqueNames = [...new Set(baseCardNames.map((n) => n.trim()).filter(Boolean))];
+    if (uniqueNames.length < MIN_BASE_CARDS) {
+      throw new DraftSessionError("too-few-base-cards");
+    }
+
+    this.target = target;
+    const resolvedMap = await this.deps.resolver.resolve(uniqueNames);
+    this.rememberResolved(resolvedMap.values());
+
+    const baseCards = uniqueNames
+      .map((name) => resolvedMap.get(name.toLowerCase()))
+      .filter((c): c is Card => c !== undefined);
+
+    if (commanderName) {
+      const key = commanderName.trim().toLowerCase();
+      const commanderCard = baseCards.find((c) => c.name.toLowerCase() === key);
+      if (!commanderCard) throw new DraftSessionError("commander-not-in-base-cards");
+
+      const others = baseCards.filter((c) => c !== commanderCard);
+      this.commander = commanderCard;
+      this.commanders = [{ quantity: 1, name: commanderCard.name }];
+      this.mainboard = others.map((c) => ({ quantity: 1, name: c.name }));
+      this.phase = "drafting";
+      this.profile = extractThemeProfile([commanderCard], others);
+      await this.openRound();
+    } else {
+      this.commander = null;
+      this.commanders = [];
+      this.mainboard = baseCards.map((c) => ({ quantity: 1, name: c.name }));
+      this.phase = "commander-selection";
+      this.profile = extractThemeProfile([], baseCards);
+      await this.openRound();
+    }
+  }
+
+  /** Pick the commander from the commander-selection round, fixing color identity. */
+  async pickCommander(name: string): Promise<void> {
+    if (this.phase !== "commander-selection") {
+      throw new DraftSessionError("not-in-commander-selection");
+    }
+    const key = name.trim().toLowerCase();
+    let card =
+      this.round.find((c) => c.card.name.toLowerCase() === key)?.card ??
+      this.pool.find((c) => c.card.name.toLowerCase() === key)?.card ??
+      this.resolved.get(key);
+    if (!card) {
+      const resolvedMap = await this.deps.resolver.resolve([name]);
+      card = resolvedMap.get(key);
+    }
+    if (!card) throw new DraftSessionError("commander-not-found");
+
+    this.commander = card;
+    this.commanders = [{ quantity: 1, name: card.name }];
+    this.rememberResolved([card]);
+    this.phase = "drafting";
+    this.profile = extractThemeProfile([card], this.mainboardCards());
+    await this.openRound();
+  }
+
+  /** Replace one round slot with the closest unshown candidate. Never repeats within the round. */
+  async refreshSlot(index: number): Promise<void> {
+    if (index < 0 || index >= this.round.length) {
+      throw new DraftSessionError("invalid-slot");
+    }
+    const replaced = this.round[index].card;
+
+    let unshown = this.pool.filter((c) => !this.shown.has(c.card.name.toLowerCase()));
+    if (unshown.length === 0) {
+      await this.refillPool();
+      unshown = this.pool.filter((c) => !this.shown.has(c.card.name.toLowerCase()));
+    }
+    if (unshown.length === 0) return;
+
+    let best = unshown[0];
+    let bestSimilarity = cardSimilarity(replaced, best.card);
+    for (const candidate of unshown.slice(1)) {
+      const similarity = cardSimilarity(replaced, candidate.card);
+      if (similarity > bestSimilarity) {
+        best = candidate;
+        bestSimilarity = similarity;
+      }
+    }
+
+    this.round[index] = best;
+    this.shown.add(best.card.name.toLowerCase());
+  }
+
+  /** Add a round slot's card to the deck (the 99), end the round, and open a fresh one. */
+  async addCard(index: number): Promise<void> {
+    if (index < 0 || index >= this.round.length) {
+      throw new DraftSessionError("invalid-slot");
+    }
+    if (this.phase !== "drafting") {
+      throw new DraftSessionError("not-in-drafting");
+    }
+    const card = this.round[index].card;
+    this.addToMainboard(card);
+    this.profile = extractThemeProfile(
+      this.commander ? [this.commander] : [],
+      this.mainboardCards(),
+    );
+    await this.openRound();
+  }
+
+  /** Re-steer subsequent suggestion rounds toward a different bracket target. */
+  setBracketTarget(target: BracketTarget): void {
+    this.target = target;
+  }
+
+  /** The deck so far as paste-able decklist text (round-trips the parser). */
+  exportText(): string {
+    return deckToText({ commanders: this.commanders, mainboard: this.mainboard });
+  }
+
+  /** Build a `SavedDeck` from the current (possibly partial) deck. */
+  toSavedDeck(name: string): SavedDeck {
+    const now = Date.now();
+    return {
+      id: crypto.randomUUID(),
+      name,
+      commanders: this.commanders,
+      mainboard: this.mainboard,
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+}

--- a/src/draft/draftSession.ts
+++ b/src/draft/draftSession.ts
@@ -6,13 +6,11 @@ import { cardSimilarity } from "./similarity";
 import {
   suggestCandidates,
   suggestCommanders,
-  createTokenSearchCache,
   hasChooseABackground,
   singleBackgroundAmong,
   type DraftEngine,
   type CardResolver,
   type RankedCandidate,
-  type TokenSearchCache,
 } from "./candidates";
 import { DEFAULT_BRACKET_TARGET, type BracketTarget } from "./bracket";
 
@@ -64,8 +62,6 @@ export class DraftSession {
   private pool: RankedCandidate[] = [];
   /** Names shown in the current round (refreshes included) — never repeated within it. */
   private shown = new Set<string>();
-  private readonly tokenCache: TokenSearchCache = createTokenSearchCache();
-
   constructor(private readonly deps: DraftSessionDeps) {}
 
   private mainboardCards(): Card[] {
@@ -111,7 +107,6 @@ export class DraftSession {
             engine: this.deps.engine,
             resolver: this.deps.resolver,
             target: this.target,
-            tokenCache: this.tokenCache,
           });
 
     this.rememberResolved(this.pool.map((c) => c.card));
@@ -140,7 +135,6 @@ export class DraftSession {
             resolver: this.deps.resolver,
             target: this.target,
             exclude,
-            tokenCache: this.tokenCache,
           });
 
     this.rememberResolved(fresh.map((c) => c.card));

--- a/src/draft/localCandidates.test.ts
+++ b/src/draft/localCandidates.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import type { DraftCandidateData } from "../engine/draftQueries";
+import type { Card } from "../lib/types";
+import { rankLocalCandidates } from "./localCandidates";
+import { extractThemeProfile } from "./themes";
+
+function card(overrides: Partial<Card> = {}): Card {
+  return {
+    name: "Test Card",
+    manaValue: 2,
+    typeLine: "Artifact",
+    oracleText: "",
+    colors: ["U"],
+    colorIdentity: ["U"],
+    producedMana: [],
+    roles: ["other"],
+    ...overrides,
+  };
+}
+
+function candidate(source: Card): DraftCandidateData {
+  return {
+    name: source.name,
+    manaValue: source.manaValue,
+    typeLine: source.typeLine,
+    oracleText: source.oracleText,
+    colorIdentity: source.colorIdentity,
+  };
+}
+
+describe("rankLocalCandidates", () => {
+  const commander = card({
+    name: "Artifact Commander",
+    typeLine: "Legendary Artifact Creature — Vedalken",
+    oracleText: "Whenever an artifact enters, draw a card.",
+    colorIdentity: ["G", "U"],
+  });
+  const profile = extractThemeProfile([commander], []);
+
+  it("filters excluded and off-color cards before ranking", () => {
+    const included = card({
+      name: "Included Artifact",
+      oracleText: "Whenever another artifact enters, draw a card.",
+      colorIdentity: ["U"],
+    });
+    const colorless = card({ name: "Colorless Artifact", colorIdentity: [] });
+    const offColor = card({
+      name: "Off-color Artifact",
+      oracleText: included.oracleText,
+      colorIdentity: ["U", "R"],
+    });
+    const excluded = card({ name: "Already Selected", colorIdentity: ["U"] });
+
+    const ranked = rankLocalCandidates(
+      [included, colorless, offColor, excluded].map(candidate),
+      profile,
+      new Set([excluded.name.toLowerCase()]),
+    );
+
+    expect(ranked.map(({ card }) => card.name)).toEqual([
+      included.name,
+      colorless.name,
+    ]);
+  });
+
+  it("ranks shared themes above otherwise similar cards", () => {
+    const matching = card({
+      name: "Matching Artifact",
+      oracleText: "Whenever another artifact enters, draw a card.",
+      colorIdentity: ["U"],
+    });
+    const unrelated = card({
+      name: "Unrelated Creature",
+      typeLine: "Creature — Beast",
+      colorIdentity: ["U"],
+    });
+
+    const ranked = rankLocalCandidates(
+      [unrelated, matching].map(candidate),
+      profile,
+      new Set(),
+    );
+
+    expect(ranked[0].card.name).toBe(matching.name);
+    expect(ranked[0].score.matchedTokens).toEqual(
+      expect.arrayContaining(["artifact", "draw a card"]),
+    );
+  });
+});

--- a/src/draft/localCandidates.ts
+++ b/src/draft/localCandidates.ts
@@ -29,6 +29,7 @@ export function rankLocalCandidates(
   candidates: DraftCandidateData[],
   profile: ThemeProfile,
   excluded: Set<string>,
+  popularityBonus: (name: string) => number = () => 0,
 ): LocallyRankedCandidate[] {
   return candidates
     .map(draftCandidateCard)
@@ -38,5 +39,10 @@ export function rankLocalCandidates(
         card.colorIdentity.every((color) => profile.colorIdentity.includes(color)),
     )
     .map((card) => ({ card, score: scoreCandidate(card, profile) }))
-    .sort((a, b) => b.score.total - a.score.total);
+    .sort(
+      (a, b) =>
+        b.score.total +
+        popularityBonus(b.card.name) -
+        (a.score.total + popularityBonus(a.card.name)),
+    );
 }

--- a/src/draft/localCandidates.ts
+++ b/src/draft/localCandidates.ts
@@ -1,0 +1,42 @@
+import type { DraftCandidateData } from "../engine/draftQueries";
+import { classifyRoles } from "../lib/roles";
+import type { Card } from "../lib/types";
+import { scoreCandidate, type CandidateScore } from "./scoring";
+import type { ThemeProfile } from "./themes";
+
+export interface LocallyRankedCandidate {
+  card: Card;
+  score: CandidateScore;
+}
+
+export function draftCandidateCard(candidate: DraftCandidateData): Card {
+  const input = {
+    typeLine: candidate.typeLine,
+    oracleText: candidate.oracleText,
+    manaValue: candidate.manaValue,
+    producedMana: [],
+  };
+  return {
+    name: candidate.name,
+    ...input,
+    colors: [],
+    colorIdentity: candidate.colorIdentity,
+    roles: classifyRoles(input),
+  };
+}
+
+export function rankLocalCandidates(
+  candidates: DraftCandidateData[],
+  profile: ThemeProfile,
+  excluded: Set<string>,
+): LocallyRankedCandidate[] {
+  return candidates
+    .map(draftCandidateCard)
+    .filter(
+      (card) =>
+        !excluded.has(card.name.toLowerCase()) &&
+        card.colorIdentity.every((color) => profile.colorIdentity.includes(color)),
+    )
+    .map((card) => ({ card, score: scoreCandidate(card, profile) }))
+    .sort((a, b) => b.score.total - a.score.total);
+}

--- a/src/draft/scoring.test.ts
+++ b/src/draft/scoring.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { scoreCandidate } from "./scoring";
+import { extractThemeProfile } from "./themes";
+import type { Card } from "../lib/types";
+
+function card(overrides: Partial<Card> = {}): Card {
+  return {
+    name: "Test Card",
+    manaValue: 2,
+    typeLine: "Creature — Bear",
+    oracleText: "",
+    colors: [],
+    producedMana: [],
+    roles: ["other"],
+    ...overrides,
+  };
+}
+
+describe("scoreCandidate", () => {
+  it("scores higher for a candidate matching a commander-only token than a non-commander one of equal strength", () => {
+    const commander = card({ typeLine: "Legendary Creature — Goblin" });
+    const nonCommander = card({ typeLine: "Creature — Elf" });
+    const profile = extractThemeProfile([commander], [nonCommander]);
+
+    const goblinCandidate = card({
+      name: "Goblin Candidate",
+      typeLine: "Creature — Goblin",
+    });
+    const elfCandidate = card({
+      name: "Elf Candidate",
+      typeLine: "Creature — Elf",
+    });
+
+    const goblinScore = scoreCandidate(goblinCandidate, profile);
+    const elfScore = scoreCandidate(elfCandidate, profile);
+
+    expect(goblinScore.themeScore).toBeGreaterThan(elfScore.themeScore);
+    expect(goblinScore.total).toBeGreaterThan(elfScore.total);
+  });
+
+  it("reports matched tokens for rationale chips", () => {
+    const commander = card({ typeLine: "Legendary Creature — Goblin" });
+    const profile = extractThemeProfile([commander], []);
+    const candidate = card({ typeLine: "Creature — Goblin" });
+
+    const score = scoreCandidate(candidate, profile);
+    expect(score.matchedTokens).toEqual(["goblin"]);
+  });
+
+  it("favors a candidate that fills a thin spot in the curve", () => {
+    const others = [
+      card({ manaValue: 2 }),
+      card({ manaValue: 2 }),
+      card({ manaValue: 2 }),
+    ];
+    const profile = extractThemeProfile([], others);
+
+    const thinSpotCandidate = card({ manaValue: 5 });
+    const crowdedSpotCandidate = card({ manaValue: 2 });
+
+    const thinScore = scoreCandidate(thinSpotCandidate, profile);
+    const crowdedScore = scoreCandidate(crowdedSpotCandidate, profile);
+
+    expect(thinScore.curveScore).toBeGreaterThan(crowdedScore.curveScore);
+  });
+
+  it("favors a candidate filling a role the deck is short on", () => {
+    const others = [
+      card({ roles: ["ramp"] }),
+      card({ roles: ["ramp"] }),
+      card({ roles: ["ramp"] }),
+    ];
+    const profile = extractThemeProfile([], others);
+
+    const drawCandidate = card({ roles: ["draw"] });
+    const rampCandidate = card({ roles: ["ramp"] });
+
+    const drawScore = scoreCandidate(drawCandidate, profile);
+    const rampScore = scoreCandidate(rampCandidate, profile);
+
+    expect(drawScore.roleScore).toBeGreaterThan(rampScore.roleScore);
+  });
+
+  it("gives no role-gap credit for the catch-all 'other' role", () => {
+    const profile = extractThemeProfile([], [card({ roles: ["other"] })]);
+    const candidate = card({ roles: ["other"] });
+    expect(scoreCandidate(candidate, profile).roleScore).toBe(0);
+  });
+
+  it("does not throw scoring against an empty deck profile", () => {
+    const profile = extractThemeProfile([], []);
+    expect(() => scoreCandidate(card(), profile)).not.toThrow();
+  });
+
+  it("does not throw for a card with empty oracle text and type line", () => {
+    const profile = extractThemeProfile([], []);
+    const blank = card({ typeLine: "", oracleText: "" });
+    expect(() => scoreCandidate(blank, profile)).not.toThrow();
+  });
+});

--- a/src/draft/scoring.test.ts
+++ b/src/draft/scoring.test.ts
@@ -10,6 +10,7 @@ function card(overrides: Partial<Card> = {}): Card {
     typeLine: "Creature — Bear",
     oracleText: "",
     colors: [],
+    colorIdentity: [],
     producedMana: [],
     roles: ["other"],
     ...overrides,

--- a/src/draft/scoring.ts
+++ b/src/draft/scoring.ts
@@ -1,0 +1,68 @@
+import type { Card } from "../lib/types";
+import type { ThemeProfile } from "./themes";
+import { cardTokens } from "./tokens";
+
+const CURVE_FIT_WEIGHT = 2;
+const ROLE_GAP_WEIGHT = 2;
+
+export interface CandidateScore {
+  total: number;
+  themeScore: number;
+  curveScore: number;
+  roleScore: number;
+  /** Tokens the candidate shares with the deck's profile, for rationale chips. */
+  matchedTokens: string[];
+}
+
+/**
+ * Score a candidate's fit against a deck's `ThemeProfile`: shared theme
+ * tokens, plus a term for filling thin spots in the mana curve, plus a term
+ * for filling role gaps. Pure and deterministic.
+ */
+export function scoreCandidate(card: Card, profile: ThemeProfile): CandidateScore {
+  const { themeScore, matchedTokens } = themeFit(card, profile);
+  const curveScore = curveFit(card, profile);
+  const roleScore = roleGapFit(card, profile);
+
+  return {
+    total: themeScore + curveScore + roleScore,
+    themeScore,
+    curveScore,
+    roleScore,
+    matchedTokens,
+  };
+}
+
+function themeFit(
+  card: Card,
+  profile: ThemeProfile,
+): { themeScore: number; matchedTokens: string[] } {
+  let themeScore = 0;
+  const matchedTokens: string[] = [];
+  for (const token of cardTokens(card)) {
+    const weight = profile.tokenWeights.get(token);
+    if (weight) {
+      themeScore += weight;
+      matchedTokens.push(token);
+    }
+  }
+  matchedTokens.sort();
+  return { themeScore, matchedTokens };
+}
+
+function curveFit(card: Card, profile: ThemeProfile): number {
+  const bucket = Math.max(
+    0,
+    Math.min(profile.curve.length - 1, Math.floor(card.manaValue)),
+  );
+  return CURVE_FIT_WEIGHT / (profile.curve[bucket] + 1);
+}
+
+function roleGapFit(card: Card, profile: ThemeProfile): number {
+  let roleScore = 0;
+  for (const role of card.roles) {
+    if (role === "other") continue;
+    roleScore += ROLE_GAP_WEIGHT / (profile.roleCounts[role] + 1);
+  }
+  return roleScore;
+}

--- a/src/draft/similarity.test.ts
+++ b/src/draft/similarity.test.ts
@@ -9,6 +9,7 @@ function card(overrides: Partial<Card> = {}): Card {
     typeLine: "Creature — Bear",
     oracleText: "",
     colors: [],
+    colorIdentity: [],
     producedMana: [],
     roles: ["other"],
     ...overrides,

--- a/src/draft/similarity.test.ts
+++ b/src/draft/similarity.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { cardSimilarity } from "./similarity";
+import type { Card } from "../lib/types";
+
+function card(overrides: Partial<Card> = {}): Card {
+  return {
+    name: "Test Card",
+    manaValue: 2,
+    typeLine: "Creature — Bear",
+    oracleText: "",
+    colors: [],
+    producedMana: [],
+    roles: ["other"],
+    ...overrides,
+  };
+}
+
+describe("cardSimilarity", () => {
+  it("is 1 for identical cards", () => {
+    const a = card({ typeLine: "Creature — Goblin", oracleText: "Sacrifice a creature." });
+    const b = card({ typeLine: "Creature — Goblin", oracleText: "Sacrifice a creature." });
+    expect(cardSimilarity(a, b)).toBe(1);
+  });
+
+  it("is 0 for cards sharing no tokens", () => {
+    const a = card({ typeLine: "Creature — Goblin", oracleText: "" });
+    const b = card({ typeLine: "Creature — Elf", oracleText: "" });
+    expect(cardSimilarity(a, b)).toBe(0);
+  });
+
+  it("is symmetric", () => {
+    const a = card({ typeLine: "Creature — Goblin Warrior", oracleText: "Sacrifice a creature." });
+    const b = card({ typeLine: "Creature — Goblin", oracleText: "Draw a card." });
+    expect(cardSimilarity(a, b)).toBe(cardSimilarity(b, a));
+  });
+
+  it("stays within [0, 1]", () => {
+    const a = card({ typeLine: "Creature — Goblin Warrior", oracleText: "Sacrifice a creature. Draw a card." });
+    const b = card({ typeLine: "Creature — Goblin", oracleText: "Sacrifice a creature." });
+    const similarity = cardSimilarity(a, b);
+    expect(similarity).toBeGreaterThanOrEqual(0);
+    expect(similarity).toBeLessThanOrEqual(1);
+  });
+
+  it("scores partial overlap between 0 and 1", () => {
+    const a = card({ typeLine: "Creature — Goblin Warrior" });
+    const b = card({ typeLine: "Creature — Goblin" });
+    const similarity = cardSimilarity(a, b);
+    expect(similarity).toBeGreaterThan(0);
+    expect(similarity).toBeLessThan(1);
+  });
+
+  it("is 0 for two cards with no tokens at all", () => {
+    const a = card({ typeLine: "Sorcery", oracleText: "" });
+    const b = card({ typeLine: "Instant", oracleText: "" });
+    expect(cardSimilarity(a, b)).toBe(0);
+  });
+});

--- a/src/draft/similarity.ts
+++ b/src/draft/similarity.ts
@@ -1,0 +1,18 @@
+import type { Card } from "../lib/types";
+import { cardTokens } from "./tokens";
+
+/**
+ * Jaccard similarity of two cards' theme tokens, in [0, 1]. Used to pick the
+ * closest replacement when a `refresh` swaps out a suggested card.
+ */
+export function cardSimilarity(a: Card, b: Card): number {
+  const tokensA = cardTokens(a);
+  const tokensB = cardTokens(b);
+
+  let intersection = 0;
+  for (const token of tokensA) {
+    if (tokensB.has(token)) intersection++;
+  }
+  const union = tokensA.size + tokensB.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}

--- a/src/draft/themes.test.ts
+++ b/src/draft/themes.test.ts
@@ -9,6 +9,7 @@ function card(overrides: Partial<Card> = {}): Card {
     typeLine: "Creature — Bear",
     oracleText: "",
     colors: [],
+    colorIdentity: [],
     producedMana: [],
     roles: ["other"],
     ...overrides,
@@ -59,9 +60,9 @@ describe("extractThemeProfile", () => {
     expect(profile.roleCounts.removal).toBe(0);
   });
 
-  it("derives color identity from the commanders only", () => {
-    const commander = card({ colors: ["R", "G"] });
-    const others = [card({ colors: ["U"] })];
+  it("derives color identity from the commanders' colorIdentity only, not colors", () => {
+    const commander = card({ colors: [], colorIdentity: ["R", "G"] });
+    const others = [card({ colors: [], colorIdentity: ["U"] })];
     const profile = extractThemeProfile([commander], others);
     expect(profile.colorIdentity).toEqual(["G", "R"]);
   });

--- a/src/draft/themes.test.ts
+++ b/src/draft/themes.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { extractThemeProfile, COMMANDER_WEIGHT } from "./themes";
+import type { Card } from "../lib/types";
+
+function card(overrides: Partial<Card> = {}): Card {
+  return {
+    name: "Test Card",
+    manaValue: 2,
+    typeLine: "Creature — Bear",
+    oracleText: "",
+    colors: [],
+    producedMana: [],
+    roles: ["other"],
+    ...overrides,
+  };
+}
+
+describe("extractThemeProfile", () => {
+  it("weights a commander's tokens by COMMANDER_WEIGHT", () => {
+    const commander = card({
+      name: "Commander",
+      typeLine: "Legendary Creature — Goblin",
+    });
+    const profile = extractThemeProfile([commander], []);
+    expect(profile.tokenWeights.get("goblin")).toBe(COMMANDER_WEIGHT);
+  });
+
+  it("accumulates weight across commander and library copies of the same token", () => {
+    const commander = card({ typeLine: "Legendary Creature — Goblin" });
+    const others = [
+      card({ typeLine: "Creature — Goblin" }),
+      card({ typeLine: "Creature — Goblin" }),
+    ];
+    const profile = extractThemeProfile([commander], others);
+    expect(profile.tokenWeights.get("goblin")).toBe(COMMANDER_WEIGHT + 2);
+  });
+
+  it("builds a mana-value curve histogram, capping at 7+", () => {
+    const others = [
+      card({ manaValue: 1 }),
+      card({ manaValue: 1 }),
+      card({ manaValue: 9 }),
+    ];
+    const profile = extractThemeProfile([], others);
+    expect(profile.curve[1]).toBe(2);
+    expect(profile.curve[7]).toBe(1);
+    expect(profile.curve.reduce((a, b) => a + b, 0)).toBe(3);
+  });
+
+  it("counts roles from the resolved cards", () => {
+    const others = [
+      card({ roles: ["ramp"] }),
+      card({ roles: ["ramp"] }),
+      card({ roles: ["draw"] }),
+    ];
+    const profile = extractThemeProfile([], others);
+    expect(profile.roleCounts.ramp).toBe(2);
+    expect(profile.roleCounts.draw).toBe(1);
+    expect(profile.roleCounts.removal).toBe(0);
+  });
+
+  it("derives color identity from the commanders only", () => {
+    const commander = card({ colors: ["R", "G"] });
+    const others = [card({ colors: ["U"] })];
+    const profile = extractThemeProfile([commander], others);
+    expect(profile.colorIdentity).toEqual(["G", "R"]);
+  });
+
+  it("does not throw on an empty deck", () => {
+    expect(() => extractThemeProfile([], [])).not.toThrow();
+    const profile = extractThemeProfile([], []);
+    expect(profile.tokenWeights.size).toBe(0);
+    expect(profile.curve.every((n) => n === 0)).toBe(true);
+    expect(profile.colorIdentity).toEqual([]);
+  });
+});

--- a/src/draft/themes.ts
+++ b/src/draft/themes.ts
@@ -1,0 +1,80 @@
+import type { Card, CardRole } from "../lib/types";
+import { cardTokens } from "./tokens";
+
+/** How many times a commander's tokens count against the same token from the 99. */
+export const COMMANDER_WEIGHT = 3;
+
+/** Number of mana-value buckets in a curve histogram (0..6, plus a 7+ bucket). */
+const CURVE_BUCKETS = 8;
+
+export interface ThemeProfile {
+  tokenWeights: Map<string, number>;
+  /** Mana-value histogram, index 0..6 plus a 7+ bucket at index 7. */
+  curve: number[];
+  roleCounts: Record<CardRole, number>;
+  colorIdentity: string[];
+}
+
+/**
+ * Summarize a deck so far into the profile candidates get scored against:
+ * weighted theme tokens (`commander weighting` applied), the mana curve, role
+ * counts, and the commanders' color identity.
+ */
+export function extractThemeProfile(
+  commanders: Card[],
+  others: Card[],
+): ThemeProfile {
+  const tokenWeights = new Map<string, number>();
+  const curve = new Array(CURVE_BUCKETS).fill(0);
+  const roleCounts: Record<CardRole, number> = {
+    land: 0,
+    ramp: 0,
+    draw: 0,
+    removal: 0,
+    other: 0,
+  };
+
+  for (const card of commanders) {
+    addTokenWeights(tokenWeights, card, COMMANDER_WEIGHT);
+    addCurveAndRoles(curve, roleCounts, card);
+  }
+  for (const card of others) {
+    addTokenWeights(tokenWeights, card, 1);
+    addCurveAndRoles(curve, roleCounts, card);
+  }
+
+  return {
+    tokenWeights,
+    curve,
+    roleCounts,
+    colorIdentity: colorIdentityOf(commanders),
+  };
+}
+
+function addTokenWeights(
+  weights: Map<string, number>,
+  card: Card,
+  weight: number,
+): void {
+  for (const token of cardTokens(card)) {
+    weights.set(token, (weights.get(token) ?? 0) + weight);
+  }
+}
+
+function addCurveAndRoles(
+  curve: number[],
+  roleCounts: Record<CardRole, number>,
+  card: Card,
+): void {
+  const bucket = Math.max(0, Math.min(CURVE_BUCKETS - 1, Math.floor(card.manaValue)));
+  curve[bucket]++;
+  for (const role of card.roles) roleCounts[role]++;
+}
+
+function colorIdentityOf(commanders: Card[]): string[] {
+  const colors = new Set<string>();
+  for (const commander of commanders) {
+    for (const color of commander.colors) colors.add(color);
+  }
+  return [...colors].sort();
+}

--- a/src/draft/themes.ts
+++ b/src/draft/themes.ts
@@ -74,7 +74,7 @@ function addCurveAndRoles(
 function colorIdentityOf(commanders: Card[]): string[] {
   const colors = new Set<string>();
   for (const commander of commanders) {
-    for (const color of commander.colors) colors.add(color);
+    for (const color of commander.colorIdentity) colors.add(color);
   }
   return [...colors].sort();
 }

--- a/src/draft/tokens.test.ts
+++ b/src/draft/tokens.test.ts
@@ -9,6 +9,7 @@ function card(overrides: Partial<Card> = {}): Card {
     typeLine: "Creature — Bear",
     oracleText: "",
     colors: [],
+    colorIdentity: [],
     producedMana: [],
     roles: ["other"],
     ...overrides,

--- a/src/draft/tokens.test.ts
+++ b/src/draft/tokens.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { cardTokens } from "./tokens";
+import type { Card } from "../lib/types";
+
+function card(overrides: Partial<Card> = {}): Card {
+  return {
+    name: "Test Card",
+    manaValue: 2,
+    typeLine: "Creature — Bear",
+    oracleText: "",
+    colors: [],
+    producedMana: [],
+    roles: ["other"],
+    ...overrides,
+  };
+}
+
+describe("cardTokens", () => {
+  it("parses a single subtype", () => {
+    const tokens = cardTokens(card({ typeLine: "Creature — Goblin" }));
+    expect(tokens).toContain("goblin");
+  });
+
+  it("parses multiple subtypes", () => {
+    const tokens = cardTokens(card({ typeLine: "Creature — Elf Warrior" }));
+    expect(tokens).toContain("elf");
+    expect(tokens).toContain("warrior");
+  });
+
+  it("has no subtype tokens when the type line carries none", () => {
+    const tokens = cardTokens(card({ typeLine: "Sorcery" }));
+    expect(tokens.size).toBe(0);
+  });
+
+  it("parses subtypes from both faces of a DFC-ish type line", () => {
+    const tokens = cardTokens(
+      card({ typeLine: "Creature — Human Werewolf // Creature — Werewolf" }),
+    );
+    expect(tokens).toContain("human");
+    expect(tokens).toContain("werewolf");
+  });
+
+  it("lowercases subtypes", () => {
+    const tokens = cardTokens(card({ typeLine: "Artifact — Vehicle" }));
+    expect(tokens).toContain("vehicle");
+  });
+
+  it("matches an oracle-text pattern", () => {
+    const tokens = cardTokens(
+      card({ oracleText: "Put a +1/+1 counter on target creature." }),
+    );
+    expect(tokens).toContain("+1/+1 counter");
+  });
+
+  it("matches multiple independent oracle-text patterns", () => {
+    const tokens = cardTokens(
+      card({
+        oracleText:
+          "Sacrifice a creature. If you do, create a 1/1 white Spirit creature token and draw a card.",
+      }),
+    );
+    expect(tokens).toContain("sacrifice");
+    expect(tokens).toContain("create token");
+    expect(tokens).toContain("draw a card");
+  });
+
+  it("is case-insensitive on oracle text", () => {
+    const tokens = cardTokens(card({ oracleText: "GAIN 3 LIFE." }));
+    expect(tokens).toContain("gain life");
+  });
+
+  it("does not match an unrelated oracle-text pattern", () => {
+    const tokens = cardTokens(card({ oracleText: "Vigilance." }));
+    expect(tokens).not.toContain("landfall");
+    expect(tokens).not.toContain("mill");
+  });
+
+  it("does not throw on empty oracle text and type line", () => {
+    const blank = card({ typeLine: "", oracleText: "" });
+    expect(() => cardTokens(blank)).not.toThrow();
+    expect(cardTokens(blank).size).toBe(0);
+  });
+
+  it("combines subtype and oracle-text tokens", () => {
+    const tokens = cardTokens(
+      card({
+        typeLine: "Creature — Zombie",
+        oracleText: "When this creature dies, mill two cards.",
+      }),
+    );
+    expect(tokens).toContain("zombie");
+    expect(tokens).toContain("mill");
+  });
+});

--- a/src/draft/tokens.ts
+++ b/src/draft/tokens.ts
@@ -1,0 +1,90 @@
+import type { Card } from "../lib/types";
+
+/** One curated oracle-text signal: matching `pattern` contributes `token`. */
+export interface OracleTextPattern {
+  token: string;
+  pattern: RegExp;
+}
+
+/**
+ * The tunable lever of synergy quality (`deck-draft/ADR-0001`): salient
+ * oracle-text phrases mapped to the theme token they signal. Case-insensitive,
+ * no `g` flag (so `.test()` stays stateless across cards).
+ */
+export const ORACLE_TEXT_PATTERNS: OracleTextPattern[] = [
+  { token: "+1/+1 counter", pattern: /\+1\/\+1 counters?\b/i },
+  { token: "-1/-1 counter", pattern: /-1\/-1 counters?\b/i },
+  { token: "sacrifice", pattern: /\bsacrifice[sd]?\b/i },
+  { token: "create token", pattern: /\bcreates?\b[^.]*\btokens?\b/i },
+  {
+    token: "draw a card",
+    pattern: /\bdraws?\b (?:a|one|two|three|four|five|\d+|x) cards?/i,
+  },
+  { token: "discard a card", pattern: /\bdiscards?\b[^.]*\bcards?\b/i },
+  {
+    token: "landfall",
+    pattern: /\blandfall\b|\bwhenever (?:a|one or more) lands? (?:you control )?enters?\b/i,
+  },
+  { token: "graveyard", pattern: /\bgraveyard\b/i },
+  { token: "gain life", pattern: /\bgains?\b[^.]*\blife\b/i },
+  { token: "mill", pattern: /\bmill(?:s|ed|ing)?\b/i },
+  {
+    token: "artifact",
+    pattern: /\bartifacts? you control\b|\bwhenever an(?:other)? artifact\b/i,
+  },
+  {
+    token: "enchantment",
+    pattern: /\benchantments? you control\b|\bwhenever an(?:other)? enchantment\b/i,
+  },
+  { token: "treasure", pattern: /\btreasure tokens?\b/i },
+  { token: "exile", pattern: /\bexile\b/i },
+  { token: "proliferate", pattern: /\bproliferate\b/i },
+  {
+    token: "reanimate",
+    pattern: /return target creature card from (?:your|a) graveyard to the battlefield/i,
+  },
+  {
+    token: "cast from graveyard",
+    pattern: /\bcast\b[^.]* from (?:your|a) graveyard/i,
+  },
+  { token: "flying", pattern: /\bflying\b/i },
+  { token: "deathtouch", pattern: /\bdeathtouch\b/i },
+  { token: "lifelink", pattern: /\blifelink\b/i },
+  { token: "trample", pattern: /\btrample\b/i },
+  { token: "menace", pattern: /\bmenace\b/i },
+  { token: "first strike", pattern: /\bfirst strike\b/i },
+  { token: "double strike", pattern: /\bdouble strike\b/i },
+  { token: "haste", pattern: /\bhaste\b/i },
+  { token: "vigilance", pattern: /\bvigilance\b/i },
+  { token: "indestructible", pattern: /\bindestructible\b/i },
+  { token: "hexproof", pattern: /\bhexproof\b/i },
+  {
+    token: "extra combat step",
+    pattern: /\badditional combat phase\b|\bextra combat\b/i,
+  },
+  { token: "equip", pattern: /\bequip\b/i },
+  { token: "flash", pattern: /\bflash\b/i },
+  { token: "convoke", pattern: /\bconvoke\b/i },
+];
+
+function subtypesFromTypeLine(typeLine: string): string[] {
+  const tokens = new Set<string>();
+  for (const face of typeLine.split("//")) {
+    const parts = face.split("—");
+    if (parts.length < 2) continue;
+    for (const word of parts[parts.length - 1].trim().split(/\s+/)) {
+      const cleaned = word.toLowerCase();
+      if (cleaned) tokens.add(cleaned);
+    }
+  }
+  return [...tokens];
+}
+
+/** Extract a card's theme tokens: permanent subtypes plus oracle-text signals. */
+export function cardTokens(card: Card): Set<string> {
+  const tokens = new Set<string>(subtypesFromTypeLine(card.typeLine));
+  for (const { token, pattern } of ORACLE_TEXT_PATTERNS) {
+    if (pattern.test(card.oracleText)) tokens.add(token);
+  }
+  return tokens;
+}

--- a/src/engine/EngineClient.ts
+++ b/src/engine/EngineClient.ts
@@ -9,6 +9,7 @@ import type {
   BracketDeckInput,
   BracketEstimate,
   ClassifyDeckResult,
+  SearchCardRow,
   SearchCardsQuery,
   SearchCardsResult,
 } from "./draftQueries";
@@ -130,6 +131,10 @@ export class EngineClient {
   /** Game-independent commander eligibility check for a single card name. */
   isCommanderEligible(name: string): Promise<boolean> {
     return this.req("isCommanderEligible", { name });
+  }
+
+  commanderCandidates(): Promise<SearchCardRow[]> {
+    return this.req("commanderCandidates");
   }
 
   terminate(): void {

--- a/src/engine/EngineClient.ts
+++ b/src/engine/EngineClient.ts
@@ -9,7 +9,7 @@ import type {
   BracketDeckInput,
   BracketEstimate,
   ClassifyDeckResult,
-  SearchCardRow,
+  CommanderCandidateData,
   SearchCardsQuery,
   SearchCardsResult,
 } from "./draftQueries";
@@ -128,12 +128,7 @@ export class EngineClient {
     return this.req("classifyDeck", { names });
   }
 
-  /** Game-independent commander eligibility check for a single card name. */
-  isCommanderEligible(name: string): Promise<boolean> {
-    return this.req("isCommanderEligible", { name });
-  }
-
-  commanderCandidates(): Promise<SearchCardRow[]> {
+  commanderCandidates(): Promise<CommanderCandidateData[]> {
     return this.req("commanderCandidates");
   }
 

--- a/src/engine/EngineClient.ts
+++ b/src/engine/EngineClient.ts
@@ -9,9 +9,9 @@ import type {
   BracketDeckInput,
   BracketEstimate,
   ClassifyDeckResult,
-  CommanderCandidateData,
-  SearchCardsQuery,
-  SearchCardsResult,
+  DraftCandidateData,
+  RankCardCandidatesInput,
+  RankedCardName,
 } from "./draftQueries";
 
 interface Pending {
@@ -113,11 +113,6 @@ export class EngineClient {
     return this.req("aiProposal", { difficulty, player });
   }
 
-  /** Game-independent card search over the engine's own card database. */
-  searchCards(query: SearchCardsQuery): Promise<SearchCardsResult> {
-    return this.req("searchCards", query);
-  }
-
   /** Game-independent WotC bracket estimate for a (possibly partial) deck. */
   estimateBracket(deck: BracketDeckInput): Promise<BracketEstimate | null> {
     return this.req("estimateBracket", deck);
@@ -128,8 +123,12 @@ export class EngineClient {
     return this.req("classifyDeck", { names });
   }
 
-  commanderCandidates(): Promise<CommanderCandidateData[]> {
+  commanderCandidates(): Promise<DraftCandidateData[]> {
     return this.req("commanderCandidates");
+  }
+
+  rankCardCandidates(input: RankCardCandidatesInput): Promise<RankedCardName[]> {
+    return this.req("rankCardCandidates", input);
   }
 
   terminate(): void {

--- a/src/engine/EngineClient.ts
+++ b/src/engine/EngineClient.ts
@@ -5,6 +5,13 @@ import type {
   GameStateEnvelope,
   LogEntry,
 } from "./types";
+import type {
+  BracketDeckInput,
+  BracketEstimate,
+  ClassifyDeckResult,
+  SearchCardsQuery,
+  SearchCardsResult,
+} from "./draftQueries";
 
 interface Pending {
   resolve: (v: any) => void;
@@ -103,6 +110,21 @@ export class EngineClient {
     player: number,
   ): Promise<{ action: any }> {
     return this.req("aiProposal", { difficulty, player });
+  }
+
+  /** Game-independent card search over the engine's own card database. */
+  searchCards(query: SearchCardsQuery): Promise<SearchCardsResult> {
+    return this.req("searchCards", query);
+  }
+
+  /** Game-independent WotC bracket estimate for a (possibly partial) deck. */
+  estimateBracket(deck: BracketDeckInput): Promise<BracketEstimate | null> {
+    return this.req("estimateBracket", deck);
+  }
+
+  /** Game-independent archetype classification for a flat list of card names. */
+  classifyDeck(names: string[]): Promise<ClassifyDeckResult> {
+    return this.req("classifyDeck", { names });
   }
 
   terminate(): void {

--- a/src/engine/EngineClient.ts
+++ b/src/engine/EngineClient.ts
@@ -138,6 +138,11 @@ export class EngineClient {
     return this.req("validateCards", { names });
   }
 
+  /** Authoritative card data (color identity, type, oracle) from the engine DB. */
+  resolveCards(names: string[]): Promise<DraftCandidateData[]> {
+    return this.req("resolveCards", { names });
+  }
+
   rankCardCandidates(input: RankCardCandidatesInput): Promise<RankedCardName[]> {
     return this.req("rankCardCandidates", input);
   }

--- a/src/engine/EngineClient.ts
+++ b/src/engine/EngineClient.ts
@@ -127,6 +127,11 @@ export class EngineClient {
     return this.req("classifyDeck", { names });
   }
 
+  /** Game-independent commander eligibility check for a single card name. */
+  isCommanderEligible(name: string): Promise<boolean> {
+    return this.req("isCommanderEligible", { name });
+  }
+
   terminate(): void {
     this.worker.terminate();
     this.pending.clear();

--- a/src/engine/EngineClient.ts
+++ b/src/engine/EngineClient.ts
@@ -8,6 +8,7 @@ import type {
 import type {
   BracketDeckInput,
   BracketEstimate,
+  CardValidation,
   ClassifyDeckResult,
   DraftCandidateData,
   RankCardCandidatesInput,
@@ -125,6 +126,16 @@ export class EngineClient {
 
   commanderCandidates(): Promise<DraftCandidateData[]> {
     return this.req("commanderCandidates");
+  }
+
+  /** Local card-name suggestions from the engine's card database (no network). */
+  searchCardNames(text: string): Promise<string[]> {
+    return this.req("searchCardNames", { text });
+  }
+
+  /** Existence, Commander legality, and commander eligibility for each name. */
+  validateCards(names: string[]): Promise<CardValidation[]> {
+    return this.req("validateCards", { names });
   }
 
   rankCardCandidates(input: RankCardCandidatesInput): Promise<RankedCardName[]> {

--- a/src/engine/draftQueries.ts
+++ b/src/engine/draftQueries.ts
@@ -36,6 +36,17 @@ export interface DraftCandidateData {
   colorIdentity: string[];
 }
 
+export interface CardValidation {
+  /** The requested name, echoed back so callers can key on it. */
+  name: string;
+  /** The name is in the engine's card database. */
+  exists: boolean;
+  /** The card is legal in the Commander format. */
+  commanderLegal: boolean;
+  /** The card may be a commander (legendary creature or engine-eligible). */
+  commanderEligible: boolean;
+}
+
 export interface EngineThemeProfile {
   tokenWeights: Array<[string, number]>;
   curve: number[];

--- a/src/engine/draftQueries.ts
+++ b/src/engine/draftQueries.ts
@@ -6,6 +6,7 @@
 // docs/engine-upgrade.md). Game-independent: they need the card database
 // loaded but not a running game (deck-draft/ADR-0001, TDR-0001).
 
+import type { CardRole } from "../lib/types";
 import * as engineWasm from "./vendor/engine_wasm.js";
 
 export interface SearchCardsQuery {
@@ -27,12 +28,32 @@ export interface SearchCardsResult {
   total: number;
 }
 
-export interface CommanderCandidateData {
+export interface DraftCandidateData {
   name: string;
   manaValue: number;
   typeLine: string;
   oracleText: string;
   colorIdentity: string[];
+}
+
+export interface EngineThemeProfile {
+  tokenWeights: Array<[string, number]>;
+  curve: number[];
+  roleCounts: Record<CardRole, number>;
+  colorIdentity: string[];
+}
+
+export interface RankCardCandidatesInput {
+  commanders: string[];
+  mainboard: string[];
+  profile: EngineThemeProfile;
+  target: string;
+  exclude: string[];
+}
+
+export interface RankedCardName {
+  name: string;
+  bracketTilt: number;
 }
 
 export interface CardFaceData {

--- a/src/engine/draftQueries.ts
+++ b/src/engine/draftQueries.ts
@@ -1,0 +1,56 @@
+// Typed view over three phase-rs exports that are real in the vendored glue
+// (src/engine/vendor/engine_wasm.js) but absent from its regenerated
+// engine_wasm.d.ts (which types only the handful of functions the game
+// driver calls). Kept here, app-owned, so a future engine upgrade's
+// regenerated .d.ts never clobbers this typing (ADR-0006,
+// docs/engine-upgrade.md). Game-independent: they need the card database
+// loaded but not a running game (deck-draft/ADR-0001, TDR-0001).
+
+import * as engineWasm from "./vendor/engine_wasm.js";
+
+export interface SearchCardsQuery {
+  text?: string;
+  colors?: string[];
+  limit?: number;
+}
+
+export interface SearchCardRow {
+  name: string;
+  oracle_id: string;
+  mana_value: number;
+  color_identity: string[];
+  legalities: Record<string, string>;
+}
+
+export interface SearchCardsResult {
+  results: SearchCardRow[];
+  total: number;
+}
+
+export interface BracketDeckInput {
+  commander: string[];
+  main_deck?: string[];
+}
+
+export interface BracketEstimate {
+  tier: string;
+  axes: Record<string, unknown>;
+  axis_caps_at_tier: Record<string, unknown>;
+  contributing: Record<string, string[]>;
+  violations: Record<string, unknown>;
+  data_version: string;
+}
+
+export interface ClassifyDeckResult {
+  archetype: string;
+  confidence: string;
+  secondary?: string;
+}
+
+interface DraftQueryExports {
+  search_cards_js(query: SearchCardsQuery): SearchCardsResult;
+  estimate_bracket_for_deck(deck: BracketDeckInput): BracketEstimate | null;
+  classify_deck_js(names: string[]): ClassifyDeckResult;
+}
+
+export const draftQueries = engineWasm as unknown as DraftQueryExports;

--- a/src/engine/draftQueries.ts
+++ b/src/engine/draftQueries.ts
@@ -51,6 +51,13 @@ interface DraftQueryExports {
   search_cards_js(query: SearchCardsQuery): SearchCardsResult;
   estimate_bracket_for_deck(deck: BracketDeckInput): BracketEstimate | null;
   classify_deck_js(names: string[]): ClassifyDeckResult;
+  /**
+   * Single-arg form: true when the named card is legendary-creature-or-else
+   * commander-eligible. The two-arg `isCardCommanderEligibleForFormat` also
+   * exists in the vendored glue but a runtime spike found it unreliable, so
+   * this app only calls the single-arg form.
+   */
+  is_card_commander_eligible(name: string): boolean;
 }
 
 export const draftQueries = engineWasm as unknown as DraftQueryExports;

--- a/src/engine/draftQueries.ts
+++ b/src/engine/draftQueries.ts
@@ -27,6 +27,24 @@ export interface SearchCardsResult {
   total: number;
 }
 
+export interface CommanderCandidateData {
+  name: string;
+  manaValue: number;
+  typeLine: string;
+  oracleText: string;
+  colorIdentity: string[];
+}
+
+export interface CardFaceData {
+  name: string;
+  card_type?: {
+    supertypes?: string[];
+    core_types?: string[];
+    subtypes?: string[];
+  };
+  oracle_text?: string;
+}
+
 export interface BracketDeckInput {
   commander: string[];
   main_deck?: string[];
@@ -49,6 +67,7 @@ export interface ClassifyDeckResult {
 
 interface DraftQueryExports {
   search_cards_js(query: SearchCardsQuery): SearchCardsResult;
+  get_card_face_data(name: string): CardFaceData | null;
   estimate_bracket_for_deck(deck: BracketDeckInput): BracketEstimate | null;
   classify_deck_js(names: string[]): ClassifyDeckResult;
   /**

--- a/src/engine/engine.worker.ts
+++ b/src/engine/engine.worker.ts
@@ -16,6 +16,7 @@ import init, {
   get_legal_actions_js,
   submit_action,
 } from "./vendor/engine_wasm.js";
+import { draftQueries } from "./draftQueries";
 
 // Absolute base URL for engine assets, supplied by the main thread on "ready".
 // It must be resolved against the *page* location, not the worker's: a relative
@@ -121,6 +122,24 @@ async function handle(cmd: string, args: any): Promise<any> {
         logEntries: res?.log_entries ?? [],
         state: get_game_state(),
       };
+    }
+    case "searchCards": {
+      await ensureStarted();
+      await ensureDb();
+      const { text, colors, limit } = args ?? {};
+      return draftQueries.search_cards_js({ text, colors, limit });
+    }
+    case "estimateBracket": {
+      await ensureStarted();
+      await ensureDb();
+      const { commander, main_deck } = args ?? {};
+      return draftQueries.estimate_bracket_for_deck({ commander, main_deck });
+    }
+    case "classifyDeck": {
+      await ensureStarted();
+      await ensureDb();
+      const { names } = args ?? {};
+      return draftQueries.classify_deck_js(names ?? []);
     }
     default:
       throw new Error(`unknown engine command: ${cmd}`);

--- a/src/engine/engine.worker.ts
+++ b/src/engine/engine.worker.ts
@@ -17,7 +17,7 @@ import init, {
   submit_action,
 } from "./vendor/engine_wasm.js";
 import { draftQueries } from "./draftQueries";
-import type { SearchCardRow, SearchCardsQuery } from "./draftQueries";
+import type { CommanderCandidateData, SearchCardsQuery } from "./draftQueries";
 
 // Absolute base URL for engine assets, supplied by the main thread on "ready".
 // It must be resolved against the *page* location, not the worker's: a relative
@@ -28,7 +28,7 @@ let assetBase = import.meta.env.BASE_URL;
 let started = false;
 let dbLoaded = false;
 let commanderConfig: any = null;
-let cachedCommanderCandidates: SearchCardRow[] | null = null;
+let cachedCommanderCandidates: CommanderCandidateData[] | null = null;
 
 async function ensureStarted(): Promise<void> {
   if (started) return;
@@ -65,14 +65,32 @@ async function ensureDb(): Promise<void> {
   dbLoaded = true;
 }
 
-function commanderCandidates(): SearchCardRow[] {
+function cardTypeLine(cardType: NonNullable<ReturnType<typeof draftQueries.get_card_face_data>>["card_type"]): string {
+  const types = [...(cardType?.supertypes ?? []), ...(cardType?.core_types ?? [])];
+  const subtypes = cardType?.subtypes ?? [];
+  return subtypes.length > 0 ? `${types.join(" ")} — ${subtypes.join(" ")}` : types.join(" ");
+}
+
+function commanderCandidates(): CommanderCandidateData[] {
   if (cachedCommanderCandidates) return cachedCommanderCandidates;
   const allCards = draftQueries.search_cards_js({ limit: 100_000 }).results;
-  cachedCommanderCandidates = allCards.filter(
-    (card) =>
-      card.legalities?.commander === "legal" &&
-      draftQueries.is_card_commander_eligible(card.name),
-  );
+  cachedCommanderCandidates = allCards.flatMap((card) => {
+    if (
+      card.legalities?.commander !== "legal" ||
+      !draftQueries.is_card_commander_eligible(card.name)
+    ) {
+      return [];
+    }
+    const face = draftQueries.get_card_face_data(card.name);
+    if (!face) return [];
+    return [{
+      name: card.name,
+      manaValue: card.mana_value,
+      typeLine: cardTypeLine(face.card_type),
+      oracleText: face.oracle_text ?? "",
+      colorIdentity: card.color_identity,
+    }];
+  });
   return cachedCommanderCandidates;
 }
 
@@ -157,12 +175,6 @@ async function handle(cmd: string, args: any): Promise<any> {
       await ensureDb();
       const { names } = args ?? {};
       return draftQueries.classify_deck_js(names ?? []);
-    }
-    case "isCommanderEligible": {
-      await ensureStarted();
-      await ensureDb();
-      const { name } = args ?? {};
-      return draftQueries.is_card_commander_eligible(name);
     }
     case "commanderCandidates": {
       await ensureStarted();

--- a/src/engine/engine.worker.ts
+++ b/src/engine/engine.worker.ts
@@ -178,6 +178,18 @@ function validateCards(names: string[]): CardValidation[] {
   });
 }
 
+function resolveCards(names: string[]): DraftCandidateData[] {
+  const index = cardIndex();
+  return names.flatMap((name) => {
+    const row =
+      index.get(name.trim().toLowerCase()) ??
+      index.get(frontFace(name).toLowerCase());
+    if (!row) return [];
+    const candidate = candidateData(row);
+    return candidate ? [candidate] : [];
+  });
+}
+
 function commanderCandidates(): DraftCandidateData[] {
   if (cachedCommanderCandidates) return cachedCommanderCandidates;
   cachedCommanderCandidates = draftQueries
@@ -345,6 +357,11 @@ async function handle(cmd: string, args: any): Promise<any> {
       await ensureStarted();
       await ensureDb();
       return validateCards(args?.names ?? []);
+    }
+    case "resolveCards": {
+      await ensureStarted();
+      await ensureDb();
+      return resolveCards(args?.names ?? []);
     }
     case "rankCardCandidates": {
       await ensureStarted();

--- a/src/engine/engine.worker.ts
+++ b/src/engine/engine.worker.ts
@@ -42,9 +42,38 @@ let commanderConfig: any = null;
 let cachedCommanderCandidates: DraftCandidateData[] | null = null;
 const cachedThemeCandidates = new Map<string, DraftCandidateData[]>();
 const THEME_COUNT = 8;
-const THEME_SEARCH_LIMIT = 250;
+// A theme token's matches are sorted by popularity, then the top slice kept.
+// The scan pulls every match first so the slice is the most-played matches,
+// not an alphabetical prefix (a common token like "graveyard" has thousands).
+const TOKEN_MATCH_SCAN = 100_000;
+const THEME_CANDIDATES_PER_TOKEN = 250;
 const BRACKET_SHORTLIST_SIZE = 12;
 const ROUND_SIZE = 3;
+// How hard reprint frequency (our only in-data popularity proxy) tilts the
+// ranking. Applied to log2(1 + printings), so it nudges ties toward staples
+// without overriding a clearly better theme fit. Calibrated (0.75) against
+// EDHREC staple lists for popular commanders (deck-draft/ADR-0002).
+const POPULARITY_WEIGHT = 0.75;
+
+// Lowercase card name -> number of printings, our proxy for how played a card
+// is (EDHREC-style play-rate data is not in the card database). Built once from
+// the same card-data JSON the engine loads — no network, no Scryfall.
+let printingCounts = new Map<string, number>();
+
+function buildPopularityIndex(cardDataJson: string): void {
+  const data = JSON.parse(cardDataJson) as Record<string, any>;
+  const counts = new Map<string, number>();
+  for (const key of Object.keys(data)) {
+    const ids = data[key]?.metadata?.source_printing_ids;
+    counts.set(key.toLowerCase(), Array.isArray(ids) ? ids.length : 0);
+  }
+  printingCounts = counts;
+}
+
+function popularityBonus(name: string): number {
+  const printings = printingCounts.get(name.trim().toLowerCase()) ?? 0;
+  return POPULARITY_WEIGHT * Math.log2(1 + printings);
+}
 
 async function ensureStarted(): Promise<void> {
   if (started) return;
@@ -75,6 +104,7 @@ async function ensureDb(): Promise<void> {
   if (dbLoaded) return;
   const text = await fetchCardData();
   load_card_database(text);
+  buildPopularityIndex(text);
   const reg = getFormatRegistry();
   const list = Array.isArray(reg) ? reg : [];
   commanderConfig = list.find((f: any) => f?.format === "Commander")?.default_config;
@@ -175,9 +205,11 @@ function themeCandidates(profile: ThemeProfile): DraftCandidateData[] {
     let tokenCandidates = cachedThemeCandidates.get(token);
     if (!tokenCandidates) {
       tokenCandidates = draftQueries
-        .search_cards_js({ text: token, limit: THEME_SEARCH_LIMIT })
-        .results.flatMap((card) => {
-          if (card.legalities?.commander !== "legal") return [];
+        .search_cards_js({ text: token, limit: TOKEN_MATCH_SCAN })
+        .results.filter((card) => card.legalities?.commander === "legal")
+        .sort((a, b) => popularityBonus(b.name) - popularityBonus(a.name))
+        .slice(0, THEME_CANDIDATES_PER_TOKEN)
+        .flatMap((card) => {
           const candidate = candidateData(card);
           return candidate ? [candidate] : [];
         });
@@ -210,6 +242,7 @@ function rankedCardNames(args: {
     themeCandidates(profile),
     profile,
     excluded,
+    popularityBonus,
   ).slice(0, BRACKET_SHORTLIST_SIZE);
   return shortlist
     .map(({ card, score }) => {
@@ -218,7 +251,8 @@ function rankedCardNames(args: {
         main_deck: [...args.mainboard, card.name].map(frontFace),
       });
       const tilt = bracketTilt(estimate, args.target);
-      return { name: card.name, bracketTilt: tilt, total: score.total + tilt };
+      const total = score.total + popularityBonus(card.name) + tilt;
+      return { name: card.name, bracketTilt: tilt, total };
     })
     .sort((a, b) => b.total - a.total)
     .slice(0, ROUND_SIZE)

--- a/src/engine/engine.worker.ts
+++ b/src/engine/engine.worker.ts
@@ -141,6 +141,12 @@ async function handle(cmd: string, args: any): Promise<any> {
       const { names } = args ?? {};
       return draftQueries.classify_deck_js(names ?? []);
     }
+    case "isCommanderEligible": {
+      await ensureStarted();
+      await ensureDb();
+      const { name } = args ?? {};
+      return draftQueries.is_card_commander_eligible(name);
+    }
     default:
       throw new Error(`unknown engine command: ${cmd}`);
   }

--- a/src/engine/engine.worker.ts
+++ b/src/engine/engine.worker.ts
@@ -17,7 +17,15 @@ import init, {
   submit_action,
 } from "./vendor/engine_wasm.js";
 import { draftQueries } from "./draftQueries";
-import type { CommanderCandidateData, SearchCardsQuery } from "./draftQueries";
+import type {
+  DraftCandidateData,
+  EngineThemeProfile,
+  SearchCardRow,
+} from "./draftQueries";
+import { frontFace } from "../lib/cardName";
+import { bracketTilt, type BracketTarget } from "../draft/bracket";
+import { rankLocalCandidates } from "../draft/localCandidates";
+import type { ThemeProfile } from "../draft/themes";
 
 // Absolute base URL for engine assets, supplied by the main thread on "ready".
 // It must be resolved against the *page* location, not the worker's: a relative
@@ -28,7 +36,12 @@ let assetBase = import.meta.env.BASE_URL;
 let started = false;
 let dbLoaded = false;
 let commanderConfig: any = null;
-let cachedCommanderCandidates: CommanderCandidateData[] | null = null;
+let cachedCommanderCandidates: DraftCandidateData[] | null = null;
+const cachedThemeCandidates = new Map<string, DraftCandidateData[]>();
+const THEME_COUNT = 8;
+const THEME_SEARCH_LIMIT = 250;
+const BRACKET_SHORTLIST_SIZE = 12;
+const ROUND_SIZE = 3;
 
 async function ensureStarted(): Promise<void> {
   if (started) return;
@@ -71,27 +84,93 @@ function cardTypeLine(cardType: NonNullable<ReturnType<typeof draftQueries.get_c
   return subtypes.length > 0 ? `${types.join(" ")} — ${subtypes.join(" ")}` : types.join(" ");
 }
 
-function commanderCandidates(): CommanderCandidateData[] {
+function candidateData(card: SearchCardRow): DraftCandidateData | null {
+  const face = draftQueries.get_card_face_data(card.name);
+  if (!face) return null;
+  return {
+    name: card.name,
+    manaValue: card.mana_value,
+    typeLine: cardTypeLine(face.card_type),
+    oracleText: face.oracle_text ?? "",
+    colorIdentity: card.color_identity,
+  };
+}
+
+function commanderCandidates(): DraftCandidateData[] {
   if (cachedCommanderCandidates) return cachedCommanderCandidates;
-  const allCards = draftQueries.search_cards_js({ limit: 100_000 }).results;
-  cachedCommanderCandidates = allCards.flatMap((card) => {
-    if (
-      card.legalities?.commander !== "legal" ||
-      !draftQueries.is_card_commander_eligible(card.name)
-    ) {
-      return [];
-    }
-    const face = draftQueries.get_card_face_data(card.name);
-    if (!face) return [];
-    return [{
-      name: card.name,
-      manaValue: card.mana_value,
-      typeLine: cardTypeLine(face.card_type),
-      oracleText: face.oracle_text ?? "",
-      colorIdentity: card.color_identity,
-    }];
-  });
+  cachedCommanderCandidates = draftQueries
+    .search_cards_js({ limit: 100_000 })
+    .results.flatMap((card) => {
+      if (
+        card.legalities?.commander !== "legal" ||
+        !draftQueries.is_card_commander_eligible(card.name)
+      ) {
+        return [];
+      }
+      const candidate = candidateData(card);
+      return candidate ? [candidate] : [];
+    });
   return cachedCommanderCandidates;
+}
+
+function themeCandidates(profile: ThemeProfile): DraftCandidateData[] {
+  const tokens = [...profile.tokenWeights]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, THEME_COUNT)
+    .map(([token]) => token);
+  const candidates = new Map<string, DraftCandidateData>();
+  for (const token of tokens) {
+    let tokenCandidates = cachedThemeCandidates.get(token);
+    if (!tokenCandidates) {
+      tokenCandidates = draftQueries
+        .search_cards_js({ text: token, limit: THEME_SEARCH_LIMIT })
+        .results.flatMap((card) => {
+          if (card.legalities?.commander !== "legal") return [];
+          const candidate = candidateData(card);
+          return candidate ? [candidate] : [];
+        });
+      cachedThemeCandidates.set(token, tokenCandidates);
+    }
+    for (const candidate of tokenCandidates) {
+      candidates.set(candidate.name.toLowerCase(), candidate);
+    }
+  }
+  return [...candidates.values()];
+}
+
+function themeProfile(profile: EngineThemeProfile): ThemeProfile {
+  return {
+    ...profile,
+    tokenWeights: new Map(profile.tokenWeights),
+  };
+}
+
+function rankedCardNames(args: {
+  commanders: string[];
+  mainboard: string[];
+  profile: EngineThemeProfile;
+  target: BracketTarget;
+  exclude: string[];
+}): Array<{ name: string; bracketTilt: number }> {
+  const profile = themeProfile(args.profile);
+  const excluded = new Set(args.exclude.map((name) => name.toLowerCase()));
+  const shortlist = rankLocalCandidates(
+    themeCandidates(profile),
+    profile,
+    excluded,
+  ).slice(0, BRACKET_SHORTLIST_SIZE);
+  return shortlist
+    .map(({ card, score }) => {
+      const estimate = draftQueries.estimate_bracket_for_deck({
+        commander: args.commanders.map(frontFace),
+        main_deck: [...args.mainboard, card.name].map(frontFace),
+      });
+      const tilt = bracketTilt(estimate, args.target);
+      return { name: card.name, bracketTilt: tilt, total: score.total + tilt };
+    })
+    .sort((a, b) => b.total - a.total)
+    .slice(0, ROUND_SIZE)
+    .map(({ name, bracketTilt: tilt }) => ({ name, bracketTilt: tilt }));
 }
 
 async function handle(cmd: string, args: any): Promise<any> {
@@ -154,16 +233,6 @@ async function handle(cmd: string, args: any): Promise<any> {
         state: get_game_state(),
       };
     }
-    case "searchCards": {
-      await ensureStarted();
-      await ensureDb();
-      const { text, colors, limit } = args ?? {};
-      const query: SearchCardsQuery = {};
-      if (text !== undefined) query.text = text;
-      if (colors !== undefined) query.colors = colors;
-      if (limit !== undefined) query.limit = limit;
-      return draftQueries.search_cards_js(query);
-    }
     case "estimateBracket": {
       await ensureStarted();
       await ensureDb();
@@ -180,6 +249,11 @@ async function handle(cmd: string, args: any): Promise<any> {
       await ensureStarted();
       await ensureDb();
       return commanderCandidates();
+    }
+    case "rankCardCandidates": {
+      await ensureStarted();
+      await ensureDb();
+      return rankedCardNames(args);
     }
     default:
       throw new Error(`unknown engine command: ${cmd}`);

--- a/src/engine/engine.worker.ts
+++ b/src/engine/engine.worker.ts
@@ -17,7 +17,7 @@ import init, {
   submit_action,
 } from "./vendor/engine_wasm.js";
 import { draftQueries } from "./draftQueries";
-import type { SearchCardsQuery } from "./draftQueries";
+import type { SearchCardRow, SearchCardsQuery } from "./draftQueries";
 
 // Absolute base URL for engine assets, supplied by the main thread on "ready".
 // It must be resolved against the *page* location, not the worker's: a relative
@@ -28,6 +28,7 @@ let assetBase = import.meta.env.BASE_URL;
 let started = false;
 let dbLoaded = false;
 let commanderConfig: any = null;
+let cachedCommanderCandidates: SearchCardRow[] | null = null;
 
 async function ensureStarted(): Promise<void> {
   if (started) return;
@@ -62,6 +63,17 @@ async function ensureDb(): Promise<void> {
   const list = Array.isArray(reg) ? reg : [];
   commanderConfig = list.find((f: any) => f?.format === "Commander")?.default_config;
   dbLoaded = true;
+}
+
+function commanderCandidates(): SearchCardRow[] {
+  if (cachedCommanderCandidates) return cachedCommanderCandidates;
+  const allCards = draftQueries.search_cards_js({ limit: 100_000 }).results;
+  cachedCommanderCandidates = allCards.filter(
+    (card) =>
+      card.legalities?.commander === "legal" &&
+      draftQueries.is_card_commander_eligible(card.name),
+  );
+  return cachedCommanderCandidates;
 }
 
 async function handle(cmd: string, args: any): Promise<any> {
@@ -151,6 +163,11 @@ async function handle(cmd: string, args: any): Promise<any> {
       await ensureDb();
       const { name } = args ?? {};
       return draftQueries.is_card_commander_eligible(name);
+    }
+    case "commanderCandidates": {
+      await ensureStarted();
+      await ensureDb();
+      return commanderCandidates();
     }
     default:
       throw new Error(`unknown engine command: ${cmd}`);

--- a/src/engine/engine.worker.ts
+++ b/src/engine/engine.worker.ts
@@ -17,6 +17,7 @@ import init, {
   submit_action,
 } from "./vendor/engine_wasm.js";
 import { draftQueries } from "./draftQueries";
+import type { SearchCardsQuery } from "./draftQueries";
 
 // Absolute base URL for engine assets, supplied by the main thread on "ready".
 // It must be resolved against the *page* location, not the worker's: a relative
@@ -127,7 +128,11 @@ async function handle(cmd: string, args: any): Promise<any> {
       await ensureStarted();
       await ensureDb();
       const { text, colors, limit } = args ?? {};
-      return draftQueries.search_cards_js({ text, colors, limit });
+      const query: SearchCardsQuery = {};
+      if (text !== undefined) query.text = text;
+      if (colors !== undefined) query.colors = colors;
+      if (limit !== undefined) query.limit = limit;
+      return draftQueries.search_cards_js(query);
     }
     case "estimateBracket": {
       await ensureStarted();

--- a/src/engine/engine.worker.ts
+++ b/src/engine/engine.worker.ts
@@ -18,6 +18,7 @@ import init, {
 } from "./vendor/engine_wasm.js";
 import { draftQueries } from "./draftQueries";
 import type {
+  CardValidation,
   DraftCandidateData,
   EngineThemeProfile,
   SearchCardRow,
@@ -25,6 +26,8 @@ import type {
 import { frontFace } from "../lib/cardName";
 import { bracketTilt, type BracketTarget } from "../draft/bracket";
 import { rankLocalCandidates } from "../draft/localCandidates";
+import { rankNameSuggestions } from "../draft/cardNameSuggest";
+import { isCommanderLegal, isCommanderEligible } from "../draft/cardLegality";
 import type { ThemeProfile } from "../draft/themes";
 
 // Absolute base URL for engine assets, supplied by the main thread on "ready".
@@ -94,6 +97,55 @@ function candidateData(card: SearchCardRow): DraftCandidateData | null {
     oracleText: face.oracle_text ?? "",
     colorIdentity: card.color_identity,
   };
+}
+
+// The engine's free-text search matches name *and* oracle text and returns many
+// alphabetical rows; `rankNameSuggestions` narrows that to a ranked name list.
+// Pull a generous slice so a name match isn't cut off before it can be ranked.
+const NAME_SUGGEST_SCAN = 2500;
+
+function searchCardNames(query: string): string[] {
+  if (query.trim().length < 2) return [];
+  const rows = draftQueries.search_cards_js({
+    text: query.trim(),
+    limit: NAME_SUGGEST_SCAN,
+  }).results;
+  return rankNameSuggestions(rows, query);
+}
+
+// Name -> search row, for O(1) existence and legality checks. Built from one
+// full scan and reused (the card database is static).
+let cachedCardIndex: Map<string, SearchCardRow> | null = null;
+function cardIndex(): Map<string, SearchCardRow> {
+  if (!cachedCardIndex) {
+    cachedCardIndex = new Map(
+      draftQueries
+        .search_cards_js({ limit: 100_000 })
+        .results.map((row) => [row.name.toLowerCase(), row]),
+    );
+  }
+  return cachedCardIndex;
+}
+
+function validateCards(names: string[]): CardValidation[] {
+  const index = cardIndex();
+  return names.map((name) => {
+    const row =
+      index.get(name.trim().toLowerCase()) ??
+      index.get(frontFace(name).toLowerCase());
+    const exists = row !== undefined;
+    const face =
+      draftQueries.get_card_face_data(name) ??
+      draftQueries.get_card_face_data(frontFace(name));
+    return {
+      name,
+      exists,
+      commanderLegal: isCommanderLegal(row),
+      commanderEligible:
+        exists &&
+        isCommanderEligible(draftQueries.is_card_commander_eligible(name), face),
+    };
+  });
 }
 
 function commanderCandidates(): DraftCandidateData[] {
@@ -249,6 +301,16 @@ async function handle(cmd: string, args: any): Promise<any> {
       await ensureStarted();
       await ensureDb();
       return commanderCandidates();
+    }
+    case "searchCardNames": {
+      await ensureStarted();
+      await ensureDb();
+      return searchCardNames(args?.text ?? "");
+    }
+    case "validateCards": {
+      await ensureStarted();
+      await ensureDb();
+      return validateCards(args?.names ?? []);
     }
     case "rankCardCandidates": {
       await ensureStarted();

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -48,6 +48,7 @@ export const messages = {
 
   "deck.noCommander": { pt: "sem comandante", en: "no commander" },
   "deck.cards": { pt: "{n} cartas", en: "{n} cards" },
+  "deck.partial": { pt: "Incompleto", en: "Partial" },
 
   "editor.editTitle": { pt: "Editar deck", en: "Edit deck" },
   "editor.newTitle": { pt: "Novo deck", en: "New deck" },
@@ -60,9 +61,9 @@ export const messages = {
   },
   "editor.linesUnread": { pt: "{n} linhas não lidas", en: "{n} lines not read" },
   "editor.unread": { pt: "Não lidas: {list}", en: "Not read: {list}" },
-  "editor.needHundred": {
-    pt: "Um deck de Commander precisa de exatamente 100 cartas (comandante + 99). Este tem {n}.",
-    en: "A Commander deck needs exactly 100 cards (commander + 99). This one has {n}.",
+  "editor.needHundredWarning": {
+    pt: "Um deck de Commander precisa de exatamente 100 cartas (comandante + 99). Este tem {n} — pode salvar como rascunho, mas não poderá ser jogado até completar.",
+    en: "A Commander deck needs exactly 100 cards (commander + 99). This one has {n} — you can save it as a draft, but it can't be played until it's complete.",
   },
   "editor.untitled": { pt: "Deck sem nome", en: "Untitled deck" },
   "editor.save": { pt: "Salvar deck", en: "Save deck" },
@@ -116,6 +117,10 @@ export const messages = {
   "detail.back": { pt: "← Voltar", en: "← Back" },
   "detail.play": { pt: "Testar em partida →", en: "Test in a match →" },
   "detail.notFound": { pt: "{n} não encontradas", en: "{n} not found" },
+  "detail.partialReason": {
+    pt: "Este deck está incompleto e não pode ser jogado até ter exatamente 100 cartas.",
+    en: "This deck is partial and can't be played until it has exactly 100 cards.",
+  },
 
   "setup.title": { pt: "Configurar partida", en: "Match setup" },
   "setup.yourDeck": { pt: "Seu deck", en: "Your deck" },
@@ -124,6 +129,11 @@ export const messages = {
   "setup.opponents": { pt: "Oponentes (IA)", en: "Opponents (AI)" },
   "setup.opponentN": { pt: "Oponente {n}", en: "Opponent {n}" },
   "setup.needOpponent": { pt: "Crie outro deck para usar como oponente.", en: "Create another deck to use as an opponent." },
+  "setup.partialSuffix": { pt: " (incompleto)", en: " (partial)" },
+  "setup.partialChosen": {
+    pt: "Um dos decks escolhidos está incompleto e não pode ser jogado. Complete-o ou escolha outro.",
+    en: "One of the chosen decks is partial and can't be played. Complete it or choose another.",
+  },
   "setup.mode": { pt: "Modo", en: "Mode" },
   "setup.modePlay": { pt: "Jogar (você pilota)", en: "Play (you pilot)" },
   "setup.modeWatch": { pt: "Assistir (IA joga)", en: "Watch (AI plays)" },

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -428,6 +428,102 @@ export const messages = {
   "goldfish.compRemoval": { pt: "Interação/removal", en: "Interaction/removal" },
   "goldfish.compAvgMv": { pt: "MV médio (não-terreno)", en: "Average MV (nonland)" },
   "goldfish.curve": { pt: "Curva de mana", en: "Mana curve" },
+
+  "library.draft": { pt: "+ Draft de deck", en: "+ Draft a deck" },
+
+  "draft.windowTitle": { pt: "Draft de deck", en: "Deck draft" },
+
+  "draft.entry.title": { pt: "Draft de deck", en: "Draft a deck" },
+  "draft.entry.subtitle": {
+    pt: "Informe três ou mais cartas para dar o tema do deck. Você pode marcar uma delas como comandante.",
+    en: "Enter three or more cards to seed the deck's theme. You can flag one of them as the commander.",
+  },
+  "draft.entry.baseCardsLabel": { pt: "Cartas base", en: "Base cards" },
+  "draft.entry.baseCardPlaceholder": { pt: "Nome da carta", en: "Card name" },
+  "draft.entry.commanderFlag": { pt: "Comandante", en: "Commander" },
+  "draft.entry.unflag": { pt: "Remover", en: "Unflag" },
+  "draft.entry.removeCard": { pt: "Remover carta", en: "Remove card" },
+  "draft.entry.addCard": { pt: "+ Adicionar carta", en: "+ Add another card" },
+  "draft.entry.bracketLabel": { pt: "Bracket alvo", en: "Bracket target" },
+  "draft.entry.start": { pt: "Iniciar draft", en: "Start draft" },
+  "draft.entry.checking": { pt: "Verificando cartas…", en: "Checking cards…" },
+  "draft.entry.starting": {
+    pt: "Iniciando — carregando o motor e o banco de cartas (pode demorar na primeira vez)…",
+    en: "Starting — loading the engine and card database (may take a while the first time)…",
+  },
+  "draft.entry.cancel": { pt: "Cancelar", en: "Cancel" },
+  "draft.entry.tooFew": {
+    pt: "Informe pelo menos três cartas (faltam {n}).",
+    en: "Enter at least three cards ({n} more needed).",
+  },
+  "draft.entry.tooFewResolved": {
+    pt: "Pelo menos três cartas precisam ser encontradas no Scryfall para iniciar.",
+    en: "At least three cards need to resolve on Scryfall to start.",
+  },
+  "draft.entry.unresolved": { pt: "Não encontradas: {list}", en: "Not found: {list}" },
+  "draft.entry.startFailed": {
+    pt: "Não foi possível iniciar o draft.",
+    en: "Couldn't start the draft.",
+  },
+
+  "draft.commander.title": { pt: "Escolha o comandante", en: "Choose your commander" },
+  "draft.commander.hint": {
+    pt: "Nenhuma carta base foi marcada como comandante — escolha uma abaixo para fixar a identidade de cor do deck.",
+    en: "No base card was flagged as commander — pick one below to fix the deck's color identity.",
+  },
+  "draft.commander.choose": { pt: "Escolher", en: "Choose" },
+  "draft.commander.empty": {
+    pt: "Nenhum candidato a comandante encontrado para essas cartas.",
+    en: "No commander candidates found for these cards.",
+  },
+
+  "draft.summary.cards": { pt: "{n}/100 cartas", en: "{n}/100 cards" },
+  "draft.summary.commander": { pt: "Comandante: {name}", en: "Commander: {name}" },
+  "draft.summary.colorIdentity": { pt: "Identidade: {list}", en: "Identity: {list}" },
+  "draft.summary.archetype": { pt: "Arquétipo: {name}", en: "Archetype: {name}" },
+  "draft.summary.bracket": { pt: "Bracket: {tier}", en: "Bracket: {tier}" },
+  "draft.summary.bracketTarget": { pt: "Bracket alvo", en: "Bracket target" },
+  "draft.summary.targetHint": {
+    pt: "Vale a partir da próxima rodada de sugestões.",
+    en: "Applies starting with the next round of suggestions.",
+  },
+
+  "draft.round.title": { pt: "Sugestões", en: "Suggestions" },
+  "draft.round.loadingNext": {
+    pt: "Buscando a próxima rodada…",
+    en: "Fetching the next round…",
+  },
+  "draft.round.empty": {
+    pt: "Nenhuma sugestão disponível agora. Tente atualizar ou mudar o bracket alvo.",
+    en: "No suggestions available right now. Try refreshing or changing the bracket target.",
+  },
+  "draft.round.add": { pt: "Adicionar", en: "Add" },
+  "draft.round.refresh": { pt: "Atualizar", en: "Refresh" },
+  "draft.round.tiltNote": {
+    pt: "Passaria do bracket alvo — por isso rankeada mais abaixo.",
+    en: "Would push past the bracket target — ranked lower for it.",
+  },
+  "draft.round.actionFailed": {
+    pt: "Não foi possível completar a ação. Tente novamente.",
+    en: "Couldn't complete that action. Try again.",
+  },
+
+  "draft.leave.title": { pt: "Sair do draft", en: "Leave the draft" },
+  "draft.leave.copy": { pt: "Copiar lista", en: "Copy list" },
+  "draft.leave.copied": { pt: "Copiado!", en: "Copied!" },
+  "draft.leave.nameLabel": { pt: "Nome do deck", en: "Deck name" },
+  "draft.leave.save": { pt: "Salvar na biblioteca", en: "Save to library" },
+  "draft.leave.back": { pt: "← Voltar para a biblioteca", en: "← Back to library" },
+  "draft.leave.partialHint": {
+    pt: "Ainda não tem 100 cartas — será salvo como incompleto e marcado até ser completado.",
+    en: "Not yet 100 cards — this will save as partial and stay flagged until it's complete.",
+  },
+
+  "draft.bracket.exhibition": { pt: "Exibição", en: "Exhibition" },
+  "draft.bracket.core": { pt: "Essencial", en: "Core" },
+  "draft.bracket.focused": { pt: "Focado", en: "Focused" },
+  "draft.bracket.optimized": { pt: "Otimizado", en: "Optimized" },
+  "draft.bracket.cedh": { pt: "cEDH", en: "cEDH" },
 } satisfies Record<string, Entry>;
 
 export type MsgKey = keyof typeof messages;

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -69,6 +69,10 @@ export const messages = {
   "editor.save": { pt: "Salvar deck", en: "Save deck" },
   "editor.cancel": { pt: "Cancelar", en: "Cancel" },
   "editor.loadSample": { pt: "Carregar exemplo", en: "Load example" },
+  "editor.draftFromDeck": {
+    pt: "Draft a partir deste deck",
+    en: "Draft from this deck",
+  },
 
   "import.label": { pt: "Importar de uma URL", en: "Import from a URL" },
   "import.placeholder": {
@@ -440,6 +444,21 @@ export const messages = {
   },
   "draft.entry.baseCardsLabel": { pt: "Cartas base", en: "Base cards" },
   "draft.entry.baseCardPlaceholder": { pt: "Nome da carta", en: "Card name" },
+  "draft.entry.modeRows": { pt: "Uma a uma", en: "One by one" },
+  "draft.entry.modePaste": { pt: "Colar lista", en: "Paste a list" },
+  "draft.entry.commanderLabel": {
+    pt: "Comandante (opcional)",
+    en: "Commander (optional)",
+  },
+  "draft.entry.noCommander": { pt: "— Sem comandante —", en: "— No commander —" },
+  "draft.entry.commanderSearchPlaceholder": {
+    pt: "Escolher comandante…",
+    en: "Pick a commander…",
+  },
+  "draft.entry.commanderNoMatch": {
+    pt: "Nenhuma carta corresponde",
+    en: "No matching card",
+  },
   "draft.entry.commanderFlag": { pt: "Comandante", en: "Commander" },
   "draft.entry.unflag": { pt: "Remover", en: "Unflag" },
   "draft.entry.removeCard": { pt: "Remover carta", en: "Remove card" },

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -450,7 +450,10 @@ export const messages = {
     pt: "Comandante (opcional)",
     en: "Commander (optional)",
   },
-  "draft.entry.noCommander": { pt: "— Sem comandante —", en: "— No commander —" },
+  "draft.entry.commanderNone": {
+    pt: "Nenhum comandante elegível nesta lista",
+    en: "No eligible commander in this list",
+  },
   "draft.entry.commanderSearchPlaceholder": {
     pt: "Escolher comandante…",
     en: "Pick a commander…",
@@ -461,6 +464,7 @@ export const messages = {
   },
   "draft.entry.commanderFlag": { pt: "Comandante", en: "Commander" },
   "draft.entry.unflag": { pt: "Remover", en: "Unflag" },
+  "draft.entry.clearCommander": { pt: "Limpar comandante", en: "Clear commander" },
   "draft.entry.removeCard": { pt: "Remover carta", en: "Remove card" },
   "draft.entry.addCard": { pt: "+ Adicionar carta", en: "+ Add another card" },
   "draft.entry.bracketLabel": { pt: "Bracket alvo", en: "Bracket target" },
@@ -480,6 +484,14 @@ export const messages = {
     en: "At least three cards need to resolve on Scryfall to start.",
   },
   "draft.entry.unresolved": { pt: "Não encontradas: {list}", en: "Not found: {list}" },
+  "draft.entry.notFoundCards": {
+    pt: "Não existem no banco de cartas: {list}",
+    en: "Not in the card database: {list}",
+  },
+  "draft.entry.notLegalCards": {
+    pt: "Não permitidas em Commander: {list}",
+    en: "Not legal in Commander: {list}",
+  },
   "draft.entry.startFailed": {
     pt: "Não foi possível iniciar o draft.",
     en: "Couldn't start the draft.",

--- a/src/lib/goldfish.test.ts
+++ b/src/lib/goldfish.test.ts
@@ -9,6 +9,7 @@ function land(): Card {
     typeLine: "Basic Land — Forest",
     oracleText: "{T}: Add {G}.",
     colors: [],
+    colorIdentity: ["G"],
     producedMana: ["G"],
     roles: ["land"],
   };
@@ -21,6 +22,7 @@ function spell(mv: number, ramp = false): Card {
     typeLine: ramp ? "Artifact" : "Creature — Bear",
     oracleText: ramp ? "{T}: Add {C}." : "Vanilla.",
     colors: [],
+    colorIdentity: [],
     producedMana: ramp ? ["C"] : [],
     roles: ramp ? ["ramp"] : ["other"],
   };

--- a/src/lib/scryfall.test.ts
+++ b/src/lib/scryfall.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  toCard,
-  resolveDeck,
-  fetchCardNameSuggestions,
-  type FetchLike,
-} from "./scryfall";
+import { toCard, resolveDeck, type FetchLike } from "./scryfall";
 import { parseDecklist } from "./decklist";
 
 describe("toCard", () => {
@@ -100,33 +95,6 @@ describe("resolveDeck", () => {
     expect(deck.unresolved).toEqual(["Nonexistent Card"]);
   });
 
-});
-
-describe("fetchCardNameSuggestions", () => {
-  it("queries the autocomplete endpoint and returns the names", async () => {
-    let calledUrl = "";
-    const fetchImpl: FetchLike = async (url) => {
-      calledUrl = url;
-      return {
-        ok: true,
-        status: 200,
-        json: async () => ({ data: ["Sol Ring", "Solemn Simulacrum"] }),
-      };
-    };
-    const names = await fetchCardNameSuggestions("sol", fetchImpl);
-    expect(names).toEqual(["Sol Ring", "Solemn Simulacrum"]);
-    expect(calledUrl).toContain("/cards/autocomplete?q=sol");
-  });
-
-  it("skips the request for queries shorter than two characters", async () => {
-    let called = false;
-    const fetchImpl: FetchLike = async () => {
-      called = true;
-      return { ok: true, status: 200, json: async () => ({ data: [] }) };
-    };
-    expect(await fetchCardNameSuggestions("s", fetchImpl)).toEqual([]);
-    expect(called).toBe(false);
-  });
 });
 
 describe("resolveDeck (two-sided)", () => {

--- a/src/lib/scryfall.test.ts
+++ b/src/lib/scryfall.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { toCard, resolveDeck, type FetchLike } from "./scryfall";
+import {
+  toCard,
+  resolveDeck,
+  fetchCardNameSuggestions,
+  type FetchLike,
+} from "./scryfall";
 import { parseDecklist } from "./decklist";
 
 describe("toCard", () => {
@@ -95,6 +100,36 @@ describe("resolveDeck", () => {
     expect(deck.unresolved).toEqual(["Nonexistent Card"]);
   });
 
+});
+
+describe("fetchCardNameSuggestions", () => {
+  it("queries the autocomplete endpoint and returns the names", async () => {
+    let calledUrl = "";
+    const fetchImpl: FetchLike = async (url) => {
+      calledUrl = url;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ data: ["Sol Ring", "Solemn Simulacrum"] }),
+      };
+    };
+    const names = await fetchCardNameSuggestions("sol", fetchImpl);
+    expect(names).toEqual(["Sol Ring", "Solemn Simulacrum"]);
+    expect(calledUrl).toContain("/cards/autocomplete?q=sol");
+  });
+
+  it("skips the request for queries shorter than two characters", async () => {
+    let called = false;
+    const fetchImpl: FetchLike = async () => {
+      called = true;
+      return { ok: true, status: 200, json: async () => ({ data: [] }) };
+    };
+    expect(await fetchCardNameSuggestions("s", fetchImpl)).toEqual([]);
+    expect(called).toBe(false);
+  });
+});
+
+describe("resolveDeck (two-sided)", () => {
   it("resolves a stored two-sided name by querying its front face", async () => {
     const parsed = parseDecklist("Deck\n1 Commit // Memory");
     // Scryfall knows the card only under the front face "Commit"; it echoes the

--- a/src/lib/scryfall.test.ts
+++ b/src/lib/scryfall.test.ts
@@ -27,6 +27,23 @@ describe("toCard", () => {
     expect(card.oracleText).toContain("Draw two cards");
     expect(card.oracleText).toContain("Add {G}");
   });
+
+  it("carries color_identity as colorIdentity, distinct from colors", () => {
+    const card = toCard({
+      name: "Dryad Arbor",
+      cmc: 0,
+      type_line: "Land Creature — Dryad",
+      colors: [],
+      color_identity: ["G"],
+    });
+    expect(card.colors).toEqual([]);
+    expect(card.colorIdentity).toEqual(["G"]);
+  });
+
+  it("defaults colorIdentity to an empty array when Scryfall omits it", () => {
+    const card = toCard({ name: "No Identity Field", cmc: 0 });
+    expect(card.colorIdentity).toEqual([]);
+  });
 });
 
 /** A fake fetch that returns a canned collection response. */

--- a/src/lib/scryfall.ts
+++ b/src/lib/scryfall.ts
@@ -8,31 +8,7 @@ import { classifyRoles } from "./roles";
 import { frontFace } from "./cardName";
 
 const SCRYFALL_COLLECTION_URL = "https://api.scryfall.com/cards/collection";
-const SCRYFALL_AUTOCOMPLETE_URL = "https://api.scryfall.com/cards/autocomplete";
 const BATCH_SIZE = 75; // Scryfall's documented max identifiers per request.
-
-interface AutocompleteResponse {
-  data?: string[];
-}
-
-/**
- * Card-name suggestions for `query` from Scryfall's autocomplete endpoint —
- * up to 20 names matching the typed text. Scryfall requires at least two
- * characters; shorter queries return nothing without a request.
- */
-export async function fetchCardNameSuggestions(
-  query: string,
-  fetchImpl: FetchLike = fetch as unknown as FetchLike,
-): Promise<string[]> {
-  const q = query.trim();
-  if (q.length < 2) return [];
-  const res = await fetchImpl(
-    `${SCRYFALL_AUTOCOMPLETE_URL}?q=${encodeURIComponent(q)}`,
-  );
-  if (!res.ok) throw new Error(`Scryfall autocomplete failed (HTTP ${res.status})`);
-  const json = (await res.json()) as AutocompleteResponse;
-  return json.data ?? [];
-}
 
 /** Shape of the fields we read from a Scryfall card object. */
 interface ScryfallCard {

--- a/src/lib/scryfall.ts
+++ b/src/lib/scryfall.ts
@@ -17,6 +17,7 @@ interface ScryfallCard {
   type_line?: string;
   oracle_text?: string;
   colors?: string[];
+  color_identity?: string[];
   produced_mana?: string[];
   image_uris?: { normal?: string };
   card_faces?: Array<{
@@ -50,6 +51,7 @@ export function toCard(sc: ScryfallCard): Card {
       .join("\n") ??
     "";
   const colors = sc.colors ?? sc.card_faces?.[0]?.colors ?? [];
+  const colorIdentity = sc.color_identity ?? [];
   const producedMana = sc.produced_mana ?? [];
   const manaValue = sc.cmc ?? 0;
   const imageUrl =
@@ -61,6 +63,7 @@ export function toCard(sc: ScryfallCard): Card {
     typeLine,
     oracleText,
     colors,
+    colorIdentity,
     producedMana,
     imageUrl,
     roles: classifyRoles({ typeLine, oracleText, manaValue, producedMana }),

--- a/src/lib/scryfall.ts
+++ b/src/lib/scryfall.ts
@@ -8,7 +8,31 @@ import { classifyRoles } from "./roles";
 import { frontFace } from "./cardName";
 
 const SCRYFALL_COLLECTION_URL = "https://api.scryfall.com/cards/collection";
+const SCRYFALL_AUTOCOMPLETE_URL = "https://api.scryfall.com/cards/autocomplete";
 const BATCH_SIZE = 75; // Scryfall's documented max identifiers per request.
+
+interface AutocompleteResponse {
+  data?: string[];
+}
+
+/**
+ * Card-name suggestions for `query` from Scryfall's autocomplete endpoint —
+ * up to 20 names matching the typed text. Scryfall requires at least two
+ * characters; shorter queries return nothing without a request.
+ */
+export async function fetchCardNameSuggestions(
+  query: string,
+  fetchImpl: FetchLike = fetch as unknown as FetchLike,
+): Promise<string[]> {
+  const q = query.trim();
+  if (q.length < 2) return [];
+  const res = await fetchImpl(
+    `${SCRYFALL_AUTOCOMPLETE_URL}?q=${encodeURIComponent(q)}`,
+  );
+  if (!res.ok) throw new Error(`Scryfall autocomplete failed (HTTP ${res.status})`);
+  const json = (await res.json()) as AutocompleteResponse;
+  return json.data ?? [];
+}
 
 /** Shape of the fields we read from a Scryfall card object. */
 interface ScryfallCard {

--- a/src/lib/scryfallCache.ts
+++ b/src/lib/scryfallCache.ts
@@ -1,7 +1,7 @@
 import type { Card, ParsedDecklist, ResolvedDeck, DecklistEntry } from "./types";
 import { fetchCards, lookup, type FetchLike } from "./scryfall";
 
-const CACHE_KEY = "commander-playtester/scryfall-cache/v1";
+const CACHE_KEY = "commander-playtester/scryfall-cache/v2";
 
 /** Card metadata cache keyed by the *requested* name, lowercased. */
 type Cache = Record<string, Card>;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -11,6 +11,8 @@ export interface Card {
   typeLine: string;
   oracleText: string;
   colors: string[];
+  /** True MTG color identity (mana cost + rules text), from Scryfall's `color_identity`. */
+  colorIdentity: string[];
   /** Colors of mana this permanent can produce (from Scryfall produced_mana). */
   producedMana: string[];
   /** Scryfall image URL (normal), when available. */

--- a/src/match/MatchSetup.tsx
+++ b/src/match/MatchSetup.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import type { SavedDeck } from "../deck/model";
+import { isHundredCards } from "../deck/model";
 import type { PlayMode, RunConfig, SeatCount } from "./config";
 import { SEAT_COUNTS, MIN_MATCHES, MAX_MATCHES, clampMatchCount } from "./config";
 import type { AiDifficulty } from "../engine/types";
@@ -42,6 +43,12 @@ export function MatchSetup({
   const yourDeck = decks.find((d) => d.id === yourDeckId) ?? decks[0];
   const opponentDecks = decks.filter((d) => d.id !== yourDeck.id);
 
+  function deckLabel(deck: SavedDeck): string {
+    return isHundredCards(deck)
+      ? deck.name
+      : deck.name + t("setup.partialSuffix");
+  }
+
   function opponentAt(index: number): string {
     const chosen = opponentIds[index];
     if (chosen && opponentDecks.some((d) => d.id === chosen)) return chosen;
@@ -55,17 +62,21 @@ export function MatchSetup({
   }
 
   const opponentSeats = seatCount - 1;
+  const chosenOpponentIds = Array.from({ length: opponentSeats }, (_, i) =>
+    opponentAt(i),
+  );
   const allChosen =
-    opponentDecks.length > 0 &&
-    Array.from({ length: opponentSeats }, (_, i) => opponentAt(i)).every(
-      Boolean,
-    );
+    opponentDecks.length > 0 && chosenOpponentIds.every(Boolean);
+  const chosenDecks = [
+    yourDeck,
+    ...chosenOpponentIds
+      .map((id) => decks.find((d) => d.id === id))
+      .filter((d): d is SavedDeck => !!d),
+  ];
+  const hasPartialChosen = chosenDecks.some((d) => !isHundredCards(d));
 
   function handleStart() {
-    const seatDeckIds = [
-      yourDeck.id,
-      ...Array.from({ length: opponentSeats }, (_, i) => opponentAt(i)),
-    ];
+    const seatDeckIds = [yourDeck.id, ...chosenOpponentIds];
     onStart({
       seatDeckIds,
       mode,
@@ -83,7 +94,10 @@ export function MatchSetup({
       <div className="field">
         <span className="field__label">{t("setup.yourDeck")}</span>
         <XpSelect
-          options={decks.map((deck) => ({ value: deck.id, label: deck.name }))}
+          options={decks.map((deck) => ({
+            value: deck.id,
+            label: deckLabel(deck),
+          }))}
           value={yourDeck.id}
           onChange={setYourDeckId}
           ariaLabel={t("setup.yourDeck")}
@@ -121,7 +135,7 @@ export function MatchSetup({
                   <XpSelect
                     options={opponentDecks.map((deck) => ({
                       value: deck.id,
-                      label: deck.name,
+                      label: deckLabel(deck),
                     }))}
                     value={opponentAt(i)}
                     onChange={(id) => setOpponentAt(i, id)}
@@ -209,11 +223,12 @@ export function MatchSetup({
       </label>
 
       <p className="hint">{t("setup.timeHint")}</p>
+      {hasPartialChosen && <p className="error">{t("setup.partialChosen")}</p>}
       <div className="import__row">
         <button
           className="btn"
           onClick={handleStart}
-          disabled={opponentSeats > 0 && !allChosen}
+          disabled={(opponentSeats > 0 && !allChosen) || hasPartialChosen}
         >
           {matchCount > 1
             ? t("setup.startN", { n: clampMatchCount(matchCount) })


### PR DESCRIPTION
## Summary

Adds an assisted **Draft a deck** flow: seed a deck with a few base cards (typed one-by-one with autocomplete, pasted as a list, or drawn from an existing deck) and iteratively draft synergistic candidates toward a target bracket. All card data and suggestions come from the vendored phase-rs card database — the entry screen makes no network calls (ADR-0010; Scryfall is used only for images).

## What's included

- **Entry screen** with two input modes (one-by-one rows with live autocomplete, or paste-a-list) plus a "Draft from this deck" entry point in the deck editor.
- **Local validation** as you type: existence, Commander legality, and commander eligibility. Unknown/banned cards are flagged, the commander picker offers only eligible legendary creatures, and Start is held until at least three valid cards are present (with a red hint explaining why when it isn't).
- **Candidate pipeline & synergy scoring** (pure, unit-tested): themes, tokens, similarity, and scoring heuristics feeding a draft session.
- **Engine query surface**: `search_cards_js`, bracket estimate, deck classification, candidate ranking, name suggestions, and card validation exposed through the worker/`EngineClient`.
- **UI polish**: candidate cards use icon actions with tags below the art; a reusable `SearchableSelect` with disabled + in-field clear (X).

## Testing

- `npm run typecheck`, `npm run lint`, `npm test` (220 passing) all green.
- Verified the entry flow in the browser preview: autocomplete, per-card validation, commander gating, and the Start/warning states.

## Docs

- `domainbook check` passes; adds ADR-0010 (serve card lookups from the local card database) and the deck-draft domainbook artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)