### PR TITLE
feat(sim): let the human browse search/tutor and fetch-land results

### DIFF
--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,6 +12,16 @@ depth live there. A purely-internal PR that touches no product or architecture m
 skip its version with a `Skip-Docs: <reason>` trailer instead. There are no
 per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
+## [0.10.0] - 2026-09-05
+
+### Added
+
+- You now browse your own **tutor/search and fetch-land results**: searching
+  your library, splitting a fetch between two destinations, or picking from
+  outside the game (Wish effects) lists the candidates for your seat to pick,
+  instead of the AI deciding
+  (`domains/simulation/features/browse-a-search-yourself.md`).
+
 ## [0.9.0] - 2026-09-05
 
 ### Added

--- a/domainbook/domains/simulation/features/browse-a-search-yourself.md
+++ b/domainbook/domains/simulation/features/browse-a-search-yourself.md
@@ -1,0 +1,101 @@
+---
+id: browse-a-search-yourself
+name: Browse a search yourself
+status: implemented
+---
+
+## Story
+
+As a player piloting my seat
+I want to browse my own tutor/search, fetch-land, and outside-the-game results
+So that which cards I find is mine to pick, not the AI's
+
+## Rule: A search prompt appears on the human's own tutor or fetch
+
+When the human's spell or ability searches the library, the engine surfaces a
+`SearchChoice` decision request naming the candidate cards and how many to
+pick. The seat's control panel lists them by name for browsing; any other
+seat's search is still resolved by the AI, and non-search state is untouched.
+
+```gherkin
+Example: The prompt appears on my own tutor
+  Given a play-mode match where I control seat 0
+  When I cast a spell that searches my library for a card
+  Then the control panel lists the candidate cards by name
+  And an opponent's tutor is still resolved by the AI
+```
+
+## Rule: Picking respects the count, exactly or up to
+
+Clicking a listed card toggles it, up to the offered `count`; once `count`
+cards are picked, unpicked rows stop responding to clicks until one is
+deselected. When the search allows a partial find (`up_to` or
+`allows_partial_find`), Confirm is enabled with anywhere from zero to `count`
+picked; otherwise Confirm stays disabled until exactly `count` are picked. A
+running "selected X of N" hint tracks progress either way.
+
+```gherkin
+Example: An exact-count search requires filling every pick
+  Given a search prompt asking for exactly 1 card among 3
+  When I pick 1 card
+  Then Confirm becomes enabled
+
+Example: An up-to search accepts fewer than the offered count
+  Given a search prompt for up to 1 card that allows a partial find
+  When I pick 0 cards
+  Then Confirm is still enabled
+```
+
+## Rule: A fetch-land partition splits the pool between two destinations
+
+A `SearchPartitionChoice` (a fetch land is the common case) offers the same
+candidate list, but the panel names both destinations: the `primary_count`
+cards picked go to `primary_destination`, and the rest go to
+`rest_destination`. The pick is always exact — a fetch land does not offer a
+partial find.
+
+```gherkin
+Example: Fetching a land
+  Given a search-partition prompt sending 1 card to the battlefield and the rest to the graveyard
+  Then the panel names both destinations
+  And Confirm requires picking exactly 1 card
+```
+
+## Rule: An outside-the-game choice lists entries by name and submits their source
+
+An `OutsideGameChoice` (Wish effects and the like) lists each candidate by its
+`name` — a sideboard card or a face-up exiled card — instead of an object id.
+Confirming submits each picked entry's own `source` field back to the engine
+verbatim, so a sideboard pick and a face-up-exile pick round-trip correctly
+even though they carry different shapes.
+
+```gherkin
+Example: Wishing for a sideboard card
+  Given an outside-game prompt listing a sideboard card and a face-up exiled card
+  When I pick the sideboard card and confirm
+  Then the engine receives that entry's Sideboard source, not the exile source
+```
+
+## Rule: The choice can be handed to the AI
+
+Choosing let the AI decide hands the whole search, partition, or
+outside-the-game choice back to the engine's own AI, so the decision is never
+stuck (`simulation/ADR-0001`).
+
+```gherkin
+Example: Letting the AI decide
+  Given a search prompt is shown
+  When I choose let the AI decide
+  Then the engine's AI picks the cards
+```
+
+## Open Questions
+
+- The `SearchChoice`, `SearchPartitionChoice`, and `OutsideGameChoice` shapes,
+  and the `SelectCards` / `ChooseOutsideGameCards` submissions, were confirmed
+  against phase-rs `client/src/adapter/types.ts` at v0.71.0, but not yet
+  round-tripped against a live tutor, fetch land, or Wish effect.
+- Destination zone names (`primary_destination`, `rest_destination`,
+  `destination`) are shown as the engine's own raw strings, capitalized, the
+  same as the existing commander-zone prompt — there is no dedicated
+  zone-label i18n convention in the project to plug into instead.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",

--- a/src/App.css
+++ b/src/App.css
@@ -926,6 +926,19 @@ th {
   margin: 0.4rem 0 0.15rem;
   font-size: 1rem;
 }
+.search-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  max-height: 260px;
+  overflow-y: auto;
+  margin: 0.5rem 0;
+}
+.search-list .btn,
+.search-list .btn--ghost {
+  width: 100%;
+  text-align: left;
+}
 
 /* ── Board ─────────────────────────────────────────────────────── */
 /* Opponents share a row on top; the player's seat sits centered below. */

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -357,6 +357,19 @@ export const messages = {
   "orderTriggers.confirm": { pt: "Confirmar", en: "Confirm" },
   "orderTriggers.letAi": { pt: "IA decide", en: "Let the AI decide" },
 
+  "search.title": { pt: "Buscar no grimório", en: "Search your library" },
+  "search.partitionTitle": {
+    pt: "Buscar e dividir entre {primary} e {rest}",
+    en: "Search and split between {primary} and {rest}",
+  },
+  "search.outsideTitle": {
+    pt: "Escolher fora do jogo",
+    en: "Choose from outside the game",
+  },
+  "search.selected": { pt: "Selecionadas: {n} / {max}", en: "Selected: {n} / {max}" },
+  "search.confirm": { pt: "Confirmar", en: "Confirm" },
+  "search.letAi": { pt: "IA decide", en: "Let the AI decide" },
+
   "modes.title": { pt: "Escolher modo", en: "Choose a mode" },
   "modes.source": {
     pt: "{name} pede uma escolha de modo.",

--- a/src/match/RunView.tsx
+++ b/src/match/RunView.tsx
@@ -57,6 +57,12 @@ import {
   orderTriggersAction,
   type OrderTriggersPrompt,
 } from "../sim/decisions/orderTriggers";
+import {
+  selectSearchCardsAction,
+  chooseOutsideGameAction,
+  type SearchDecisionPrompt,
+  type OutsideGameSelection,
+} from "../sim/decisions/search";
 import { XpWindow } from "../components/XpWindow";
 import {
   declareAttackersAction,
@@ -270,9 +276,104 @@ interface OrderTriggersTurn {
   resolve: (choice: HumanChoice) => void;
 }
 
+interface SearchTurn {
+  prompt: SearchDecisionPrompt;
+  resolve: (choice: HumanChoice) => void;
+}
+
 function formatZoneLabel(zone: string): string {
   if (!zone) return zone;
   return zone.charAt(0).toUpperCase() + zone.slice(1).toLowerCase();
+}
+
+/** One row in the search/outside-game candidate list: a stable key plus its label. */
+interface SearchListItem {
+  key: number;
+  label: string;
+}
+
+function searchListItems(prompt: SearchDecisionPrompt): SearchListItem[] {
+  if (prompt.kind === "outside") {
+    return prompt.entries.map((entry, i) => ({ key: i, label: entry.label }));
+  }
+  return prompt.cards.map((card) => ({ key: card.id, label: card.name }));
+}
+
+/** Build the confirm action: card ids for search/partition, entry sources for outside-game. */
+function searchConfirmAction(prompt: SearchDecisionPrompt, pick: number[]) {
+  if (prompt.kind === "outside") {
+    return chooseOutsideGameAction(
+      pick.map((i) => prompt.entries[i].source as OutsideGameSelection),
+    );
+  }
+  return selectSearchCardsAction(pick);
+}
+
+function searchPanelTitle(
+  prompt: SearchDecisionPrompt,
+  t: (key: MsgKey, vars?: Vars) => string,
+): string {
+  if (prompt.kind === "partition") {
+    return t("search.partitionTitle", {
+      primary: formatZoneLabel(prompt.primaryDestination),
+      rest: formatZoneLabel(prompt.restDestination),
+    });
+  }
+  if (prompt.kind === "outside") return t("search.outsideTitle");
+  return t("search.title");
+}
+
+function SearchPanel({
+  turn,
+  pick,
+  onTogglePick,
+  onConfirm,
+  onLetAi,
+}: {
+  turn: SearchTurn;
+  pick: number[];
+  onTogglePick: (key: number) => void;
+  onConfirm: () => void;
+  onLetAi: () => void;
+}) {
+  const { t } = useI18n();
+  const { prompt } = turn;
+  const atCap = pick.length >= prompt.count;
+  const upTo = prompt.kind === "search" && prompt.upTo;
+  const valid = upTo ? pick.length <= prompt.count : pick.length === prompt.count;
+  return (
+    <>
+      <div className="control-title">
+        <strong>{searchPanelTitle(prompt, t)}</strong>
+      </div>
+      <p className="hint">
+        {t("search.selected", { n: pick.length, max: prompt.count })}
+      </p>
+      <div className="search-list">
+        {searchListItems(prompt).map((item) => {
+          const picked = pick.includes(item.key);
+          return (
+            <button
+              key={item.key}
+              className={picked ? "btn" : "btn--ghost"}
+              disabled={!picked && atCap}
+              onClick={() => onTogglePick(item.key)}
+            >
+              {item.label}
+            </button>
+          );
+        })}
+      </div>
+      <div className="import__row">
+        <button className="btn" disabled={!valid} onClick={onConfirm}>
+          {t("search.confirm")}
+        </button>
+        <button className="btn btn--ghost" onClick={onLetAi}>
+          {t("search.letAi")}
+        </button>
+      </div>
+    </>
+  );
 }
 
 function isTargetOptional(
@@ -413,6 +514,8 @@ interface RunnerCallbackDeps {
   setXValueTurn: Dispatch<SetStateAction<XValueTurn | null>>;
   setOrderTriggersPick: Dispatch<SetStateAction<number[]>>;
   setOrderTriggersTurn: Dispatch<SetStateAction<OrderTriggersTurn | null>>;
+  setSearchPick: Dispatch<SetStateAction<number[]>>;
+  setSearchTurn: Dispatch<SetStateAction<SearchTurn | null>>;
 }
 
 function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
@@ -451,6 +554,8 @@ function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
     setXValueTurn,
     setOrderTriggersPick,
     setOrderTriggersTurn,
+    setSearchPick,
+    setSearchTurn,
   } = deps;
   return {
     onFrame: (env) => {
@@ -717,6 +822,22 @@ function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
           },
         });
       }),
+    requestHumanSearch: (_env, prompt) =>
+      new Promise<HumanChoice>((resolve) => {
+        if (isCancelled()) {
+          resolve({ ai: true });
+          return;
+        }
+        setSearchPick([]);
+        setSearchTurn({
+          prompt,
+          resolve: (choice) => {
+            setSearchTurn(null);
+            setSearchPick([]);
+            resolve(choice);
+          },
+        });
+      }),
   };
 }
 
@@ -818,6 +939,8 @@ export function RunView({
   const [orderTriggersTurn, setOrderTriggersTurn] =
     useState<OrderTriggersTurn | null>(null);
   const [orderTriggersPick, setOrderTriggersPick] = useState<number[]>([]);
+  const [searchTurn, setSearchTurn] = useState<SearchTurn | null>(null);
+  const [searchPick, setSearchPick] = useState<number[]>([]);
   const [passingTurn, setPassingTurn] = useState(false);
   const [logEntries, setLogEntries] = useState<LoggedEntry[]>([]);
   // On mobile the log is a full-screen drawer, so it always starts closed and
@@ -920,6 +1043,8 @@ export function RunView({
             setXValueTurn,
             setOrderTriggersPick,
             setOrderTriggersTurn,
+            setSearchPick,
+            setSearchTurn,
           }),
         );
         runnerRef.current = runner;
@@ -1051,7 +1176,8 @@ export function RunView({
         optionalCostTurn ||
         commanderZoneTurn ||
         xValueTurn ||
-        orderTriggersTurn)
+        orderTriggersTurn ||
+        searchTurn)
     ) {
       setPassingTurn(false);
     }
@@ -1068,6 +1194,7 @@ export function RunView({
     commanderZoneTurn,
     xValueTurn,
     orderTriggersTurn,
+    searchTurn,
   ]);
 
   // Map draggable hand cards to their play actions for the current window.
@@ -2048,6 +2175,26 @@ export function RunView({
                 </button>
               </div>
             </>
+          )}
+
+          {searchTurn && (
+            <SearchPanel
+              turn={searchTurn}
+              pick={searchPick}
+              onTogglePick={(key) =>
+                setSearchPick((prev) => {
+                  if (prev.includes(key)) return prev.filter((k) => k !== key);
+                  if (prev.length >= searchTurn.prompt.count) return prev;
+                  return [...prev, key];
+                })
+              }
+              onConfirm={() =>
+                searchTurn.resolve({
+                  action: searchConfirmAction(searchTurn.prompt, searchPick),
+                })
+              }
+              onLetAi={() => searchTurn.resolve({ ai: true })}
+            />
           )}
         </section>
       )}

--- a/src/sim/decisions/search.test.ts
+++ b/src/sim/decisions/search.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseSearchPrompt,
+  selectSearchCardsAction,
+  chooseOutsideGameAction,
+} from "./search";
+import type { GameState, WaitingFor } from "../../engine/types";
+
+// Shapes confirmed against phase-rs client/src/adapter/types.ts (v0.71.0):
+// SearchChoice { player, cards, count, up_to?, allows_partial_find? }.
+const REAL_SEARCH: WaitingFor = {
+  type: "SearchChoice",
+  data: {
+    player: 0,
+    cards: [12, 34, 56],
+    count: 1,
+    up_to: true,
+  },
+};
+
+// SearchPartitionChoice { player, cards, primary_destination, primary_count,
+// primary_enter_tapped, rest_destination, source_id }.
+const REAL_PARTITION: WaitingFor = {
+  type: "SearchPartitionChoice",
+  data: {
+    player: 0,
+    cards: [12, 34, 56],
+    primary_destination: "Battlefield",
+    primary_count: 1,
+    primary_enter_tapped: true,
+    rest_destination: "Graveyard",
+    source_id: 78,
+  },
+};
+
+// OutsideGameChoice { player, source_id, choices: { source, count, name }[],
+// count, destination }.
+const REAL_OUTSIDE: WaitingFor = {
+  type: "OutsideGameChoice",
+  data: {
+    player: 0,
+    source_id: 90,
+    choices: [
+      { source: { type: "Sideboard", data: { sideboard_index: 2 } }, count: 1, name: "Beast Within" },
+      { source: { type: "FaceUpExile", data: { object_id: 44 } }, count: 1, name: "Regrowth" },
+    ],
+    count: 1,
+    destination: "Hand",
+  },
+};
+
+const STATE: GameState = {
+  turn_number: 1,
+  phase: "Main1",
+  active_player: 0,
+  waiting_for: { type: "Priority" },
+  players: [],
+  objects: {
+    12: { id: 12, name: "Sol Ring", zone: "Library" },
+    34: { id: 34, name: "Arcane Signet", zone: "Library" },
+    56: { id: 56, name: "Command Tower", zone: "Library" },
+  },
+  battlefield: [],
+  command_zone: [],
+  stack: [],
+  eliminated_players: [],
+};
+
+describe("parseSearchPrompt", () => {
+  describe("SearchChoice", () => {
+    it("parses the player, cards, count and upTo (up_to)", () => {
+      const p = parseSearchPrompt(REAL_SEARCH, STATE)!;
+      expect(p).not.toBeNull();
+      if (p.kind !== "search") throw new Error("expected a search prompt");
+      expect(p.player).toBe(0);
+      expect(p.count).toBe(1);
+      expect(p.upTo).toBe(true);
+      expect(p.cards).toEqual([
+        { id: 12, name: "Sol Ring" },
+        { id: 34, name: "Arcane Signet" },
+        { id: 56, name: "Command Tower" },
+      ]);
+    });
+
+    it("falls back to empty card names when state is omitted", () => {
+      const p = parseSearchPrompt(REAL_SEARCH);
+      if (p?.kind !== "search") throw new Error("expected a search prompt");
+      expect(p.cards.map((c) => c.name)).toEqual(["", "", ""]);
+    });
+
+    it("treats allows_partial_find as upTo too", () => {
+      const wf: WaitingFor = {
+        type: "SearchChoice",
+        data: { player: 1, cards: [1], count: 2, allows_partial_find: true },
+      };
+      const p = parseSearchPrompt(wf);
+      if (p?.kind !== "search") throw new Error("expected a search prompt");
+      expect(p.upTo).toBe(true);
+    });
+
+    it("is not upTo when neither up_to nor allows_partial_find is set", () => {
+      const wf: WaitingFor = {
+        type: "SearchChoice",
+        data: { player: 1, cards: [1], count: 1 },
+      };
+      const p = parseSearchPrompt(wf);
+      if (p?.kind !== "search") throw new Error("expected a search prompt");
+      expect(p.upTo).toBe(false);
+    });
+
+    it("returns null when cards is empty", () => {
+      const wf: WaitingFor = {
+        type: "SearchChoice",
+        data: { player: 0, cards: [], count: 1 },
+      };
+      expect(parseSearchPrompt(wf)).toBeNull();
+    });
+  });
+
+  describe("SearchPartitionChoice", () => {
+    it("parses the player, cards, primary_count as count, and both destinations", () => {
+      const p = parseSearchPrompt(REAL_PARTITION, STATE)!;
+      expect(p).not.toBeNull();
+      if (p.kind !== "partition") throw new Error("expected a partition prompt");
+      expect(p.player).toBe(0);
+      expect(p.count).toBe(1);
+      expect(p.upTo).toBe(false);
+      expect(p.primaryDestination).toBe("Battlefield");
+      expect(p.restDestination).toBe("Graveyard");
+      expect(p.cards).toEqual([
+        { id: 12, name: "Sol Ring" },
+        { id: 34, name: "Arcane Signet" },
+        { id: 56, name: "Command Tower" },
+      ]);
+    });
+
+    it("returns null when cards is empty", () => {
+      const wf: WaitingFor = {
+        type: "SearchPartitionChoice",
+        data: {
+          player: 0,
+          cards: [],
+          primary_destination: "Battlefield",
+          primary_count: 1,
+          rest_destination: "Graveyard",
+        },
+      };
+      expect(parseSearchPrompt(wf)).toBeNull();
+    });
+  });
+
+  describe("OutsideGameChoice", () => {
+    it("parses the player, entries (label + source), count and destination", () => {
+      const p = parseSearchPrompt(REAL_OUTSIDE)!;
+      expect(p).not.toBeNull();
+      expect(p.kind).toBe("outside");
+      expect(p.player).toBe(0);
+      expect(p.count).toBe(1);
+      if (p.kind === "outside") {
+        expect(p.destination).toBe("Hand");
+        expect(p.entries).toEqual([
+          {
+            label: "Beast Within",
+            source: { type: "Sideboard", data: { sideboard_index: 2 } },
+          },
+          {
+            label: "Regrowth",
+            source: { type: "FaceUpExile", data: { object_id: 44 } },
+          },
+        ]);
+      }
+    });
+
+    it("returns null when choices is empty", () => {
+      const wf: WaitingFor = {
+        type: "OutsideGameChoice",
+        data: { player: 0, choices: [], count: 1, destination: "Hand" },
+      };
+      expect(parseSearchPrompt(wf)).toBeNull();
+    });
+  });
+
+  it("returns null for a non-matching waiting_for", () => {
+    expect(parseSearchPrompt(undefined)).toBeNull();
+    expect(parseSearchPrompt({ type: "Priority", data: {} })).toBeNull();
+  });
+});
+
+describe("selectSearchCardsAction", () => {
+  it("builds the SelectCards action", () => {
+    expect(selectSearchCardsAction([12, 34])).toEqual({
+      type: "SelectCards",
+      data: { cards: [12, 34] },
+    });
+  });
+
+  it("builds the action for an empty selection", () => {
+    expect(selectSearchCardsAction([])).toEqual({
+      type: "SelectCards",
+      data: { cards: [] },
+    });
+  });
+});
+
+describe("chooseOutsideGameAction", () => {
+  it("builds the ChooseOutsideGameCards action with a Sideboard selection", () => {
+    expect(
+      chooseOutsideGameAction([
+        { type: "Sideboard", data: { sideboard_index: 2 } },
+      ]),
+    ).toEqual({
+      type: "ChooseOutsideGameCards",
+      data: { selections: [{ type: "Sideboard", data: { sideboard_index: 2 } }] },
+    });
+  });
+
+  it("builds the action with a FaceUpExile selection", () => {
+    expect(
+      chooseOutsideGameAction([
+        { type: "FaceUpExile", data: { object_id: 44 } },
+      ]),
+    ).toEqual({
+      type: "ChooseOutsideGameCards",
+      data: { selections: [{ type: "FaceUpExile", data: { object_id: 44 } }] },
+    });
+  });
+});

--- a/src/sim/decisions/search.ts
+++ b/src/sim/decisions/search.ts
@@ -1,0 +1,160 @@
+// Browsing a tutor/search, a fetch-land partition, or an outside-game pool
+// (Wish effects) — letting the human pick the results themselves instead of
+// the AI. The engine surfaces three waiting_for shapes:
+// - `SearchChoice` { player, cards: ObjId[], count, up_to?, allows_partial_find?,
+//   constraint? } — a tutor-style search: browse `cards` and pick up to (or
+//   exactly) `count` of them.
+// - `SearchPartitionChoice` { player, cards, primary_destination, primary_count,
+//   primary_enter_tapped, rest_destination, source_id } — split the pool into
+//   a primary destination (exactly `primary_count` of them) and a rest
+//   destination (everything else), as with a fetch land.
+// - `OutsideGameChoice` { player, source_id, choices: OutsideGameChoiceEntry[]
+//   { source, count, name }, count, destination } — pick from outside the
+//   game (sideboard or face-up exile).
+// Both search kinds answer with `SelectCards { cards: ObjId[] }`; the
+// outside-game choice answers with `ChooseOutsideGameCards { selections }`,
+// where each selection echoes the chosen entry's `source` verbatim
+// (`{type:"Sideboard",data:{sideboard_index}}` or
+// `{type:"FaceUpExile",data:{object_id}}`). Shapes confirmed against
+// phase-rs client/src/adapter/types.ts at v0.71.0.
+
+import type { GameState, WaitingFor } from "../../engine/types";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/** A card offered up for a search/tutor or fetch-land partition. */
+export interface SearchCard {
+  id: number;
+  name: string;
+}
+
+export interface SearchPrompt {
+  kind: "search";
+  player: number;
+  cards: SearchCard[];
+  /** How many cards to pick. */
+  count: number;
+  /** True when fewer than `count` may be picked. */
+  upTo: boolean;
+}
+
+export interface SearchPartitionPrompt {
+  kind: "partition";
+  player: number;
+  cards: SearchCard[];
+  /** Exactly this many go to `primaryDestination`; the rest go to `restDestination`. */
+  count: number;
+  upTo: false;
+  primaryDestination: string;
+  restDestination: string;
+}
+
+/** One outside-the-game option (a sideboard card or a face-up exiled card). */
+export interface OutsideGameEntry {
+  label: string;
+  source: unknown;
+}
+
+export interface OutsideGamePrompt {
+  kind: "outside";
+  player: number;
+  entries: OutsideGameEntry[];
+  count: number;
+  destination: string;
+}
+
+export type SearchDecisionPrompt =
+  | SearchPrompt
+  | SearchPartitionPrompt
+  | OutsideGamePrompt;
+
+function toSearchCards(ids: unknown, state?: GameState): SearchCard[] {
+  if (!Array.isArray(ids)) return [];
+  return ids.map((id) => ({ id, name: state?.objects?.[id]?.name ?? "" }));
+}
+
+function parseSearchChoice(d: any, state?: GameState): SearchPrompt | null {
+  const cards = toSearchCards(d.cards, state);
+  if (cards.length === 0) return null;
+  return {
+    kind: "search",
+    player: typeof d.player === "number" ? d.player : 0,
+    cards,
+    count: typeof d.count === "number" ? d.count : 1,
+    upTo: !!(d.up_to || d.allows_partial_find),
+  };
+}
+
+function parseSearchPartitionChoice(
+  d: any,
+  state?: GameState,
+): SearchPartitionPrompt | null {
+  const cards = toSearchCards(d.cards, state);
+  if (cards.length === 0) return null;
+  return {
+    kind: "partition",
+    player: typeof d.player === "number" ? d.player : 0,
+    cards,
+    count: typeof d.primary_count === "number" ? d.primary_count : 0,
+    upTo: false,
+    primaryDestination:
+      typeof d.primary_destination === "string" ? d.primary_destination : "",
+    restDestination:
+      typeof d.rest_destination === "string" ? d.rest_destination : "",
+  };
+}
+
+function parseOutsideGameChoice(d: any): OutsideGamePrompt | null {
+  const rawChoices = d.choices;
+  if (!Array.isArray(rawChoices) || rawChoices.length === 0) return null;
+  const entries: OutsideGameEntry[] = rawChoices.map((c: any) => ({
+    label: typeof c?.name === "string" ? c.name : "",
+    source: c?.source,
+  }));
+  return {
+    kind: "outside",
+    player: typeof d.player === "number" ? d.player : 0,
+    entries,
+    count: typeof d.count === "number" ? d.count : 1,
+    destination: typeof d.destination === "string" ? d.destination : "",
+  };
+}
+
+/** Read a search/tutor, fetch-land partition, or outside-game decision aimed at the human, or null. */
+export function parseSearchPrompt(
+  wf: WaitingFor | undefined,
+  state?: GameState,
+): SearchDecisionPrompt | null {
+  if (!wf) return null;
+  const d: any = wf.data ?? {};
+  switch (wf.type) {
+    case "SearchChoice":
+      return parseSearchChoice(d, state);
+    case "SearchPartitionChoice":
+      return parseSearchPartitionChoice(d, state);
+    case "OutsideGameChoice":
+      return parseOutsideGameChoice(d);
+    default:
+      return null;
+  }
+}
+
+/** Submit the chosen card ids for a search or fetch-land partition decision. */
+export function selectSearchCardsAction(ids: number[]): {
+  type: string;
+  data: { cards: number[] };
+} {
+  return { type: "SelectCards", data: { cards: ids } };
+}
+
+/** One outside-game pick, echoing an `OutsideGameEntry.source` verbatim. */
+export type OutsideGameSelection =
+  | { type: "Sideboard"; data: { sideboard_index: number } }
+  | { type: "FaceUpExile"; data: { object_id: number } };
+
+/** Submit the chosen outside-game entries back to the engine. */
+export function chooseOutsideGameAction(
+  selections: OutsideGameSelection[],
+): { type: string; data: { selections: OutsideGameSelection[] } } {
+  return { type: "ChooseOutsideGameCards", data: { selections } };
+}

--- a/src/sim/driver.ts
+++ b/src/sim/driver.ts
@@ -44,6 +44,10 @@ import {
   parseOrderTriggersPrompt,
   type OrderTriggersPrompt,
 } from "./decisions/orderTriggers";
+import {
+  parseSearchPrompt,
+  type SearchDecisionPrompt,
+} from "./decisions/search";
 
 export interface MatchResult {
   matchIndex: number;
@@ -275,6 +279,11 @@ export interface DriverCallbacks {
   requestHumanOrderTriggers?: (
     env: GameStateEnvelope,
     prompt: OrderTriggersPrompt,
+  ) => Promise<HumanChoice>;
+  /** Called when the human browses a tutor/search, a fetch-land partition, or an outside-game pool. */
+  requestHumanSearch?: (
+    env: GameStateEnvelope,
+    prompt: SearchDecisionPrompt,
   ) => Promise<HumanChoice>;
 }
 
@@ -604,6 +613,7 @@ export class MatchRunner {
           cb.requestHumanOrderTriggers,
           parseOrderTriggersPrompt(wf),
         ),
+      () => humanRequest(env, cb.requestHumanSearch, parseSearchPrompt(wf, state)),
     ];
     for (const resolve of resolvers) {
       const req = resolve();


### PR DESCRIPTION
Implements #45: lets the human seat browse and pick tutor/search, fetch-land partition, and outside-the-game (Wish) results themselves, instead of the AI deciding.

## What changed
- `src/sim/decisions/search.ts` (+ `.test.ts`): parses the engine's `SearchChoice`, `SearchPartitionChoice`, and `OutsideGameChoice` waiting_for shapes into a discriminated-union prompt, and builds the `SelectCards` / `ChooseOutsideGameCards` submissions. Shapes confirmed against phase-rs v0.71.0's reference client.
- `src/sim/driver.ts`: wires `requestHumanSearch` into the non-priority resolver chain.
- `src/match/RunView.tsx`: a `SearchPanel` in the play-controls panel — a scrollable, click-to-toggle candidate list respecting the offered count (exact or up-to), with a running "selected X of N" hint and a let-the-AI-decide escape.
- `src/i18n/messages.ts`: new `search.*` pt/en keys.
- `domainbook/domains/simulation/features/browse-a-search-yourself.md`, `domainbook/changelog.md` (0.10.0), `package.json` version bump.

## Judgment calls
- Partition and outside-game picks are treated as exact-count (no up-to), since neither shape carries an `up_to`/`allows_partial_find` field — only `SearchChoice` does.
- The "selected X of N" hint reuses the existing `{n}`/`{max}` interpolation names from `modes.progress`/`discard.progress` rather than introducing `{selected}`/`{count}`, to stay consistent with the project's convention.
- No shared `letAi` i18n key exists anywhere in the project (each decision has its own `<name>.letAi`), so this follows suit with `search.letAi` rather than inventing a shared one.
- Destination zone names (fetch-land primary/rest, outside-game destination) are shown via the existing `formatZoneLabel` raw-string capitalizer already used for `commanderZone`, since there's no dedicated zone-label i18n convention in the project.

## Gates
`npm run lint && npm run typecheck && npm run duplication && npm test && npm run build` — all pass (duplication 0.91%, well under the 7% threshold). `npx domainbook check --range main..HEAD` and `npx domainbook validate` both pass.

Closes #45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)