### PR TITLE
feat(sim): let the human decide optional costs (#44)

### DIFF
--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,6 +12,16 @@ depth live there. A purely-internal PR that touches no product or architecture m
 skip its version with a `Skip-Docs: <reason>` trailer instead. There are no
 per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
+## [0.6.0] - 2026-09-05
+
+### Added
+
+- You now decide your own spells' **optional costs** (kicker, buyback, entwine,
+  escalate…): casting a spell that offers a "you may pay an additional cost"
+  choice prompts your seat to pay or not, instead of the AI deciding — with the
+  running kick count shown for repeatable costs, and a let-the-AI-decide escape
+  (`domains/simulation/features/decide-an-optional-cost.md`).
+
 ## [0.5.0] - 2026-09-03
 
 ### Added

--- a/domainbook/domains/simulation/features/decide-an-optional-cost.md
+++ b/domainbook/domains/simulation/features/decide-an-optional-cost.md
@@ -1,0 +1,67 @@
+---
+id: decide-an-optional-cost
+name: Decide an optional cost
+status: implemented
+---
+
+## Story
+
+As a player piloting my seat
+I want to decide whether to pay a spell's optional cost (kicker, buyback, entwine…)
+So that a choice that changes what mana I hold up is mine, not the AI's
+
+## Rule: An optional-cost offer prompts the human on their own cast
+
+When the engine asks the human to resolve an `OptionalCostChoice` `decision
+request` — a "you may pay an additional cost" offer while casting — the seat's
+control panel shows a pay/don't-pay prompt naming the spell. Other seats resolve
+it by `AI action proposal` as before, and any non-`OptionalCostChoice` state is
+untouched.
+
+```gherkin
+Example: The prompt appears on my own kicker spell
+  Given a play-mode match where I control seat 0
+  When I cast a spell that offers an optional cost
+  Then the control panel asks whether to pay the additional cost, naming the spell
+  And an opponent's optional-cost spell is still decided by the AI
+```
+
+## Rule: Pay and don't-pay submit the engine's yes/no answer
+
+Choosing pay submits `DecideOptionalCost { pay: true }`; choosing don't-pay
+submits `DecideOptionalCost { pay: false }`. For a repeatable cost that has
+already been paid on this cast, the panel shows how many times so far, so a
+multikicker-style "pay again?" offer reads clearly.
+
+```gherkin
+Example: Paying the cost
+  Given the optional-cost prompt for my spell is shown
+  When I choose pay
+  Then the engine records the additional cost as paid
+
+Example: A repeatable cost shows the running count
+  Given a repeatable optional cost already paid once on this cast
+  Then the prompt notes it has been paid once so far
+```
+
+## Rule: The choice can be handed to the AI
+
+Choosing let the AI decide hands the whole optional-cost choice back to the
+engine's own AI, so the decision is never stuck (`simulation/ADR-0001`).
+
+```gherkin
+Example: Letting the AI decide
+  Given the optional-cost prompt is shown
+  When I choose let the AI decide
+  Then the engine's AI decides whether to pay
+```
+
+## Open Questions
+
+- The `OptionalCostChoice` shape (`cost: AdditionalCost`, `times_kicked`,
+  `pending_cast`) and the `DecideOptionalCost { pay }` submission were confirmed
+  against phase-rs `client/src/adapter/types.ts` and the reference client's
+  `OptionalCostModal` at v0.71.0, but not yet round-tripped against a live cast.
+  The panel names the spell and the running kick count rather than the exact
+  mana of the additional cost, which the coarse `AdditionalCost` category does
+  not carry uniformly; rendering the concrete cost is a follow-up.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -297,6 +297,20 @@ export const messages = {
   "resolutionOptionalPayment.decline": { pt: "Recusar", en: "Decline" },
   "resolutionOptionalPayment.letAi": { pt: "IA decide", en: "Let the AI decide" },
 
+  "optionalCost.title": { pt: "Custo adicional", en: "Optional cost" },
+  "optionalCost.prompt": {
+    pt: "Pagar um custo adicional de {name}?",
+    en: "Pay an additional cost for {name}?",
+  },
+  "optionalCost.spellFallback": { pt: "esta mágica", en: "this spell" },
+  "optionalCost.timesPaid": {
+    pt: "Já pago {count}x nesta conjuração.",
+    en: "Already paid {count}× on this cast.",
+  },
+  "optionalCost.pay": { pt: "Pagar", en: "Pay" },
+  "optionalCost.decline": { pt: "Não pagar", en: "Don't pay" },
+  "optionalCost.letAi": { pt: "IA decide", en: "Let the AI decide" },
+
   "modes.title": { pt: "Escolher modo", en: "Choose a mode" },
   "modes.source": {
     pt: "{name} pede uma escolha de modo.",

--- a/src/match/RunView.tsx
+++ b/src/match/RunView.tsx
@@ -44,6 +44,10 @@ import {
   payResolutionOptionalPaymentAction,
   type ResolutionOptionalPaymentPrompt,
 } from "../sim/decisions/resolutionOptionalPayment";
+import {
+  decideOptionalCostAction,
+  type OptionalCostPrompt,
+} from "../sim/decisions/optionalCost";
 import { XpWindow } from "../components/XpWindow";
 import {
   declareAttackersAction,
@@ -237,6 +241,11 @@ interface ResolutionOptionalPaymentTurn {
   resolve: (choice: HumanChoice) => void;
 }
 
+interface OptionalCostTurn {
+  prompt: OptionalCostPrompt;
+  resolve: (choice: HumanChoice) => void;
+}
+
 function isTargetOptional(
   targeting: TargetTurn | null,
   chosen: TargetRef[],
@@ -369,6 +378,7 @@ interface RunnerCallbackDeps {
   setResolutionOptionalPaymentTurn: Dispatch<
     SetStateAction<ResolutionOptionalPaymentTurn | null>
   >;
+  setOptionalCostTurn: Dispatch<SetStateAction<OptionalCostTurn | null>>;
 }
 
 function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
@@ -401,6 +411,7 @@ function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
     setDiscardTurn,
     setScryTurn,
     setResolutionOptionalPaymentTurn,
+    setOptionalCostTurn,
   } = deps;
   return {
     onFrame: (env) => {
@@ -606,6 +617,20 @@ function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
           },
         });
       }),
+    requestHumanOptionalCost: (_env, prompt) =>
+      new Promise<HumanChoice>((resolve) => {
+        if (isCancelled()) {
+          resolve({ ai: true });
+          return;
+        }
+        setOptionalCostTurn({
+          prompt,
+          resolve: (choice) => {
+            setOptionalCostTurn(null);
+            resolve(choice);
+          },
+        });
+      }),
   };
 }
 
@@ -698,6 +723,8 @@ export function RunView({
   const [scryTurn, setScryTurn] = useState<ScryTurn | null>(null);
   const [resolutionOptionalPaymentTurn, setResolutionOptionalPaymentTurn] =
     useState<ResolutionOptionalPaymentTurn | null>(null);
+  const [optionalCostTurn, setOptionalCostTurn] =
+    useState<OptionalCostTurn | null>(null);
   const [passingTurn, setPassingTurn] = useState(false);
   const [logEntries, setLogEntries] = useState<LoggedEntry[]>([]);
   // On mobile the log is a full-screen drawer, so it always starts closed and
@@ -794,6 +821,7 @@ export function RunView({
             setDiscardTurn,
             setScryTurn,
             setResolutionOptionalPaymentTurn,
+            setOptionalCostTurn,
           }),
         );
         runnerRef.current = runner;
@@ -921,7 +949,8 @@ export function RunView({
         creatureTypeTurn ||
         modesTurn ||
         scryTurn ||
-        resolutionOptionalPaymentTurn)
+        resolutionOptionalPaymentTurn ||
+        optionalCostTurn)
     ) {
       setPassingTurn(false);
     }
@@ -934,6 +963,7 @@ export function RunView({
     modesTurn,
     scryTurn,
     resolutionOptionalPaymentTurn,
+    optionalCostTurn,
   ]);
 
   // Map draggable hand cards to their play actions for the current window.
@@ -1679,6 +1709,57 @@ export function RunView({
                   onClick={() => resolutionOptionalPaymentTurn.resolve({ ai: true })}
                 >
                   {t("resolutionOptionalPayment.letAi")}
+                </button>
+              </div>
+            </>
+          )}
+
+          {optionalCostTurn && (
+            <>
+              <div className="control-title">
+                <strong>{t("optionalCost.title")}</strong>
+              </div>
+              <p className="hint">
+                {t("optionalCost.prompt", {
+                  name:
+                    optionalCostTurn.prompt.sourceName ||
+                    t("optionalCost.spellFallback"),
+                })}
+              </p>
+              {optionalCostTurn.prompt.repeatable &&
+                optionalCostTurn.prompt.timesKicked > 0 && (
+                  <p className="hint">
+                    {t("optionalCost.timesPaid", {
+                      count: optionalCostTurn.prompt.timesKicked,
+                    })}
+                  </p>
+                )}
+              <div className="import__row">
+                <button
+                  className="btn"
+                  onClick={() =>
+                    optionalCostTurn.resolve({
+                      action: decideOptionalCostAction(true),
+                    })
+                  }
+                >
+                  {t("optionalCost.pay")}
+                </button>
+                <button
+                  className="btn btn--ghost"
+                  onClick={() =>
+                    optionalCostTurn.resolve({
+                      action: decideOptionalCostAction(false),
+                    })
+                  }
+                >
+                  {t("optionalCost.decline")}
+                </button>
+                <button
+                  className="btn btn--ghost"
+                  onClick={() => optionalCostTurn.resolve({ ai: true })}
+                >
+                  {t("optionalCost.letAi")}
                 </button>
               </div>
             </>

--- a/src/sim/decisions/optionalCost.test.ts
+++ b/src/sim/decisions/optionalCost.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseOptionalCostPrompt,
+  decideOptionalCostAction,
+} from "./optionalCost";
+import type { GameObject, WaitingFor } from "../../engine/types";
+
+// Shape confirmed against phase-rs client/src/adapter/types.ts (v0.71.0):
+// OptionalCostChoice { player, cost: AdditionalCost, times_kicked, pending_cast }.
+const REAL_OPTIONAL_COST: WaitingFor = {
+  type: "OptionalCostChoice",
+  data: {
+    player: 0,
+    cost: { type: "Kicker", data: { costs: [], repeatable: true } },
+    times_kicked: 1,
+    pending_cast: { object_id: 12, card_id: 900 },
+  },
+};
+
+const OBJECTS: Record<string, GameObject> = {
+  12: { id: 12, name: "Rite of Replication", zone: "Stack" },
+};
+
+describe("parseOptionalCostPrompt", () => {
+  it("parses the cost kind, source name and kick count", () => {
+    const p = parseOptionalCostPrompt(REAL_OPTIONAL_COST, OBJECTS)!;
+    expect(p).not.toBeNull();
+    expect(p.player).toBe(0);
+    expect(p.sourceName).toBe("Rite of Replication");
+    expect(p.costKind).toBe("Kicker");
+    expect(p.timesKicked).toBe(1);
+    expect(p.repeatable).toBe(true);
+  });
+
+  it("falls back to an empty source name when the object is unknown", () => {
+    const p = parseOptionalCostPrompt(REAL_OPTIONAL_COST);
+    expect(p?.sourceName).toBe("");
+  });
+
+  it("marks a non-repeatable optional cost", () => {
+    const wf: WaitingFor = {
+      type: "OptionalCostChoice",
+      data: {
+        player: 1,
+        cost: { type: "Optional", data: { cost: { type: "Mana" } } },
+        times_kicked: 0,
+        pending_cast: { object_id: 3 },
+      },
+    };
+    const p = parseOptionalCostPrompt(wf)!;
+    expect(p.costKind).toBe("Optional");
+    expect(p.repeatable).toBe(false);
+    expect(p.timesKicked).toBe(0);
+  });
+
+  it("returns null for a non-matching waiting_for", () => {
+    expect(parseOptionalCostPrompt(undefined)).toBeNull();
+    expect(parseOptionalCostPrompt({ type: "Priority", data: {} })).toBeNull();
+  });
+
+  it("returns null when the cost has no kind", () => {
+    const wf: WaitingFor = {
+      type: "OptionalCostChoice",
+      data: { player: 0, cost: {}, times_kicked: 0, pending_cast: {} },
+    };
+    expect(parseOptionalCostPrompt(wf)).toBeNull();
+  });
+});
+
+describe("decideOptionalCostAction", () => {
+  it("builds the pay action", () => {
+    expect(decideOptionalCostAction(true)).toEqual({
+      type: "DecideOptionalCost",
+      data: { pay: true },
+    });
+  });
+
+  it("builds the decline action", () => {
+    expect(decideOptionalCostAction(false)).toEqual({
+      type: "DecideOptionalCost",
+      data: { pay: false },
+    });
+  });
+});

--- a/src/sim/decisions/optionalCost.ts
+++ b/src/sim/decisions/optionalCost.ts
@@ -1,0 +1,55 @@
+// "You may pay an additional cost" — kicker, buyback, entwine, escalate and the
+// like. When a spell offers one, the engine surfaces an `OptionalCostChoice`
+// waiting_for whose `data` carries the acting `player`, the `cost`
+// (an `AdditionalCost`: Optional / Kicker / Required / Choice), how many times
+// it has been paid already (`times_kicked`, for repeatable kickers), and the
+// `pending_cast` naming the spell. The seat answers by submitting
+// `DecideOptionalCost` with `pay` true or false.
+
+import type { GameObject, WaitingFor } from "../../engine/types";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export interface OptionalCostPrompt {
+  player: number;
+  /** The spell offering the cost, for the prompt (may be empty). */
+  sourceName: string;
+  /** The kind of additional cost — "Kicker", "Optional", "Required", "Choice". */
+  costKind: string;
+  /** How many times this repeatable cost has already been paid. */
+  timesKicked: number;
+  /** True when the cost may be paid more than once (multikicker-style). */
+  repeatable: boolean;
+}
+
+/** Read a "pay an optional cost" decision aimed at the human, or null. */
+export function parseOptionalCostPrompt(
+  wf: WaitingFor | undefined,
+  objects?: Record<string, GameObject>,
+): OptionalCostPrompt | null {
+  if (!wf || wf.type !== "OptionalCostChoice") return null;
+  const d: any = wf.data ?? {};
+  const cost = d.cost ?? {};
+  const costKind: string = typeof cost.type === "string" ? cost.type : "";
+  if (!costKind) return null;
+
+  const srcId = d.pending_cast?.object_id;
+  const sourceName =
+    (typeof srcId === "number" && objects?.[srcId]?.name) || "";
+
+  return {
+    player: typeof d.player === "number" ? d.player : 0,
+    sourceName,
+    costKind,
+    timesKicked: typeof d.times_kicked === "number" ? d.times_kicked : 0,
+    repeatable: !!cost.data?.repeatable,
+  };
+}
+
+/** Submit the pay/don't-pay answer back to the engine. */
+export function decideOptionalCostAction(pay: boolean): {
+  type: string;
+  data: { pay: boolean };
+} {
+  return { type: "DecideOptionalCost", data: { pay } };
+}

--- a/src/sim/driver.ts
+++ b/src/sim/driver.ts
@@ -31,6 +31,10 @@ import {
   parseResolutionOptionalPaymentPrompt,
   type ResolutionOptionalPaymentPrompt,
 } from "./decisions/resolutionOptionalPayment";
+import {
+  parseOptionalCostPrompt,
+  type OptionalCostPrompt,
+} from "./decisions/optionalCost";
 
 export interface MatchResult {
   matchIndex: number;
@@ -242,6 +246,11 @@ export interface DriverCallbacks {
   requestHumanResolutionOptionalPayment?: (
     env: GameStateEnvelope,
     prompt: ResolutionOptionalPaymentPrompt,
+  ) => Promise<HumanChoice>;
+  /** Called when casting a spell offers the human an optional cost (kicker, buyback…). */
+  requestHumanOptionalCost?: (
+    env: GameStateEnvelope,
+    prompt: OptionalCostPrompt,
   ) => Promise<HumanChoice>;
 }
 
@@ -550,6 +559,12 @@ export class MatchRunner {
           env,
           cb.requestHumanResolutionOptionalPayment,
           parseResolutionOptionalPaymentPrompt(wf, state.objects),
+        ),
+      () =>
+        humanRequest(
+          env,
+          cb.requestHumanOptionalCost,
+          parseOptionalCostPrompt(wf, state.objects),
         ),
     ];
     for (const resolve of resolvers) {


### PR DESCRIPTION
Closes #44.

## What

Casting a spell that offers an optional cost — kicker, buyback, entwine, escalate, and the like — now prompts **your** seat to pay or not, instead of the AI silently deciding. It's a decision that changes what mana you hold up, so it belongs to the player.

## How

Follows the repo's standard decision-wiring pattern:

- `src/sim/decisions/optionalCost.ts` — `parseOptionalCostPrompt(wf, objects)` reads the engine's `OptionalCostChoice` (`cost: AdditionalCost`, `times_kicked`, `pending_cast`); `decideOptionalCostAction(pay)` builds the `DecideOptionalCost { pay }` submission. With tests.
- `src/sim/driver.ts` — `requestHumanOptionalCost` callback + dispatch branch.
- `src/match/RunView.tsx` — pending-turn state, resolve wiring, and a pay / don't-pay / let-AI panel that names the spell and shows the running kick count for repeatable costs.
- `src/i18n/messages.ts` — PT + EN strings.

## Verification

The `OptionalCostChoice` data shape and the `DecideOptionalCost { pay }` action were confirmed against phase-rs **v0.71.0** (the vendored engine) — its `client/src/adapter/types.ts` and the reference client's `OptionalCostModal` — not guessed. Parser returns `null` (safe AI fallback) for any unexpected shape.

Local gates all green: lint, typecheck, jscpd (0.72%), 225 tests, build, `domainbook check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)