### PR TITLE
feat(sim): let the human choose X on X spells and abilities

### DIFF
--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,6 +12,15 @@ depth live there. A purely-internal PR that touches no product or architecture m
 skip its version with a `Skip-Docs: <reason>` trailer instead. There are no
 per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
+## [0.8.0] - 2026-09-05
+
+### Added
+
+- You now choose your own **X value** on X spells and X abilities: casting a
+  spell or activating an ability that asks for X prompts your seat with a
+  numeric picker bounded to the engine's allowed range, instead of the AI
+  deciding (`domains/simulation/features/choose-x-on-an-x-spell.md`).
+
 ## [0.7.0] - 2026-09-05
 
 ### Added

--- a/domainbook/domains/simulation/features/choose-x-on-an-x-spell.md
+++ b/domainbook/domains/simulation/features/choose-x-on-an-x-spell.md
@@ -1,0 +1,68 @@
+---
+id: choose-x-on-an-x-spell
+name: Choose X on an X spell or ability
+status: implemented
+---
+
+## Story
+
+As a player piloting my seat
+I want to pick X's value myself when I cast an X spell or activate an X ability
+So that a choice that decides my spell's power and cost is mine, not the AI's
+
+## Rule: An X choice prompts the human on their own cast or activation
+
+When the engine asks the human to resolve a `ChooseXValue` decision request —
+casting an X spell or activating an X ability that needs a value for X before
+the cost is paid — the seat's control panel shows a numeric picker naming the
+source. Other seats resolve it by AI action proposal as before, and any
+non-`ChooseXValue` state is untouched.
+
+```gherkin
+Example: The prompt appears on my own X spell
+  Given a play-mode match where I control seat 0
+  When I cast a spell that asks me to choose X
+  Then the control panel asks me to pick a value for X, naming the spell
+  And an opponent's X spell is still decided by the AI
+```
+
+## Rule: The value is bounded to the engine's allowed range
+
+The picker only accepts an integer between the engine's `min` (0 when the
+engine does not send one) and `max`. Confirm is disabled outside that range,
+so the seat can never submit an X value the engine would reject.
+
+```gherkin
+Example: The value is clamped to the allowed range
+  Given the choose-X prompt for my spell shows a range of 0 to 6
+  When I type a value outside that range
+  Then the picker clamps it back into range
+  And Confirm stays disabled until the value is a whole number in range
+```
+
+## Rule: Confirm submits the chosen X, and the choice can be handed to the AI
+
+Confirm submits `ChooseX { value }` with the picked number. Choosing let the
+AI decide hands the whole X choice back to the engine's own AI, so the
+decision is never stuck (`simulation/ADR-0001`).
+
+```gherkin
+Example: Confirming a value for X
+  Given the choose-X prompt for my spell is shown
+  When I type 3 and confirm
+  Then the engine casts the spell with X equal to 3
+
+Example: Letting the AI decide
+  Given the choose-X prompt is shown
+  When I choose let the AI decide
+  Then the engine's AI decides the value of X
+```
+
+## Open Questions
+
+- The `ChooseXValue` shape (`min?`, `max`, `pending_cast`, `x_cost_previews?`)
+  and the `ChooseX { value }` submission were confirmed against phase-rs
+  `client/src/adapter/types.ts` at v0.71.0, but not yet round-tripped against
+  a live cast. The panel does not yet surface `x_cost_previews` (the mana
+  each candidate X would cost) — showing that alongside the picker is a
+  follow-up.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -327,6 +327,19 @@ export const messages = {
   },
   "commanderZone.letAi": { pt: "IA decide", en: "Let the AI decide" },
 
+  "xValue.title": { pt: "Escolher X", en: "Choose X" },
+  "xValue.source": {
+    pt: "{name} pede um valor para X.",
+    en: "{name} asks for a value for X.",
+  },
+  "xValue.spellFallback": { pt: "Esta mágica", en: "This spell" },
+  "xValue.range": {
+    pt: "X pode ser {min}–{max}.",
+    en: "X can be {min}–{max}.",
+  },
+  "xValue.confirm": { pt: "Confirmar", en: "Confirm" },
+  "xValue.letAi": { pt: "IA decide", en: "Let the AI decide" },
+
   "modes.title": { pt: "Escolher modo", en: "Choose a mode" },
   "modes.source": {
     pt: "{name} pede uma escolha de modo.",

--- a/src/match/RunView.tsx
+++ b/src/match/RunView.tsx
@@ -52,6 +52,7 @@ import {
   commanderZoneAction,
   type CommanderZonePrompt,
 } from "../sim/decisions/commanderZone";
+import { chooseXAction, type XValuePrompt } from "../sim/decisions/xValue";
 import { XpWindow } from "../components/XpWindow";
 import {
   declareAttackersAction,
@@ -255,6 +256,11 @@ interface CommanderZoneTurn {
   resolve: (choice: HumanChoice) => void;
 }
 
+interface XValueTurn {
+  prompt: XValuePrompt;
+  resolve: (choice: HumanChoice) => void;
+}
+
 function formatZoneLabel(zone: string): string {
   if (!zone) return zone;
   return zone.charAt(0).toUpperCase() + zone.slice(1).toLowerCase();
@@ -394,6 +400,8 @@ interface RunnerCallbackDeps {
   >;
   setOptionalCostTurn: Dispatch<SetStateAction<OptionalCostTurn | null>>;
   setCommanderZoneTurn: Dispatch<SetStateAction<CommanderZoneTurn | null>>;
+  setXValuePick: Dispatch<SetStateAction<number>>;
+  setXValueTurn: Dispatch<SetStateAction<XValueTurn | null>>;
 }
 
 function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
@@ -428,6 +436,8 @@ function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
     setResolutionOptionalPaymentTurn,
     setOptionalCostTurn,
     setCommanderZoneTurn,
+    setXValuePick,
+    setXValueTurn,
   } = deps;
   return {
     onFrame: (env) => {
@@ -661,6 +671,22 @@ function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
           },
         });
       }),
+    requestHumanXValue: (_env, prompt) =>
+      new Promise<HumanChoice>((resolve) => {
+        if (isCancelled()) {
+          resolve({ ai: true });
+          return;
+        }
+        setXValuePick(prompt.min);
+        setXValueTurn({
+          prompt,
+          resolve: (choice) => {
+            setXValueTurn(null);
+            setXValuePick(prompt.min);
+            resolve(choice);
+          },
+        });
+      }),
   };
 }
 
@@ -757,6 +783,8 @@ export function RunView({
     useState<OptionalCostTurn | null>(null);
   const [commanderZoneTurn, setCommanderZoneTurn] =
     useState<CommanderZoneTurn | null>(null);
+  const [xValueTurn, setXValueTurn] = useState<XValueTurn | null>(null);
+  const [xValuePick, setXValuePick] = useState(0);
   const [passingTurn, setPassingTurn] = useState(false);
   const [logEntries, setLogEntries] = useState<LoggedEntry[]>([]);
   // On mobile the log is a full-screen drawer, so it always starts closed and
@@ -855,6 +883,8 @@ export function RunView({
             setResolutionOptionalPaymentTurn,
             setOptionalCostTurn,
             setCommanderZoneTurn,
+            setXValuePick,
+            setXValueTurn,
           }),
         );
         runnerRef.current = runner;
@@ -984,7 +1014,8 @@ export function RunView({
         scryTurn ||
         resolutionOptionalPaymentTurn ||
         optionalCostTurn ||
-        commanderZoneTurn)
+        commanderZoneTurn ||
+        xValueTurn)
     ) {
       setPassingTurn(false);
     }
@@ -999,6 +1030,7 @@ export function RunView({
     resolutionOptionalPaymentTurn,
     optionalCostTurn,
     commanderZoneTurn,
+    xValueTurn,
   ]);
 
   // Map draggable hand cards to their play actions for the current window.
@@ -1841,6 +1873,62 @@ export function RunView({
                   onClick={() => commanderZoneTurn.resolve({ ai: true })}
                 >
                   {t("commanderZone.letAi")}
+                </button>
+              </div>
+            </>
+          )}
+
+          {xValueTurn && (
+            <>
+              <div className="control-title">
+                <strong>{t("xValue.title")}</strong>
+              </div>
+              <p className="hint">
+                {t("xValue.source", {
+                  name: xValueTurn.prompt.sourceName || t("xValue.spellFallback"),
+                })}
+              </p>
+              <div className="import__row">
+                <input
+                  className="input"
+                  type="number"
+                  min={xValueTurn.prompt.min}
+                  max={xValueTurn.prompt.max}
+                  value={xValuePick}
+                  onChange={(e) => {
+                    const { min, max } = xValueTurn.prompt;
+                    const n = Math.round(Number(e.target.value));
+                    setXValuePick(
+                      Number.isFinite(n) ? Math.min(max, Math.max(min, n)) : min,
+                    );
+                  }}
+                />
+              </div>
+              <p className="hint">
+                {t("xValue.range", {
+                  min: xValueTurn.prompt.min,
+                  max: xValueTurn.prompt.max,
+                })}
+              </p>
+              <div className="import__row">
+                <button
+                  className="btn"
+                  disabled={
+                    !Number.isInteger(xValuePick) ||
+                    xValuePick < xValueTurn.prompt.min ||
+                    xValuePick > xValueTurn.prompt.max
+                  }
+                  onClick={() =>
+                    xValueTurn.resolve({ action: chooseXAction(xValuePick) })
+                  }
+                >
+                  {t("xValue.confirm")}
+                </button>
+                <button
+                  className="btn btn--ghost"
+                  onClick={() => xValueTurn.resolve({ ai: true })}
+                >
+                  {t("xValue.letAi")}
                 </button>
               </div>
             </>

--- a/src/sim/decisions/xValue.test.ts
+++ b/src/sim/decisions/xValue.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { parseXValuePrompt, chooseXAction } from "./xValue";
+import type { GameObject, WaitingFor } from "../../engine/types";
+
+// Shape confirmed against phase-rs client/src/adapter/types.ts (v0.71.0):
+// ChooseXValue { player, min?, max, pending_cast, x_cost_previews? }.
+const REAL_CHOOSE_X: WaitingFor = {
+  type: "ChooseXValue",
+  data: {
+    player: 0,
+    min: 1,
+    max: 6,
+    pending_cast: { object_id: 12, card_id: 900 },
+    x_cost_previews: [
+      [1, { generic: 1 }],
+      [2, { generic: 2 }],
+    ],
+  },
+};
+
+const OBJECTS: Record<string, GameObject> = {
+  12: { id: 12, name: "Fireball", zone: "Stack" },
+};
+
+describe("parseXValuePrompt", () => {
+  it("parses the player, source name, min and max", () => {
+    const p = parseXValuePrompt(REAL_CHOOSE_X, OBJECTS)!;
+    expect(p).not.toBeNull();
+    expect(p.player).toBe(0);
+    expect(p.sourceName).toBe("Fireball");
+    expect(p.min).toBe(1);
+    expect(p.max).toBe(6);
+  });
+
+  it("falls back to an empty source name when the object is unknown", () => {
+    const p = parseXValuePrompt(REAL_CHOOSE_X);
+    expect(p?.sourceName).toBe("");
+  });
+
+  it("defaults min to 0 when absent", () => {
+    const wf: WaitingFor = {
+      type: "ChooseXValue",
+      data: { player: 1, max: 10, pending_cast: { object_id: 3 } },
+    };
+    const p = parseXValuePrompt(wf)!;
+    expect(p.min).toBe(0);
+    expect(p.max).toBe(10);
+  });
+
+  it("returns null for a non-matching waiting_for", () => {
+    expect(parseXValuePrompt(undefined)).toBeNull();
+    expect(parseXValuePrompt({ type: "Priority", data: {} })).toBeNull();
+  });
+
+  it("returns null when max is missing", () => {
+    const wf: WaitingFor = {
+      type: "ChooseXValue",
+      data: { player: 0, pending_cast: {} },
+    };
+    expect(parseXValuePrompt(wf)).toBeNull();
+  });
+});
+
+describe("chooseXAction", () => {
+  it("builds the ChooseX action", () => {
+    expect(chooseXAction(3)).toEqual({
+      type: "ChooseX",
+      data: { value: 3 },
+    });
+  });
+
+  it("builds the action for a zero X", () => {
+    expect(chooseXAction(0)).toEqual({
+      type: "ChooseX",
+      data: { value: 0 },
+    });
+  });
+});

--- a/src/sim/decisions/xValue.ts
+++ b/src/sim/decisions/xValue.ts
@@ -1,0 +1,50 @@
+// "Choose X" — casting an X spell (or activating an X ability) asks the
+// controller to pick X's value before the cost is paid or the effect
+// resolves. The engine surfaces a `ChooseXValue` waiting_for whose `data`
+// carries the acting `player`, an optional `min` (defaults to 0 when
+// absent), the `max` X may be, the `pending_cast` naming the spell, and
+// optionally `x_cost_previews` (the mana each candidate X would cost). The
+// seat answers by submitting `ChooseX` with the chosen `value`.
+
+import type { GameObject, WaitingFor } from "../../engine/types";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export interface XValuePrompt {
+  player: number;
+  /** The spell or ability offering X, for the prompt (may be empty). */
+  sourceName: string;
+  /** The lowest value X may take. */
+  min: number;
+  /** The highest value X may take. */
+  max: number;
+}
+
+/** Read a "choose X" decision aimed at the human, or null. */
+export function parseXValuePrompt(
+  wf: WaitingFor | undefined,
+  objects?: Record<string, GameObject>,
+): XValuePrompt | null {
+  if (!wf || wf.type !== "ChooseXValue") return null;
+  const d: any = wf.data ?? {};
+  if (typeof d.max !== "number") return null;
+
+  const srcId = d.pending_cast?.object_id;
+  const sourceName =
+    (typeof srcId === "number" && objects?.[srcId]?.name) || "";
+
+  return {
+    player: typeof d.player === "number" ? d.player : 0,
+    sourceName,
+    min: typeof d.min === "number" ? d.min : 0,
+    max: d.max,
+  };
+}
+
+/** Submit the chosen X value back to the engine. */
+export function chooseXAction(value: number): {
+  type: string;
+  data: { value: number };
+} {
+  return { type: "ChooseX", data: { value } };
+}

--- a/src/sim/driver.ts
+++ b/src/sim/driver.ts
@@ -39,6 +39,7 @@ import {
   parseCommanderZonePrompt,
   type CommanderZonePrompt,
 } from "./decisions/commanderZone";
+import { parseXValuePrompt, type XValuePrompt } from "./decisions/xValue";
 
 export interface MatchResult {
   matchIndex: number;
@@ -260,6 +261,11 @@ export interface DriverCallbacks {
   requestHumanCommanderZone?: (
     env: GameStateEnvelope,
     prompt: CommanderZonePrompt,
+  ) => Promise<HumanChoice>;
+  /** Called when casting an X spell or activating an X ability asks the human to choose X. */
+  requestHumanXValue?: (
+    env: GameStateEnvelope,
+    prompt: XValuePrompt,
   ) => Promise<HumanChoice>;
 }
 
@@ -581,6 +587,8 @@ export class MatchRunner {
           cb.requestHumanCommanderZone,
           parseCommanderZonePrompt(wf, state.objects),
         ),
+      () =>
+        humanRequest(env, cb.requestHumanXValue, parseXValuePrompt(wf, state.objects)),
     ];
     for (const resolve of resolvers) {
       const req = resolve();


### PR DESCRIPTION
## Summary
Wires the engine's `ChooseXValue` decision to the human seat: casting an X spell or activating an X ability that needs a value for X now prompts the seat's control panel with a numeric picker (bounded to the engine's `min`/`max` range, defaulting `min` to 0) instead of the AI deciding. A "let the AI decide" escape is always available.

Confirmed against phase-rs v0.71.0's reference client: `ChooseXValue { player, min?, max, pending_cast, x_cost_previews? }` → `ChooseX { value }`.

## Changes
- `src/sim/decisions/xValue.ts` (+ `.test.ts`) — `parseXValuePrompt` / `chooseXAction`
- `src/sim/driver.ts` — `requestHumanXValue` callback + resolver
- `src/match/RunView.tsx` — `XValueTurn`, pick-state, panel UI
- `src/i18n/messages.ts` — `xValue.*` keys (pt/en)
- `domainbook/domains/simulation/features/choose-x-on-an-x-spell.md`
- `domainbook/changelog.md` — 0.8.0, `package.json` bump

## Verification
- `npm run lint` — pass
- `npm run typecheck` — pass
- `npm run duplication` — pass (0.92% total, well under 7% threshold)
- `npm test` — pass (238 passed, 3 skipped, including 7 new xValue tests)
- `npm run build` — pass
- `npx domainbook check --range main..HEAD` — nothing stale

Closes #42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)