### PR TITLE
feat(sim): let the human choose which cards to keep on an impulse dig

### DIFF
--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,6 +12,15 @@ depth live there. A purely-internal PR that touches no product or architecture m
 skip its version with a `Skip-Docs: <reason>` trailer instead. There are no
 per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
+## [0.11.0] - 2026-09-05
+
+### Added
+
+- You now choose which cards to **keep on an impulse draw or dig effect**:
+  the control panel lists the dug-up cards for your seat to pick from,
+  instead of the AI deciding
+  (`domains/simulation/features/keep-cards-on-an-impulse-dig.md`).
+
 ## [0.10.0] - 2026-09-05
 
 ### Added

--- a/domainbook/domains/simulation/features/keep-cards-on-an-impulse-dig.md
+++ b/domainbook/domains/simulation/features/keep-cards-on-an-impulse-dig.md
@@ -1,0 +1,97 @@
+---
+id: keep-cards-on-an-impulse-dig
+name: Keep cards on an impulse dig
+status: implemented
+---
+
+## Story
+
+As a player piloting my seat
+I want to choose which cards to keep on an impulse draw or dig effect
+So that the pick is mine, not the AI's
+
+## Rule: A dig prompt appears on the human's own impulse draw or dig effect
+
+When the human's spell or ability digs into the library (an impulse draw, a
+card-advantage dig, and the like), the engine surfaces a `DigChoice` decision
+request naming the dug-up cards and how many to keep. The seat's control
+panel lists them by name for browsing; any other seat's dig is still
+resolved by the AI, and non-dig state is untouched.
+
+```gherkin
+Example: The prompt appears on my own dig
+  Given a play-mode match where I control seat 0
+  When I cast a spell that digs into my library and offers a choice
+  Then the control panel lists the dug-up cards by name
+  And an opponent's dig is still resolved by the AI
+```
+
+## Rule: Keeping respects the offered count, exactly or up to
+
+Clicking a listed card toggles whether it is kept, up to the offered
+`keep_count`; once `keep_count` cards are picked, unpicked rows stop
+responding to clicks until one is deselected. When the dig allows keeping
+fewer (`up_to`), Confirm is enabled with anywhere from zero to `keep_count`
+picked; otherwise Confirm stays disabled until exactly `keep_count` are
+picked. A running "kept X of N" hint tracks progress either way.
+
+```gherkin
+Example: An exact-count dig requires filling every pick
+  Given a dig prompt asking to keep exactly 1 card among 3
+  When I pick 1 card
+  Then Confirm becomes enabled
+
+Example: An up-to dig accepts fewer than the offered count
+  Given a dig prompt to keep up to 1 card
+  When I pick 0 cards
+  Then Confirm is still enabled
+```
+
+## Rule: Only the selectable cards can be kept
+
+When the engine restricts which of the dug-up cards may actually be kept
+(`selectable_cards`, a strict subset of `cards`), the panel still lists every
+dug-up card by name, but only the selectable ones respond to clicks — the
+rest are shown disabled for context. When `selectable_cards` is absent, every
+dug-up card is selectable.
+
+```gherkin
+Example: Some dug-up cards are not eligible to keep
+  Given a dig prompt listing 3 cards where only 2 are selectable
+  Then the third card is shown but cannot be picked
+```
+
+## Rule: The panel names where kept and unkept cards go
+
+The prompt names `kept_destination` (where the kept cards end up, e.g. the
+top of the library, the battlefield, or the hand) and `rest_destination`
+(where everything else goes), and the panel shows both alongside the keep
+count so the choice is made with full context.
+
+```gherkin
+Example: The destinations are shown
+  Given a dig prompt with kept_destination "Hand" and rest_destination "Graveyard"
+  Then the panel names both destinations
+```
+
+## Rule: The choice can be handed to the AI
+
+Choosing let the AI decide hands the whole dig choice back to the engine's
+own AI, so the decision is never stuck (`simulation/ADR-0001`).
+
+```gherkin
+Example: Letting the AI decide
+  Given a dig prompt is shown
+  When I choose let the AI decide
+  Then the engine's AI picks which cards to keep
+```
+
+## Open Questions
+
+- The `DigChoice` shape and the `SelectCards` submission were confirmed
+  against phase-rs `client/src/adapter/types.ts` (the reference client's
+  DigModal) at v0.71.0, but not yet round-tripped against a live impulse
+  draw or dig effect.
+- Destination zone names (`kept_destination`, `rest_destination`) are shown
+  as the engine's own raw strings, capitalized, the same as the existing
+  search and commander-zone prompts.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -370,6 +370,22 @@ export const messages = {
   "search.confirm": { pt: "Confirmar", en: "Confirm" },
   "search.letAi": { pt: "IA decide", en: "Let the AI decide" },
 
+  "dig.title": {
+    pt: "Escolher quais cartas manter",
+    en: "Choose which card(s) to keep",
+  },
+  "dig.hintExact": {
+    pt: "Mantenha {n} carta(s): as mantidas vão para {kept}; o resto vai para {rest}.",
+    en: "Keep {n} card(s): kept cards go to {kept}; the rest go to {rest}.",
+  },
+  "dig.hintUpTo": {
+    pt: "Mantenha até {n} carta(s): as mantidas vão para {kept}; o resto vai para {rest}.",
+    en: "Keep up to {n} card(s): kept cards go to {kept}; the rest go to {rest}.",
+  },
+  "dig.kept": { pt: "Mantidas: {picked} / {n}", en: "Kept {picked} of {n}" },
+  "dig.confirm": { pt: "Confirmar", en: "Confirm" },
+  "dig.letAi": { pt: "IA decide", en: "Let the AI decide" },
+
   "modes.title": { pt: "Escolher modo", en: "Choose a mode" },
   "modes.source": {
     pt: "{name} pede uma escolha de modo.",

--- a/src/match/RunView.tsx
+++ b/src/match/RunView.tsx
@@ -63,6 +63,7 @@ import {
   type SearchDecisionPrompt,
   type OutsideGameSelection,
 } from "../sim/decisions/search";
+import { keepDigCardsAction, type DigPrompt } from "../sim/decisions/dig";
 import { XpWindow } from "../components/XpWindow";
 import {
   declareAttackersAction,
@@ -376,6 +377,78 @@ function SearchPanel({
   );
 }
 
+interface DigTurn {
+  prompt: DigPrompt;
+  resolve: (choice: HumanChoice) => void;
+}
+
+function digHint(
+  prompt: DigPrompt,
+  t: (key: MsgKey, vars?: Vars) => string,
+): string {
+  return t(prompt.upTo ? "dig.hintUpTo" : "dig.hintExact", {
+    n: prompt.keepCount,
+    kept: formatZoneLabel(prompt.keptDestination),
+    rest: formatZoneLabel(prompt.restDestination),
+  });
+}
+
+function DigPanel({
+  turn,
+  pick,
+  onTogglePick,
+  onConfirm,
+  onLetAi,
+}: {
+  turn: DigTurn;
+  pick: Set<number>;
+  onTogglePick: (id: number) => void;
+  onConfirm: () => void;
+  onLetAi: () => void;
+}) {
+  const { t } = useI18n();
+  const { prompt } = turn;
+  const atCap = pick.size >= prompt.keepCount;
+  const valid = prompt.upTo
+    ? pick.size <= prompt.keepCount
+    : pick.size === prompt.keepCount;
+  return (
+    <>
+      <div className="control-title">
+        <strong>{t("dig.title")}</strong>
+      </div>
+      <p className="hint">{digHint(prompt, t)}</p>
+      <p className="hint">
+        {t("dig.kept", { picked: pick.size, n: prompt.keepCount })}
+      </p>
+      <div className="search-list">
+        {prompt.cards.map((card) => {
+          const selectable = prompt.selectableIds.includes(card.id);
+          const picked = pick.has(card.id);
+          return (
+            <button
+              key={card.id}
+              className={picked ? "btn" : "btn--ghost"}
+              disabled={!selectable || (!picked && atCap)}
+              onClick={() => onTogglePick(card.id)}
+            >
+              {card.name}
+            </button>
+          );
+        })}
+      </div>
+      <div className="import__row">
+        <button className="btn" disabled={!valid} onClick={onConfirm}>
+          {t("dig.confirm")}
+        </button>
+        <button className="btn btn--ghost" onClick={onLetAi}>
+          {t("dig.letAi")}
+        </button>
+      </div>
+    </>
+  );
+}
+
 function isTargetOptional(
   targeting: TargetTurn | null,
   chosen: TargetRef[],
@@ -516,6 +589,8 @@ interface RunnerCallbackDeps {
   setOrderTriggersTurn: Dispatch<SetStateAction<OrderTriggersTurn | null>>;
   setSearchPick: Dispatch<SetStateAction<number[]>>;
   setSearchTurn: Dispatch<SetStateAction<SearchTurn | null>>;
+  setDigPick: Dispatch<SetStateAction<Set<number>>>;
+  setDigTurn: Dispatch<SetStateAction<DigTurn | null>>;
 }
 
 function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
@@ -556,6 +631,8 @@ function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
     setOrderTriggersTurn,
     setSearchPick,
     setSearchTurn,
+    setDigPick,
+    setDigTurn,
   } = deps;
   return {
     onFrame: (env) => {
@@ -838,6 +915,22 @@ function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
           },
         });
       }),
+    requestHumanDig: (_env, prompt) =>
+      new Promise<HumanChoice>((resolve) => {
+        if (isCancelled()) {
+          resolve({ ai: true });
+          return;
+        }
+        setDigPick(new Set());
+        setDigTurn({
+          prompt,
+          resolve: (choice) => {
+            setDigTurn(null);
+            setDigPick(new Set());
+            resolve(choice);
+          },
+        });
+      }),
   };
 }
 
@@ -941,6 +1034,8 @@ export function RunView({
   const [orderTriggersPick, setOrderTriggersPick] = useState<number[]>([]);
   const [searchTurn, setSearchTurn] = useState<SearchTurn | null>(null);
   const [searchPick, setSearchPick] = useState<number[]>([]);
+  const [digTurn, setDigTurn] = useState<DigTurn | null>(null);
+  const [digPick, setDigPick] = useState<Set<number>>(new Set());
   const [passingTurn, setPassingTurn] = useState(false);
   const [logEntries, setLogEntries] = useState<LoggedEntry[]>([]);
   // On mobile the log is a full-screen drawer, so it always starts closed and
@@ -1045,6 +1140,8 @@ export function RunView({
             setOrderTriggersTurn,
             setSearchPick,
             setSearchTurn,
+            setDigPick,
+            setDigTurn,
           }),
         );
         runnerRef.current = runner;
@@ -1177,7 +1274,8 @@ export function RunView({
         commanderZoneTurn ||
         xValueTurn ||
         orderTriggersTurn ||
-        searchTurn)
+        searchTurn ||
+        digTurn)
     ) {
       setPassingTurn(false);
     }
@@ -1195,6 +1293,7 @@ export function RunView({
     xValueTurn,
     orderTriggersTurn,
     searchTurn,
+    digTurn,
   ]);
 
   // Map draggable hand cards to their play actions for the current window.
@@ -2194,6 +2293,30 @@ export function RunView({
                 })
               }
               onLetAi={() => searchTurn.resolve({ ai: true })}
+            />
+          )}
+
+          {digTurn && (
+            <DigPanel
+              turn={digTurn}
+              pick={digPick}
+              onTogglePick={(id) =>
+                setDigPick((prev) => {
+                  const next = new Set(prev);
+                  if (next.has(id)) {
+                    next.delete(id);
+                  } else if (next.size < digTurn.prompt.keepCount) {
+                    next.add(id);
+                  }
+                  return next;
+                })
+              }
+              onConfirm={() =>
+                digTurn.resolve({
+                  action: keepDigCardsAction([...digPick]),
+                })
+              }
+              onLetAi={() => digTurn.resolve({ ai: true })}
             />
           )}
         </section>

--- a/src/sim/decisions/dig.test.ts
+++ b/src/sim/decisions/dig.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import { parseDigPrompt, keepDigCardsAction } from "./dig";
+import type { GameState, WaitingFor } from "../../engine/types";
+
+// Shapes confirmed against phase-rs client/src/adapter/types.ts (DigModal)
+// at v0.71.0: DigChoice { player, cards, keep_count, up_to?,
+// selectable_cards?, kept_destination?, rest_destination? }.
+const REAL_DIG: WaitingFor = {
+  type: "DigChoice",
+  data: {
+    player: 0,
+    cards: [12, 34, 56],
+    keep_count: 1,
+    up_to: true,
+    kept_destination: "Hand",
+    rest_destination: "Graveyard",
+  },
+};
+
+// A dig where the engine restricts which of the dug cards are actually
+// eligible to keep (selectable_cards is a strict subset of cards).
+const REAL_DIG_RESTRICTED: WaitingFor = {
+  type: "DigChoice",
+  data: {
+    player: 0,
+    cards: [12, 34, 56],
+    selectable_cards: [12, 56],
+    keep_count: 1,
+    kept_destination: "Battlefield",
+    rest_destination: "Library",
+  },
+};
+
+const STATE: GameState = {
+  turn_number: 1,
+  phase: "Main1",
+  active_player: 0,
+  waiting_for: { type: "Priority" },
+  players: [],
+  objects: {
+    12: { id: 12, name: "Sol Ring", zone: "Library" },
+    34: { id: 34, name: "Arcane Signet", zone: "Library" },
+    56: { id: 56, name: "Command Tower", zone: "Library" },
+  },
+  battlefield: [],
+  command_zone: [],
+  stack: [],
+  eliminated_players: [],
+};
+
+describe("parseDigPrompt", () => {
+  it("parses the player, cards, keepCount, upTo and destinations", () => {
+    const p = parseDigPrompt(REAL_DIG, STATE);
+    expect(p).not.toBeNull();
+    expect(p?.player).toBe(0);
+    expect(p?.keepCount).toBe(1);
+    expect(p?.upTo).toBe(true);
+    expect(p?.keptDestination).toBe("Hand");
+    expect(p?.restDestination).toBe("Graveyard");
+    expect(p?.cards).toEqual([
+      { id: 12, name: "Sol Ring" },
+      { id: 34, name: "Arcane Signet" },
+      { id: 56, name: "Command Tower" },
+    ]);
+  });
+
+  it("defaults selectableIds to all cards when selectable_cards is absent", () => {
+    const p = parseDigPrompt(REAL_DIG, STATE);
+    expect(p?.selectableIds).toEqual([12, 34, 56]);
+  });
+
+  it("restricts selectableIds to selectable_cards when it is a subset of cards", () => {
+    const p = parseDigPrompt(REAL_DIG_RESTRICTED, STATE);
+    expect(p).not.toBeNull();
+    expect(p?.selectableIds).toEqual([12, 56]);
+    expect(p?.upTo).toBe(false);
+    expect(p?.keptDestination).toBe("Battlefield");
+    expect(p?.restDestination).toBe("Library");
+  });
+
+  it("falls back to empty card names when state is omitted", () => {
+    const p = parseDigPrompt(REAL_DIG);
+    expect(p?.cards.map((c) => c.name)).toEqual(["", "", ""]);
+  });
+
+  it("defaults keepCount to 1 and upTo to false when absent", () => {
+    const wf: WaitingFor = {
+      type: "DigChoice",
+      data: { player: 1, cards: [1] },
+    };
+    const p = parseDigPrompt(wf);
+    expect(p?.keepCount).toBe(1);
+    expect(p?.upTo).toBe(false);
+  });
+
+  it("returns null when cards is empty", () => {
+    const wf: WaitingFor = {
+      type: "DigChoice",
+      data: { player: 0, cards: [], keep_count: 1 },
+    };
+    expect(parseDigPrompt(wf)).toBeNull();
+  });
+
+  it("returns null for a non-matching waiting_for", () => {
+    expect(parseDigPrompt(undefined)).toBeNull();
+    expect(parseDigPrompt({ type: "Priority", data: {} })).toBeNull();
+  });
+});
+
+describe("keepDigCardsAction", () => {
+  it("builds the SelectCards action with the kept ids", () => {
+    expect(keepDigCardsAction([12, 56])).toEqual({
+      type: "SelectCards",
+      data: { cards: [12, 56] },
+    });
+  });
+
+  it("builds the action for an empty selection", () => {
+    expect(keepDigCardsAction([])).toEqual({
+      type: "SelectCards",
+      data: { cards: [] },
+    });
+  });
+});

--- a/src/sim/decisions/dig.ts
+++ b/src/sim/decisions/dig.ts
@@ -1,0 +1,72 @@
+// Choosing which cards to keep on an impulse draw or a dig effect. The
+// engine surfaces this as a `DigChoice` waiting_for:
+// { player, cards: ObjId[], keep_count, up_to?, selectable_cards?,
+//   kept_destination?: Zone, rest_destination?: Zone }.
+// Only the cards in `selectable_cards` (defaulting to all of `cards` when
+// absent) may be kept; the player toggles a subset of up to `keep_count` of
+// them. When `up_to` is set, fewer than `keep_count` may be kept; otherwise
+// exactly `keep_count` must be. The kept subset is submitted back as
+// `SelectCards { cards }`. Shapes confirmed against phase-rs
+// client/src/adapter/types.ts (DigModal) at v0.71.0.
+
+import type { GameState, WaitingFor } from "../../engine/types";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/** A card dug up for an impulse draw or dig effect. */
+export interface DigCard {
+  id: number;
+  name: string;
+}
+
+export interface DigPrompt {
+  player: number;
+  cards: DigCard[];
+  /** Ids among `cards` that may actually be kept. */
+  selectableIds: number[];
+  /** How many cards to keep. */
+  keepCount: number;
+  /** True when fewer than `keepCount` may be kept. */
+  upTo: boolean;
+  /** Where the kept cards go, e.g. "Library" (top), "Battlefield", "Hand". */
+  keptDestination: string;
+  /** Where the rest of the cards go. */
+  restDestination: string;
+}
+
+/** Read a dig/impulse-draw decision aimed at the human, or null. */
+export function parseDigPrompt(
+  wf: WaitingFor | undefined,
+  state?: GameState,
+): DigPrompt | null {
+  if (!wf || wf.type !== "DigChoice") return null;
+  const d: any = wf.data ?? {};
+  const rawCards = d.cards;
+  if (!Array.isArray(rawCards) || rawCards.length === 0) return null;
+  const cards: DigCard[] = rawCards.map((id: number) => ({
+    id,
+    name: state?.objects?.[id]?.name ?? "",
+  }));
+  const selectableIds = Array.isArray(d.selectable_cards)
+    ? d.selectable_cards
+    : rawCards;
+  return {
+    player: typeof d.player === "number" ? d.player : 0,
+    cards,
+    selectableIds,
+    keepCount: typeof d.keep_count === "number" ? d.keep_count : 1,
+    upTo: !!d.up_to,
+    keptDestination:
+      typeof d.kept_destination === "string" ? d.kept_destination : "",
+    restDestination:
+      typeof d.rest_destination === "string" ? d.rest_destination : "",
+  };
+}
+
+/** Submit the kept card ids for a dig/impulse-draw decision. */
+export function keepDigCardsAction(ids: number[]): {
+  type: string;
+  data: { cards: number[] };
+} {
+  return { type: "SelectCards", data: { cards: ids } };
+}

--- a/src/sim/driver.ts
+++ b/src/sim/driver.ts
@@ -48,6 +48,7 @@ import {
   parseSearchPrompt,
   type SearchDecisionPrompt,
 } from "./decisions/search";
+import { parseDigPrompt, type DigPrompt } from "./decisions/dig";
 
 export interface MatchResult {
   matchIndex: number;
@@ -284,6 +285,11 @@ export interface DriverCallbacks {
   requestHumanSearch?: (
     env: GameStateEnvelope,
     prompt: SearchDecisionPrompt,
+  ) => Promise<HumanChoice>;
+  /** Called when the human chooses which cards to keep on an impulse draw or dig effect. */
+  requestHumanDig?: (
+    env: GameStateEnvelope,
+    prompt: DigPrompt,
   ) => Promise<HumanChoice>;
 }
 
@@ -614,6 +620,7 @@ export class MatchRunner {
           parseOrderTriggersPrompt(wf),
         ),
       () => humanRequest(env, cb.requestHumanSearch, parseSearchPrompt(wf, state)),
+      () => humanRequest(env, cb.requestHumanDig, parseDigPrompt(wf, state)),
     ];
     for (const resolve of resolvers) {
       const req = resolve();


### PR DESCRIPTION
Surfaces the engine's `DigChoice` (impulse draws, dig effects) to the human seat as a browsable candidate list instead of the AI deciding: the panel lists the dug-up cards by name, toggles a subset up to `keep_count` (or fewer when `up_to`), disables cards outside `selectable_cards`, and names both `kept_destination` and `rest_destination` for context.

Mirrors the just-merged `search` decision (SearchPanel-style card-list picker, reusing `formatZoneLabel`). Confirmed the `DigChoice` / `SelectCards` shapes against phase-rs v0.71.0's reference client `DigModal`.

## Gates
- `npm run lint` — pass
- `npm run typecheck` — pass
- `npm run duplication` — pass (0.91% total, threshold 7%)
- `npm test` — pass (267 passed, 3 skipped, incl. 9 new dig tests)
- `npm run build` — pass
- `npx domainbook check --range main..HEAD` — nothing stale
- `npx domainbook validate` — valid (6 domains, 24 features, 17 decisions)

Closes #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)