### PR TITLE
feat(sim): let the human decide the commander's zone

### DIFF
--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,6 +12,16 @@ depth live there. A purely-internal PR that touches no product or architecture m
 skip its version with a `Skip-Docs: <reason>` trailer instead. There are no
 per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
+## [0.7.0] - 2026-09-05
+
+### Added
+
+- You now decide your own **commander's zone choice**: when your commander
+  would move to the graveyard, exile, hand, or another zone, the control panel
+  lets you send it to the command zone instead or leave it in place, rather
+  than the AI deciding
+  (`domains/simulation/features/decide-the-commander-zone.md`).
+
 ## [0.6.0] - 2026-09-05
 
 ### Added

--- a/domainbook/domains/simulation/features/decide-the-commander-zone.md
+++ b/domainbook/domains/simulation/features/decide-the-commander-zone.md
@@ -1,0 +1,67 @@
+---
+id: decide-the-commander-zone
+name: Decide the commander zone
+status: implemented
+---
+
+## Story
+
+As a player piloting my seat
+I want to decide whether my commander goes to the command zone or stays where it landed
+So that the replacement effect I built my deck around is mine to invoke, not the AI's
+
+## Rule: A commander-zone offer prompts the human on their own commander
+
+When the engine asks the human to resolve a `CommanderZoneChoice` `decision
+request` — offered whenever the human's commander would change zones — the
+seat's control panel shows a command-zone/leave-it prompt naming the commander
+and the zone it would otherwise land in. Other seats resolve it by `AI action
+proposal` as before, and any non-`CommanderZoneChoice` state is untouched.
+
+```gherkin
+Example: The prompt appears on my own commander's zone change
+  Given a play-mode match where I control seat 0
+  When my commander would move to the graveyard
+  Then the control panel asks whether to send it to the command zone instead
+  And an opponent's commander-zone choice is still decided by the AI
+```
+
+## Rule: Command zone and leave-it submit the engine's yes/no answer
+
+Choosing command zone submits `DecideOptionalEffect { accept: true }`, sending
+the commander to the command zone. Choosing leave it submits
+`DecideOptionalEffect { accept: false }`, leaving the commander in the zone
+the engine named (`current_zone`) — graveyard, exile, hand, and so on.
+
+```gherkin
+Example: Choosing the command zone
+  Given the commander-zone prompt names the graveyard as the current zone
+  When I choose the command zone
+  Then the engine sends the commander to the command zone
+
+Example: Leaving the commander in place
+  Given the commander-zone prompt names the graveyard as the current zone
+  When I choose to leave it there
+  Then the commander stays in the graveyard
+```
+
+## Rule: The choice can be handed to the AI
+
+Choosing let the AI decide hands the whole commander-zone choice back to the
+engine's own AI, so the decision is never stuck (`simulation/ADR-0001`).
+
+```gherkin
+Example: Letting the AI decide
+  Given the commander-zone prompt is shown
+  When I choose let the AI decide
+  Then the engine's AI decides where the commander goes
+```
+
+## Open Questions
+
+- The `CommanderZoneChoice` shape (`commander_id`, `current_zone`) and the
+  `DecideOptionalEffect { accept }` submission were confirmed against phase-rs
+  `client/src/adapter/types.ts` at v0.71.0, but not yet round-tripped against a
+  live cast. The panel title-cases the raw `current_zone` string for display
+  rather than localizing every possible zone name; a future pass can map the
+  full zone vocabulary to friendly, localized words if this proves confusing.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -311,6 +311,22 @@ export const messages = {
   "optionalCost.decline": { pt: "Não pagar", en: "Don't pay" },
   "optionalCost.letAi": { pt: "IA decide", en: "Let the AI decide" },
 
+  "commanderZone.title": { pt: "Zona do comandante", en: "Commander zone" },
+  "commanderZone.prompt": {
+    pt: "Enviar {name} para a zona de comando em vez do {zone}?",
+    en: "Send {name} to the command zone instead of the {zone}?",
+  },
+  "commanderZone.commanderFallback": {
+    pt: "seu comandante",
+    en: "your commander",
+  },
+  "commanderZone.commandZone": { pt: "Zona de comando", en: "Command zone" },
+  "commanderZone.leave": {
+    pt: "Deixar no {zone}",
+    en: "Leave in {zone}",
+  },
+  "commanderZone.letAi": { pt: "IA decide", en: "Let the AI decide" },
+
   "modes.title": { pt: "Escolher modo", en: "Choose a mode" },
   "modes.source": {
     pt: "{name} pede uma escolha de modo.",

--- a/src/match/RunView.tsx
+++ b/src/match/RunView.tsx
@@ -48,6 +48,10 @@ import {
   decideOptionalCostAction,
   type OptionalCostPrompt,
 } from "../sim/decisions/optionalCost";
+import {
+  commanderZoneAction,
+  type CommanderZonePrompt,
+} from "../sim/decisions/commanderZone";
 import { XpWindow } from "../components/XpWindow";
 import {
   declareAttackersAction,
@@ -246,6 +250,16 @@ interface OptionalCostTurn {
   resolve: (choice: HumanChoice) => void;
 }
 
+interface CommanderZoneTurn {
+  prompt: CommanderZonePrompt;
+  resolve: (choice: HumanChoice) => void;
+}
+
+function formatZoneLabel(zone: string): string {
+  if (!zone) return zone;
+  return zone.charAt(0).toUpperCase() + zone.slice(1).toLowerCase();
+}
+
 function isTargetOptional(
   targeting: TargetTurn | null,
   chosen: TargetRef[],
@@ -379,6 +393,7 @@ interface RunnerCallbackDeps {
     SetStateAction<ResolutionOptionalPaymentTurn | null>
   >;
   setOptionalCostTurn: Dispatch<SetStateAction<OptionalCostTurn | null>>;
+  setCommanderZoneTurn: Dispatch<SetStateAction<CommanderZoneTurn | null>>;
 }
 
 function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
@@ -412,6 +427,7 @@ function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
     setScryTurn,
     setResolutionOptionalPaymentTurn,
     setOptionalCostTurn,
+    setCommanderZoneTurn,
   } = deps;
   return {
     onFrame: (env) => {
@@ -631,6 +647,20 @@ function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
           },
         });
       }),
+    requestHumanCommanderZone: (_env, prompt) =>
+      new Promise<HumanChoice>((resolve) => {
+        if (isCancelled()) {
+          resolve({ ai: true });
+          return;
+        }
+        setCommanderZoneTurn({
+          prompt,
+          resolve: (choice) => {
+            setCommanderZoneTurn(null);
+            resolve(choice);
+          },
+        });
+      }),
   };
 }
 
@@ -725,6 +755,8 @@ export function RunView({
     useState<ResolutionOptionalPaymentTurn | null>(null);
   const [optionalCostTurn, setOptionalCostTurn] =
     useState<OptionalCostTurn | null>(null);
+  const [commanderZoneTurn, setCommanderZoneTurn] =
+    useState<CommanderZoneTurn | null>(null);
   const [passingTurn, setPassingTurn] = useState(false);
   const [logEntries, setLogEntries] = useState<LoggedEntry[]>([]);
   // On mobile the log is a full-screen drawer, so it always starts closed and
@@ -822,6 +854,7 @@ export function RunView({
             setScryTurn,
             setResolutionOptionalPaymentTurn,
             setOptionalCostTurn,
+            setCommanderZoneTurn,
           }),
         );
         runnerRef.current = runner;
@@ -950,7 +983,8 @@ export function RunView({
         modesTurn ||
         scryTurn ||
         resolutionOptionalPaymentTurn ||
-        optionalCostTurn)
+        optionalCostTurn ||
+        commanderZoneTurn)
     ) {
       setPassingTurn(false);
     }
@@ -964,6 +998,7 @@ export function RunView({
     scryTurn,
     resolutionOptionalPaymentTurn,
     optionalCostTurn,
+    commanderZoneTurn,
   ]);
 
   // Map draggable hand cards to their play actions for the current window.
@@ -1760,6 +1795,52 @@ export function RunView({
                   onClick={() => optionalCostTurn.resolve({ ai: true })}
                 >
                   {t("optionalCost.letAi")}
+                </button>
+              </div>
+            </>
+          )}
+
+          {commanderZoneTurn && (
+            <>
+              <div className="control-title">
+                <strong>{t("commanderZone.title")}</strong>
+              </div>
+              <p className="hint">
+                {t("commanderZone.prompt", {
+                  name:
+                    commanderZoneTurn.prompt.commanderName ||
+                    t("commanderZone.commanderFallback"),
+                  zone: formatZoneLabel(commanderZoneTurn.prompt.currentZone),
+                })}
+              </p>
+              <div className="import__row">
+                <button
+                  className="btn"
+                  onClick={() =>
+                    commanderZoneTurn.resolve({
+                      action: commanderZoneAction(true),
+                    })
+                  }
+                >
+                  {t("commanderZone.commandZone")}
+                </button>
+                <button
+                  className="btn btn--ghost"
+                  onClick={() =>
+                    commanderZoneTurn.resolve({
+                      action: commanderZoneAction(false),
+                    })
+                  }
+                >
+                  {t("commanderZone.leave", {
+                    zone: formatZoneLabel(commanderZoneTurn.prompt.currentZone),
+                  })}
+                </button>
+                <button
+                  className="btn btn--ghost"
+                  onClick={() => commanderZoneTurn.resolve({ ai: true })}
+                >
+                  {t("commanderZone.letAi")}
                 </button>
               </div>
             </>

--- a/src/sim/decisions/commanderZone.test.ts
+++ b/src/sim/decisions/commanderZone.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseCommanderZonePrompt,
+  commanderZoneAction,
+} from "./commanderZone";
+import type { GameObject, WaitingFor } from "../../engine/types";
+
+// Shape confirmed against phase-rs client/src/adapter/types.ts (v0.71.0):
+// CommanderZoneChoice { player, commander_id, current_zone }.
+const REAL_COMMANDER_ZONE: WaitingFor = {
+  type: "CommanderZoneChoice",
+  data: {
+    player: 0,
+    commander_id: 12,
+    current_zone: "Graveyard",
+  },
+};
+
+const OBJECTS: Record<string, GameObject> = {
+  12: { id: 12, name: "Atraxa, Praetors' Voice", zone: "Graveyard" },
+};
+
+describe("parseCommanderZonePrompt", () => {
+  it("parses the player, commander name and current zone", () => {
+    const p = parseCommanderZonePrompt(REAL_COMMANDER_ZONE, OBJECTS)!;
+    expect(p).not.toBeNull();
+    expect(p.player).toBe(0);
+    expect(p.commanderName).toBe("Atraxa, Praetors' Voice");
+    expect(p.currentZone).toBe("Graveyard");
+  });
+
+  it("falls back to an empty commander name when the object is unknown", () => {
+    const p = parseCommanderZonePrompt(REAL_COMMANDER_ZONE);
+    expect(p?.commanderName).toBe("");
+  });
+
+  it("returns null for a non-matching waiting_for", () => {
+    expect(parseCommanderZonePrompt(undefined)).toBeNull();
+    expect(
+      parseCommanderZonePrompt({ type: "Priority", data: {} }),
+    ).toBeNull();
+  });
+
+  it("returns null when the current zone is missing", () => {
+    const wf: WaitingFor = {
+      type: "CommanderZoneChoice",
+      data: { player: 0, commander_id: 12 },
+    };
+    expect(parseCommanderZonePrompt(wf)).toBeNull();
+  });
+});
+
+describe("commanderZoneAction", () => {
+  it("builds the send-to-command-zone action", () => {
+    expect(commanderZoneAction(true)).toEqual({
+      type: "DecideOptionalEffect",
+      data: { accept: true },
+    });
+  });
+
+  it("builds the leave-in-current-zone action", () => {
+    expect(commanderZoneAction(false)).toEqual({
+      type: "DecideOptionalEffect",
+      data: { accept: false },
+    });
+  });
+});

--- a/src/sim/decisions/commanderZone.ts
+++ b/src/sim/decisions/commanderZone.ts
@@ -1,0 +1,49 @@
+// A commander that would leave the battlefield (or another zone change that
+// checks the commander's ownership) may go to the command zone instead. When
+// this applies, the engine surfaces a `CommanderZoneChoice` waiting_for whose
+// `data` carries the acting `player`, the `commander_id`, and the
+// `current_zone` the commander would otherwise end up in (graveyard, exile,
+// hand, ...). The seat answers by submitting `DecideOptionalEffect` — `accept:
+// true` sends the commander to the command zone, `accept: false` leaves it in
+// `current_zone`.
+
+import type { GameObject, WaitingFor } from "../../engine/types";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export interface CommanderZonePrompt {
+  player: number;
+  /** The commander's name, for the prompt (may be empty). */
+  commanderName: string;
+  /** The zone the commander would go to if left alone (raw engine string). */
+  currentZone: string;
+}
+
+/** Read a "send commander to the command zone?" decision aimed at the human, or null. */
+export function parseCommanderZonePrompt(
+  wf: WaitingFor | undefined,
+  objects?: Record<string, GameObject>,
+): CommanderZonePrompt | null {
+  if (!wf || wf.type !== "CommanderZoneChoice") return null;
+  const d: any = wf.data ?? {};
+  const currentZone: string =
+    typeof d.current_zone === "string" ? d.current_zone : "";
+  if (!currentZone) return null;
+
+  const commanderId = d.commander_id;
+  const commanderName = objects?.[commanderId]?.name ?? "";
+
+  return {
+    player: typeof d.player === "number" ? d.player : 0,
+    commanderName,
+    currentZone,
+  };
+}
+
+/** Submit the command-zone/leave-in-place answer back to the engine. */
+export function commanderZoneAction(toCommandZone: boolean): {
+  type: string;
+  data: { accept: boolean };
+} {
+  return { type: "DecideOptionalEffect", data: { accept: toCommandZone } };
+}

--- a/src/sim/driver.ts
+++ b/src/sim/driver.ts
@@ -35,6 +35,10 @@ import {
   parseOptionalCostPrompt,
   type OptionalCostPrompt,
 } from "./decisions/optionalCost";
+import {
+  parseCommanderZonePrompt,
+  type CommanderZonePrompt,
+} from "./decisions/commanderZone";
 
 export interface MatchResult {
   matchIndex: number;
@@ -251,6 +255,11 @@ export interface DriverCallbacks {
   requestHumanOptionalCost?: (
     env: GameStateEnvelope,
     prompt: OptionalCostPrompt,
+  ) => Promise<HumanChoice>;
+  /** Called when the human's commander may go to the command zone instead of its current zone. */
+  requestHumanCommanderZone?: (
+    env: GameStateEnvelope,
+    prompt: CommanderZonePrompt,
   ) => Promise<HumanChoice>;
 }
 
@@ -565,6 +574,12 @@ export class MatchRunner {
           env,
           cb.requestHumanOptionalCost,
           parseOptionalCostPrompt(wf, state.objects),
+        ),
+      () =>
+        humanRequest(
+          env,
+          cb.requestHumanCommanderZone,
+          parseCommanderZonePrompt(wf, state.objects),
         ),
     ];
     for (const resolve of resolvers) {


### PR DESCRIPTION
Lets the human player decide their commander's zone choice instead of the AI: whenever the human's commander would move to the graveyard, exile, hand, or another zone, the control panel offers to send it to the command zone instead or leave it in place.

Mirrors the existing decision-wiring pattern (commit 8b4b847, issue #44):
- `src/sim/decisions/commanderZone.ts` (+ tests): `parseCommanderZonePrompt` / `commanderZoneAction`, submitting `DecideOptionalEffect { accept }`.
- `src/sim/driver.ts`: `requestHumanCommanderZone` callback + resolver.
- `src/match/RunView.tsx`: turn state, callback wiring, pass-turn interrupt, and a control panel (Command zone / Leave in {zone} / Let the AI decide).
- `src/i18n/messages.ts`: `commanderZone.*` keys (pt + en).
- domainbook: new feature doc, changelog v0.7.0, package.json bump.

Shapes confirmed against phase-rs v0.71.0's reference client per the engine interaction protocol; not yet round-tripped against a live cast (noted as an Open Question in the feature doc).

All gates green: lint, typecheck, duplication, test (231 passed, including 6 new commanderZone tests), build, and `domainbook check`.

Closes #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
