### PR TITLE
feat(sim): let the human order their own simultaneous triggers

### DIFF
--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,6 +12,15 @@ depth live there. A purely-internal PR that touches no product or architecture m
 skip its version with a `Skip-Docs: <reason>` trailer instead. There are no
 per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
+## [0.9.0] - 2026-09-05
+
+### Added
+
+- You now order your own **simultaneous triggers**: when two or more of your
+  triggered abilities go on the stack at once, the control panel lets you
+  arrange them with ▲/▼ instead of the AI deciding
+  (`domains/simulation/features/order-your-own-triggers.md`).
+
 ## [0.8.0] - 2026-09-05
 
 ### Added

--- a/domainbook/domains/simulation/features/order-your-own-triggers.md
+++ b/domainbook/domains/simulation/features/order-your-own-triggers.md
@@ -1,0 +1,75 @@
+---
+id: order-your-own-triggers
+name: Order your own simultaneous triggers
+status: implemented
+---
+
+## Story
+
+As a player piloting my seat
+I want to choose the order my own simultaneous triggers go on the stack
+So that the sequencing of my triggers is mine to decide, not the AI's
+
+## Rule: A simultaneous-trigger prompt appears on the human's own triggers
+
+When two or more of the human's triggered abilities go on the stack at the
+same time, the engine surfaces an `OrderTriggers` decision request naming
+each pending trigger's source and description. The seat's control panel
+shows the list for arranging; any other seat's simultaneous triggers are
+still ordered by the AI, and non-`OrderTriggers` state is untouched.
+
+
+```gherkin
+Example: The prompt appears on my own simultaneous triggers
+  Given a play-mode match where I control seat 0
+  And two of my permanents trigger off the same event
+  When the engine asks me to order the resulting triggers
+  Then the control panel lists both triggers by source and description
+  And an opponent's simultaneous triggers are still ordered by the AI
+```
+
+## Rule: The list starts in the engine's default order and can be rearranged
+
+The panel starts with the identity order the engine sent (the array's own
+order) and lets the seat move any entry up or down with ▲/▼ buttons — the
+top entry's ▲ and the bottom entry's ▼ are disabled since there's nowhere
+left to move. The top of the list is placed on the stack first, so it
+resolves last; the panel says so.
+
+```gherkin
+Example: Rearranging the trigger order
+  Given the order-triggers prompt shows two triggers in their default order
+  When I move the second trigger to the top of the list
+  Then the list now shows that trigger first
+  And the panel still says the top of the list resolves last
+```
+
+## Rule: Confirm submits the arranged order, and the choice can be handed to the AI
+
+Confirm submits `OrderTriggers { order }`, a permutation of the triggers'
+original indices reflecting the seat's arrangement — the engine puts them on
+the stack in that order. Choosing let the AI decide hands the whole ordering
+back to the engine's own AI, so the decision is never stuck
+(`simulation/ADR-0001`).
+
+```gherkin
+Example: Confirming a chosen order
+  Given the order-triggers prompt shows triggers in positions [1, 0]
+  When I confirm
+  Then the engine puts trigger 1 on the stack first and trigger 0 second
+  And trigger 0 resolves first
+
+Example: Letting the AI decide
+  Given the order-triggers prompt is shown
+  When I choose let the AI decide
+  Then the engine's AI decides the order
+```
+
+## Open Questions
+
+- The `OrderTriggers` shape (`player`, `triggers: PendingTriggerSummary[]`
+  with `source_id`/`source_name`/`description`) and the
+  `OrderTriggers { order }` submission were confirmed against phase-rs
+  `client/src/adapter/types.ts` and its `TriggerOrderModal` at v0.71.0, but
+  not yet round-tripped against a live match with genuinely simultaneous
+  triggers.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -340,6 +340,23 @@ export const messages = {
   "xValue.confirm": { pt: "Confirmar", en: "Confirm" },
   "xValue.letAi": { pt: "IA decide", en: "Let the AI decide" },
 
+  "orderTriggers.title": {
+    pt: "Ordenar seus gatilhos",
+    en: "Order your triggers",
+  },
+  "orderTriggers.resolvesLast": {
+    pt: "O topo da lista é colocado na pilha primeiro, então resolve por último.",
+    en: "The top of the list is placed on the stack first, so it resolves last.",
+  },
+  "orderTriggers.triggerFallback": {
+    pt: "Gatilho {number}",
+    en: "Trigger {number}",
+  },
+  "orderTriggers.moveUp": { pt: "Mover para cima", en: "Move up" },
+  "orderTriggers.moveDown": { pt: "Mover para baixo", en: "Move down" },
+  "orderTriggers.confirm": { pt: "Confirmar", en: "Confirm" },
+  "orderTriggers.letAi": { pt: "IA decide", en: "Let the AI decide" },
+
   "modes.title": { pt: "Escolher modo", en: "Choose a mode" },
   "modes.source": {
     pt: "{name} pede uma escolha de modo.",

--- a/src/match/RunView.tsx
+++ b/src/match/RunView.tsx
@@ -53,6 +53,10 @@ import {
   type CommanderZonePrompt,
 } from "../sim/decisions/commanderZone";
 import { chooseXAction, type XValuePrompt } from "../sim/decisions/xValue";
+import {
+  orderTriggersAction,
+  type OrderTriggersPrompt,
+} from "../sim/decisions/orderTriggers";
 import { XpWindow } from "../components/XpWindow";
 import {
   declareAttackersAction,
@@ -261,6 +265,11 @@ interface XValueTurn {
   resolve: (choice: HumanChoice) => void;
 }
 
+interface OrderTriggersTurn {
+  prompt: OrderTriggersPrompt;
+  resolve: (choice: HumanChoice) => void;
+}
+
 function formatZoneLabel(zone: string): string {
   if (!zone) return zone;
   return zone.charAt(0).toUpperCase() + zone.slice(1).toLowerCase();
@@ -402,6 +411,8 @@ interface RunnerCallbackDeps {
   setCommanderZoneTurn: Dispatch<SetStateAction<CommanderZoneTurn | null>>;
   setXValuePick: Dispatch<SetStateAction<number>>;
   setXValueTurn: Dispatch<SetStateAction<XValueTurn | null>>;
+  setOrderTriggersPick: Dispatch<SetStateAction<number[]>>;
+  setOrderTriggersTurn: Dispatch<SetStateAction<OrderTriggersTurn | null>>;
 }
 
 function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
@@ -438,6 +449,8 @@ function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
     setCommanderZoneTurn,
     setXValuePick,
     setXValueTurn,
+    setOrderTriggersPick,
+    setOrderTriggersTurn,
   } = deps;
   return {
     onFrame: (env) => {
@@ -687,6 +700,23 @@ function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
           },
         });
       }),
+    requestHumanOrderTriggers: (_env, prompt) =>
+      new Promise<HumanChoice>((resolve) => {
+        if (isCancelled()) {
+          resolve({ ai: true });
+          return;
+        }
+        const identity = prompt.triggers.map((_, i) => i);
+        setOrderTriggersPick(identity);
+        setOrderTriggersTurn({
+          prompt,
+          resolve: (choice) => {
+            setOrderTriggersTurn(null);
+            setOrderTriggersPick(identity);
+            resolve(choice);
+          },
+        });
+      }),
   };
 }
 
@@ -785,6 +815,9 @@ export function RunView({
     useState<CommanderZoneTurn | null>(null);
   const [xValueTurn, setXValueTurn] = useState<XValueTurn | null>(null);
   const [xValuePick, setXValuePick] = useState(0);
+  const [orderTriggersTurn, setOrderTriggersTurn] =
+    useState<OrderTriggersTurn | null>(null);
+  const [orderTriggersPick, setOrderTriggersPick] = useState<number[]>([]);
   const [passingTurn, setPassingTurn] = useState(false);
   const [logEntries, setLogEntries] = useState<LoggedEntry[]>([]);
   // On mobile the log is a full-screen drawer, so it always starts closed and
@@ -885,6 +918,8 @@ export function RunView({
             setCommanderZoneTurn,
             setXValuePick,
             setXValueTurn,
+            setOrderTriggersPick,
+            setOrderTriggersTurn,
           }),
         );
         runnerRef.current = runner;
@@ -1015,7 +1050,8 @@ export function RunView({
         resolutionOptionalPaymentTurn ||
         optionalCostTurn ||
         commanderZoneTurn ||
-        xValueTurn)
+        xValueTurn ||
+        orderTriggersTurn)
     ) {
       setPassingTurn(false);
     }
@@ -1031,6 +1067,7 @@ export function RunView({
     optionalCostTurn,
     commanderZoneTurn,
     xValueTurn,
+    orderTriggersTurn,
   ]);
 
   // Map draggable hand cards to their play actions for the current window.
@@ -1929,6 +1966,85 @@ export function RunView({
                   onClick={() => xValueTurn.resolve({ ai: true })}
                 >
                   {t("xValue.letAi")}
+                </button>
+              </div>
+            </>
+          )}
+
+          {orderTriggersTurn && (
+            <>
+              <div className="control-title">
+                <strong>{t("orderTriggers.title")}</strong>
+              </div>
+              <p className="hint">{t("orderTriggers.resolvesLast")}</p>
+              {orderTriggersPick.map((triggerIndex, position) => {
+                const trigger = orderTriggersTurn.prompt.triggers[triggerIndex];
+                return (
+                  <div className="import__row" key={triggerIndex}>
+                    <div>
+                      <strong>
+                        {trigger.sourceName ||
+                          t("orderTriggers.triggerFallback", {
+                            number: triggerIndex + 1,
+                          })}
+                      </strong>
+                      {trigger.description && (
+                        <p className="hint">{trigger.description}</p>
+                      )}
+                    </div>
+                    <button
+                      className="btn btn--ghost"
+                      aria-label={t("orderTriggers.moveUp")}
+                      disabled={position === 0}
+                      onClick={() =>
+                        setOrderTriggersPick((prev) => {
+                          const next = [...prev];
+                          [next[position - 1], next[position]] = [
+                            next[position],
+                            next[position - 1],
+                          ];
+                          return next;
+                        })
+                      }
+                    >
+                      ▲
+                    </button>
+                    <button
+                      className="btn btn--ghost"
+                      aria-label={t("orderTriggers.moveDown")}
+                      disabled={position === orderTriggersPick.length - 1}
+                      onClick={() =>
+                        setOrderTriggersPick((prev) => {
+                          const next = [...prev];
+                          [next[position], next[position + 1]] = [
+                            next[position + 1],
+                            next[position],
+                          ];
+                          return next;
+                        })
+                      }
+                    >
+                      ▼
+                    </button>
+                  </div>
+                );
+              })}
+              <div className="import__row">
+                <button
+                  className="btn"
+                  onClick={() =>
+                    orderTriggersTurn.resolve({
+                      action: orderTriggersAction(orderTriggersPick),
+                    })
+                  }
+                >
+                  {t("orderTriggers.confirm")}
+                </button>
+                <button
+                  className="btn btn--ghost"
+                  onClick={() => orderTriggersTurn.resolve({ ai: true })}
+                >
+                  {t("orderTriggers.letAi")}
                 </button>
               </div>
             </>

--- a/src/sim/decisions/orderTriggers.test.ts
+++ b/src/sim/decisions/orderTriggers.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { parseOrderTriggersPrompt, orderTriggersAction } from "./orderTriggers";
+import type { WaitingFor } from "../../engine/types";
+
+// Shape confirmed against phase-rs client/src/adapter/types.ts (v0.71.0):
+// OrderTriggers { player, triggers: PendingTriggerSummary[] } where each
+// PendingTriggerSummary is { source_id, source_name, description }.
+const REAL_ORDER_TRIGGERS: WaitingFor = {
+  type: "OrderTriggers",
+  data: {
+    player: 0,
+    triggers: [
+      {
+        source_id: 12,
+        source_name: "Blood Artist",
+        description: "Target player loses 1 life and you gain 1 life.",
+      },
+      {
+        source_id: 34,
+        source_name: "Zulaport Cutthroat",
+        description: "Each opponent loses 1 life and you gain 1 life.",
+      },
+      {
+        source_id: 56,
+        source_name: "Cruel Celebrant",
+        description: "Target opponent loses 1 life and you gain 1 life.",
+      },
+    ],
+  },
+};
+
+describe("parseOrderTriggersPrompt", () => {
+  it("parses the player and each pending trigger", () => {
+    const p = parseOrderTriggersPrompt(REAL_ORDER_TRIGGERS)!;
+    expect(p).not.toBeNull();
+    expect(p.player).toBe(0);
+    expect(p.triggers).toEqual([
+      {
+        sourceId: 12,
+        sourceName: "Blood Artist",
+        description: "Target player loses 1 life and you gain 1 life.",
+      },
+      {
+        sourceId: 34,
+        sourceName: "Zulaport Cutthroat",
+        description: "Each opponent loses 1 life and you gain 1 life.",
+      },
+      {
+        sourceId: 56,
+        sourceName: "Cruel Celebrant",
+        description: "Target opponent loses 1 life and you gain 1 life.",
+      },
+    ]);
+  });
+
+  it("falls back to empty strings when a trigger has no name or description", () => {
+    const wf: WaitingFor = {
+      type: "OrderTriggers",
+      data: { player: 1, triggers: [{ source_id: 7 }] },
+    };
+    const p = parseOrderTriggersPrompt(wf)!;
+    expect(p.triggers).toEqual([
+      { sourceId: 7, sourceName: "", description: "" },
+    ]);
+  });
+
+  it("returns null for a non-matching waiting_for", () => {
+    expect(parseOrderTriggersPrompt(undefined)).toBeNull();
+    expect(parseOrderTriggersPrompt({ type: "Priority", data: {} })).toBeNull();
+  });
+
+  it("returns null when triggers is missing or empty", () => {
+    expect(
+      parseOrderTriggersPrompt({ type: "OrderTriggers", data: { player: 0 } }),
+    ).toBeNull();
+    expect(
+      parseOrderTriggersPrompt({
+        type: "OrderTriggers",
+        data: { player: 0, triggers: [] },
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("orderTriggersAction", () => {
+  it("builds the OrderTriggers action with the chosen permutation", () => {
+    expect(orderTriggersAction([2, 0, 1])).toEqual({
+      type: "OrderTriggers",
+      data: { order: [2, 0, 1] },
+    });
+  });
+
+  it("builds the identity order", () => {
+    expect(orderTriggersAction([0, 1, 2])).toEqual({
+      type: "OrderTriggers",
+      data: { order: [0, 1, 2] },
+    });
+  });
+});

--- a/src/sim/decisions/orderTriggers.ts
+++ b/src/sim/decisions/orderTriggers.ts
@@ -1,0 +1,53 @@
+// Ordering simultaneous triggers — when two or more of the acting player's
+// triggered abilities go on the stack at the same time, that player chooses
+// the order they're put on the stack in. The engine surfaces an
+// `OrderTriggers` waiting_for whose `data` carries the acting `player` and
+// the pending `triggers` (each a `PendingTriggerSummary`: `source_id`,
+// `source_name`, `description`). The seat answers by submitting
+// `OrderTriggers` with an `order`: a permutation of the indices
+// `0..triggers.length-1` into that array. The engine puts them on the stack
+// in that order, so the first index goes on first and resolves last (LIFO).
+
+import type { WaitingFor } from "../../engine/types";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export interface PendingTriggerSummary {
+  sourceId: number;
+  sourceName: string;
+  description: string;
+}
+
+export interface OrderTriggersPrompt {
+  player: number;
+  triggers: PendingTriggerSummary[];
+}
+
+/** Read an "order your triggers" decision aimed at the human, or null. */
+export function parseOrderTriggersPrompt(
+  wf: WaitingFor | undefined,
+): OrderTriggersPrompt | null {
+  if (!wf || wf.type !== "OrderTriggers") return null;
+  const d: any = wf.data ?? {};
+  const rawTriggers = d.triggers;
+  if (!Array.isArray(rawTriggers) || rawTriggers.length === 0) return null;
+
+  const triggers: PendingTriggerSummary[] = rawTriggers.map((t: any) => ({
+    sourceId: typeof t?.source_id === "number" ? t.source_id : 0,
+    sourceName: typeof t?.source_name === "string" ? t.source_name : "",
+    description: typeof t?.description === "string" ? t.description : "",
+  }));
+
+  return {
+    player: typeof d.player === "number" ? d.player : 0,
+    triggers,
+  };
+}
+
+/** Submit the chosen stack order back to the engine. */
+export function orderTriggersAction(order: number[]): {
+  type: string;
+  data: { order: number[] };
+} {
+  return { type: "OrderTriggers", data: { order } };
+}

--- a/src/sim/driver.ts
+++ b/src/sim/driver.ts
@@ -40,6 +40,10 @@ import {
   type CommanderZonePrompt,
 } from "./decisions/commanderZone";
 import { parseXValuePrompt, type XValuePrompt } from "./decisions/xValue";
+import {
+  parseOrderTriggersPrompt,
+  type OrderTriggersPrompt,
+} from "./decisions/orderTriggers";
 
 export interface MatchResult {
   matchIndex: number;
@@ -266,6 +270,11 @@ export interface DriverCallbacks {
   requestHumanXValue?: (
     env: GameStateEnvelope,
     prompt: XValuePrompt,
+  ) => Promise<HumanChoice>;
+  /** Called when two or more of the human's triggers go on the stack at once and must be ordered. */
+  requestHumanOrderTriggers?: (
+    env: GameStateEnvelope,
+    prompt: OrderTriggersPrompt,
   ) => Promise<HumanChoice>;
 }
 
@@ -589,6 +598,12 @@ export class MatchRunner {
         ),
       () =>
         humanRequest(env, cb.requestHumanXValue, parseXValuePrompt(wf, state.objects)),
+      () =>
+        humanRequest(
+          env,
+          cb.requestHumanOrderTriggers,
+          parseOrderTriggersPrompt(wf),
+        ),
     ];
     for (const resolve of resolvers) {
       const req = resolve();


### PR DESCRIPTION
## Summary

Surfaces the engine's `OrderTriggers` decision to the human seat instead of
letting the AI decide. When two or more of the human's triggered abilities
go on the stack at the same time, the control panel lists them (source name
+ description) with ▲/▼ buttons to reorder, a hint that the top of the list
resolves last, a Confirm button, and a ghost "let the AI decide" fallback.

Confirmed against phase-rs v0.71.0's reference client (`TriggerOrderModal`,
`client/src/adapter/types.ts`): `OrderTriggers` data is `{ player, triggers:
PendingTriggerSummary[] }`; the submission is `OrderTriggers { order }`
where `order` is a permutation of the indices `0..triggers.length-1`.

## Changes

- `src/sim/decisions/orderTriggers.ts` (+ `.test.ts`): `parseOrderTriggersPrompt`
  / `orderTriggersAction`.
- `src/sim/driver.ts`: `requestHumanOrderTriggers` callback + resolver.
- `src/match/RunView.tsx`: `OrderTriggersTurn`, pick-state reset to the
  identity permutation on each new prompt, panel with per-row up/down
  reordering.
- `src/i18n/messages.ts`: `orderTriggers.*` keys (pt/en).
- `domainbook/domains/simulation/features/order-your-own-triggers.md` +
  changelog `[0.9.0]` + `package.json` bump.

## Gates

`npm run lint && npm run typecheck && npm run duplication && npm test && npm run build` — all pass.
`npx domainbook check --range main..HEAD` — nothing stale.

Closes #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)