### PR TITLE
feat(sim): let the human choose explore and reveal-until outcomes

### DIFF
--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,6 +12,14 @@ depth live there. A purely-internal PR that touches no product or architecture m
 skip its version with a `Skip-Docs: <reason>` trailer instead. There are no
 per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
+## [0.12.0] - 2026-09-05
+
+### Added
+
+- You now choose which creature **explores**, and whether to **keep what a
+  reveal-until-you-find effect finds**, instead of the AI deciding
+  (`domains/simulation/features/choose-explore-and-reveal-outcomes.md`).
+
 ## [0.11.0] - 2026-09-05
 
 ### Added

--- a/domainbook/domains/simulation/features/choose-explore-and-reveal-outcomes.md
+++ b/domainbook/domains/simulation/features/choose-explore-and-reveal-outcomes.md
@@ -1,0 +1,81 @@
+---
+id: choose-explore-and-reveal-outcomes
+name: Choose explore and reveal-until outcomes
+status: implemented
+---
+
+## Story
+
+As a player piloting my seat
+I want to pick which creature explores and whether to keep what a reveal-until effect finds
+So that those outcomes are mine to choose, not the AI's
+
+## Rule: An explore prompt lists the choosable creatures by name
+
+When the engine asks the human to resolve an `ExploreChoice` `decision request`
+— offered whenever one of the human's creatures may explore — the seat's
+control panel names the source and lists the `choosable` creatures for the
+seat to pick from. Other seats resolve it by `AI action proposal` as before,
+and any non-`ExploreChoice` state is untouched.
+
+```gherkin
+Example: The prompt appears on my own explore trigger
+  Given a play-mode match where I control seat 0
+  When one of my creatures explores
+  Then the control panel lists the choosable creatures by name
+  And an opponent's explore trigger is still decided by the AI
+```
+
+## Rule: Picking a creature submits it directly
+
+Clicking a listed creature submits `ChooseTarget { target: { Object: id } }`
+for that creature immediately — there is no separate confirm step, since
+exploring is always a single pick among `choosable`.
+
+```gherkin
+Example: Choosing which creature explores
+  Given an explore prompt listing two choosable creatures
+  When I click one of them
+  Then the engine receives that creature as the chosen target
+```
+
+## Rule: A reveal-until-you-find prompt names the source and the found card
+
+A `RevealUntilKeptChoice` (a "reveal cards until you find a land/creature/…"
+effect) names both the ability's source and the `hit_card` it found, and asks
+whether to keep it. The panel shows a primary button naming `accept_zone`
+(where the card goes if kept) and a secondary button naming `decline_zone`
+(where it goes if declined).
+
+```gherkin
+Example: Keeping the found card
+  Given a reveal-until prompt found a land bound for the battlefield if kept, the graveyard otherwise
+  When I choose to keep it
+  Then the engine sends the found card to the battlefield
+
+Example: Declining the found card
+  Given the same reveal-until prompt
+  When I choose not to keep it
+  Then the engine sends the found card to the graveyard
+```
+
+## Rule: The choice can be handed to the AI
+
+Choosing let the AI decide hands the whole explore or reveal-until choice
+back to the engine's own AI, so the decision is never stuck
+(`simulation/ADR-0001`).
+
+```gherkin
+Example: Letting the AI decide
+  Given an explore or reveal-until prompt is shown
+  When I choose let the AI decide
+  Then the engine's AI makes that choice
+```
+
+## Open Questions
+
+- The `ExploreChoice` and `RevealUntilKeptChoice` shapes, and the
+  `ChooseTarget` / `DecideOptionalEffect` submissions, were confirmed against
+  phase-rs `client/src/adapter/types.ts` (TargetingOverlay,
+  RevealUntilKeptChoiceModal) at v0.71.0, but not yet round-tripped against a
+  live explore trigger or reveal-until effect.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -386,6 +386,30 @@ export const messages = {
   "dig.confirm": { pt: "Confirmar", en: "Confirm" },
   "dig.letAi": { pt: "IA decide", en: "Let the AI decide" },
 
+  "exploreReveal.exploreTitle": {
+    pt: "Escolher uma criatura para explorar",
+    en: "Choose a creature to explore",
+  },
+  "exploreReveal.exploreHint": {
+    pt: "{name} está explorando. Escolha qual criatura explora.",
+    en: "{name} is exploring. Choose which creature explores.",
+  },
+  "exploreReveal.revealTitle": {
+    pt: "Revelar até encontrar",
+    en: "Reveal until you find one",
+  },
+  "exploreReveal.revealHint": {
+    pt: "{name} revelou cartas até encontrar {card}. Manter {card}?",
+    en: "{name} revealed cards until it found {card}. Keep {card}?",
+  },
+  "exploreReveal.keep": { pt: "Manter ({zone})", en: "Keep ({zone})" },
+  "exploreReveal.decline": { pt: "Colocar em {zone}", en: "Put in {zone}" },
+  "exploreReveal.sourceFallback": {
+    pt: "sua criatura",
+    en: "your creature",
+  },
+  "exploreReveal.letAi": { pt: "IA decide", en: "Let the AI decide" },
+
   "modes.title": { pt: "Escolher modo", en: "Choose a mode" },
   "modes.source": {
     pt: "{name} pede uma escolha de modo.",

--- a/src/match/RunView.tsx
+++ b/src/match/RunView.tsx
@@ -64,6 +64,11 @@ import {
   type OutsideGameSelection,
 } from "../sim/decisions/search";
 import { keepDigCardsAction, type DigPrompt } from "../sim/decisions/dig";
+import {
+  exploreCreatureAction,
+  revealUntilAction,
+  type ExploreRevealPrompt,
+} from "../sim/decisions/exploreReveal";
 import { XpWindow } from "../components/XpWindow";
 import {
   declareAttackersAction,
@@ -449,6 +454,89 @@ function DigPanel({
   );
 }
 
+interface ExploreRevealTurn {
+  prompt: ExploreRevealPrompt;
+  resolve: (choice: HumanChoice) => void;
+}
+
+function ExploreRevealPanel({ turn }: { turn: ExploreRevealTurn }) {
+  const { t } = useI18n();
+  const { prompt, resolve } = turn;
+  const sourceName = prompt.sourceName || t("exploreReveal.sourceFallback");
+
+  if (prompt.kind === "explore") {
+    return (
+      <>
+        <div className="control-title">
+          <strong>{t("exploreReveal.exploreTitle")}</strong>
+        </div>
+        <p className="hint">
+          {t("exploreReveal.exploreHint", { name: sourceName })}
+        </p>
+        <div className="search-list">
+          {prompt.creatures.map((creature) => (
+            <button
+              key={creature.id}
+              className="btn"
+              onClick={() =>
+                resolve({ action: exploreCreatureAction(creature.id) })
+              }
+            >
+              {creature.name}
+            </button>
+          ))}
+        </div>
+        <div className="import__row">
+          <button
+            className="btn btn--ghost"
+            onClick={() => resolve({ ai: true })}
+          >
+            {t("exploreReveal.letAi")}
+          </button>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div className="control-title">
+        <strong>{t("exploreReveal.revealTitle")}</strong>
+      </div>
+      <p className="hint">
+        {t("exploreReveal.revealHint", {
+          name: sourceName,
+          card: prompt.hitCardName,
+        })}
+      </p>
+      <div className="import__row">
+        <button
+          className="btn"
+          onClick={() => resolve({ action: revealUntilAction(true) })}
+        >
+          {t("exploreReveal.keep", {
+            zone: formatZoneLabel(prompt.acceptZone),
+          })}
+        </button>
+        <button
+          className="btn btn--ghost"
+          onClick={() => resolve({ action: revealUntilAction(false) })}
+        >
+          {t("exploreReveal.decline", {
+            zone: formatZoneLabel(prompt.declineZone),
+          })}
+        </button>
+        <button
+          className="btn btn--ghost"
+          onClick={() => resolve({ ai: true })}
+        >
+          {t("exploreReveal.letAi")}
+        </button>
+      </div>
+    </>
+  );
+}
+
 function isTargetOptional(
   targeting: TargetTurn | null,
   chosen: TargetRef[],
@@ -591,6 +679,7 @@ interface RunnerCallbackDeps {
   setSearchTurn: Dispatch<SetStateAction<SearchTurn | null>>;
   setDigPick: Dispatch<SetStateAction<Set<number>>>;
   setDigTurn: Dispatch<SetStateAction<DigTurn | null>>;
+  setExploreRevealTurn: Dispatch<SetStateAction<ExploreRevealTurn | null>>;
 }
 
 function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
@@ -633,6 +722,7 @@ function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
     setSearchTurn,
     setDigPick,
     setDigTurn,
+    setExploreRevealTurn,
   } = deps;
   return {
     onFrame: (env) => {
@@ -931,6 +1021,20 @@ function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
           },
         });
       }),
+    requestHumanExploreReveal: (_env, prompt) =>
+      new Promise<HumanChoice>((resolve) => {
+        if (isCancelled()) {
+          resolve({ ai: true });
+          return;
+        }
+        setExploreRevealTurn({
+          prompt,
+          resolve: (choice) => {
+            setExploreRevealTurn(null);
+            resolve(choice);
+          },
+        });
+      }),
   };
 }
 
@@ -1036,6 +1140,8 @@ export function RunView({
   const [searchPick, setSearchPick] = useState<number[]>([]);
   const [digTurn, setDigTurn] = useState<DigTurn | null>(null);
   const [digPick, setDigPick] = useState<Set<number>>(new Set());
+  const [exploreRevealTurn, setExploreRevealTurn] =
+    useState<ExploreRevealTurn | null>(null);
   const [passingTurn, setPassingTurn] = useState(false);
   const [logEntries, setLogEntries] = useState<LoggedEntry[]>([]);
   // On mobile the log is a full-screen drawer, so it always starts closed and
@@ -1142,6 +1248,7 @@ export function RunView({
             setSearchTurn,
             setDigPick,
             setDigTurn,
+            setExploreRevealTurn,
           }),
         );
         runnerRef.current = runner;
@@ -1275,7 +1382,8 @@ export function RunView({
         xValueTurn ||
         orderTriggersTurn ||
         searchTurn ||
-        digTurn)
+        digTurn ||
+        exploreRevealTurn)
     ) {
       setPassingTurn(false);
     }
@@ -1294,6 +1402,7 @@ export function RunView({
     orderTriggersTurn,
     searchTurn,
     digTurn,
+    exploreRevealTurn,
   ]);
 
   // Map draggable hand cards to their play actions for the current window.
@@ -2319,6 +2428,8 @@ export function RunView({
               onLetAi={() => digTurn.resolve({ ai: true })}
             />
           )}
+
+          {exploreRevealTurn && <ExploreRevealPanel turn={exploreRevealTurn} />}
         </section>
       )}
 

--- a/src/sim/decisions/exploreReveal.test.ts
+++ b/src/sim/decisions/exploreReveal.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseExploreRevealPrompt,
+  exploreCreatureAction,
+  revealUntilAction,
+} from "./exploreReveal";
+import type { GameState, WaitingFor } from "../../engine/types";
+
+// Shape confirmed against phase-rs client/src/adapter/types.ts (TargetingOverlay)
+// at v0.71.0: ExploreChoice { player, source_id, choosable, remaining, pending_effect }.
+const REAL_EXPLORE: WaitingFor = {
+  type: "ExploreChoice",
+  data: {
+    player: 0,
+    source_id: 90,
+    choosable: [12, 34],
+    remaining: [56],
+    pending_effect: { type: "Explore" },
+  },
+};
+
+// Shape confirmed against phase-rs client/src/adapter/types.ts
+// (RevealUntilKeptChoiceModal) at v0.71.0: RevealUntilKeptChoice { player,
+// hit_card, source_id, accept_zone, decline_zone, enter_tapped,
+// enters_attacking, revealed_misses, rest_destination }.
+const REAL_REVEAL: WaitingFor = {
+  type: "RevealUntilKeptChoice",
+  data: {
+    player: 0,
+    hit_card: 78,
+    source_id: 90,
+    accept_zone: "Battlefield",
+    decline_zone: "Graveyard",
+    enter_tapped: false,
+    enters_attacking: false,
+    revealed_misses: [11, 22],
+    rest_destination: "Graveyard",
+  },
+};
+
+const STATE: GameState = {
+  turn_number: 1,
+  phase: "Main1",
+  active_player: 0,
+  waiting_for: { type: "Priority" },
+  players: [],
+  objects: {
+    12: { id: 12, name: "Elvish Mystic", zone: "Library" },
+    34: { id: 34, name: "Nyxbloom Ancient", zone: "Library" },
+    56: { id: 56, name: "Sol Ring", zone: "Library" },
+    78: { id: 78, name: "Kodama's Reach", zone: "Library" },
+    90: { id: 90, name: "Ranger of Eos", zone: "Battlefield" },
+  },
+  battlefield: [],
+  command_zone: [],
+  stack: [],
+  eliminated_players: [],
+};
+
+describe("parseExploreRevealPrompt", () => {
+  describe("ExploreChoice", () => {
+    it("parses the player, source name and choosable creatures", () => {
+      const p = parseExploreRevealPrompt(REAL_EXPLORE, STATE)!;
+      expect(p).not.toBeNull();
+      if (p.kind !== "explore") throw new Error("expected an explore prompt");
+      expect(p.player).toBe(0);
+      expect(p.sourceName).toBe("Ranger of Eos");
+      expect(p.creatures).toEqual([
+        { id: 12, name: "Elvish Mystic" },
+        { id: 34, name: "Nyxbloom Ancient" },
+      ]);
+    });
+
+    it("falls back to empty names when state is omitted", () => {
+      const p = parseExploreRevealPrompt(REAL_EXPLORE);
+      if (p?.kind !== "explore") throw new Error("expected an explore prompt");
+      expect(p.sourceName).toBe("");
+      expect(p.creatures.map((c) => c.name)).toEqual(["", ""]);
+    });
+
+    it("returns null when choosable is empty", () => {
+      const wf: WaitingFor = {
+        type: "ExploreChoice",
+        data: { player: 0, source_id: 90, choosable: [], remaining: [] },
+      };
+      expect(parseExploreRevealPrompt(wf)).toBeNull();
+    });
+  });
+
+  describe("RevealUntilKeptChoice", () => {
+    it("parses the player, source/hit names and both zones", () => {
+      const p = parseExploreRevealPrompt(REAL_REVEAL, STATE)!;
+      expect(p).not.toBeNull();
+      if (p.kind !== "reveal") throw new Error("expected a reveal prompt");
+      expect(p.player).toBe(0);
+      expect(p.sourceName).toBe("Ranger of Eos");
+      expect(p.hitCardName).toBe("Kodama's Reach");
+      expect(p.acceptZone).toBe("Battlefield");
+      expect(p.declineZone).toBe("Graveyard");
+    });
+
+    it("falls back to empty names when state is omitted", () => {
+      const p = parseExploreRevealPrompt(REAL_REVEAL);
+      if (p?.kind !== "reveal") throw new Error("expected a reveal prompt");
+      expect(p.sourceName).toBe("");
+      expect(p.hitCardName).toBe("");
+    });
+
+    it("returns null when accept_zone is missing", () => {
+      const wf: WaitingFor = {
+        type: "RevealUntilKeptChoice",
+        data: {
+          player: 0,
+          hit_card: 78,
+          source_id: 90,
+          decline_zone: "Graveyard",
+        },
+      };
+      expect(parseExploreRevealPrompt(wf)).toBeNull();
+    });
+
+    it("returns null when decline_zone is missing", () => {
+      const wf: WaitingFor = {
+        type: "RevealUntilKeptChoice",
+        data: {
+          player: 0,
+          hit_card: 78,
+          source_id: 90,
+          accept_zone: "Battlefield",
+        },
+      };
+      expect(parseExploreRevealPrompt(wf)).toBeNull();
+    });
+  });
+
+  it("returns null for a non-matching waiting_for", () => {
+    expect(parseExploreRevealPrompt(undefined)).toBeNull();
+    expect(parseExploreRevealPrompt({ type: "Priority", data: {} })).toBeNull();
+  });
+});
+
+describe("exploreCreatureAction", () => {
+  it("builds the ChooseTarget action", () => {
+    expect(exploreCreatureAction(12)).toEqual({
+      type: "ChooseTarget",
+      data: { target: { Object: 12 } },
+    });
+  });
+});
+
+describe("revealUntilAction", () => {
+  it("builds the accept action", () => {
+    expect(revealUntilAction(true)).toEqual({
+      type: "DecideOptionalEffect",
+      data: { accept: true },
+    });
+  });
+
+  it("builds the decline action", () => {
+    expect(revealUntilAction(false)).toEqual({
+      type: "DecideOptionalEffect",
+      data: { accept: false },
+    });
+  });
+});

--- a/src/sim/decisions/exploreReveal.ts
+++ b/src/sim/decisions/exploreReveal.ts
@@ -1,0 +1,107 @@
+// Choosing a creature to explore, and deciding whether to keep a card found
+// by a reveal-until-you-find effect. The engine surfaces two waiting_for
+// shapes:
+// - `ExploreChoice` { player, source_id, choosable: ObjId[], remaining: ObjId[],
+//   pending_effect } — pick which creature (among `choosable`) explores next.
+//   Answered with `ChooseTarget { target: { Object: id } }`.
+// - `RevealUntilKeptChoice` { player, hit_card, source_id, accept_zone,
+//   decline_zone, enter_tapped, enters_attacking, revealed_misses,
+//   rest_destination } — keep the found `hit_card` (goes to `accept_zone`) or
+//   decline it (goes to `decline_zone`). Answered with
+//   `DecideOptionalEffect { accept }`.
+// Shapes confirmed against phase-rs client/src/adapter/types.ts (TargetingOverlay,
+// RevealUntilKeptChoiceModal) at v0.71.0.
+
+import type { GameState, WaitingFor } from "../../engine/types";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/** One creature offered up to explore. */
+export interface ExploreCreature {
+  id: number;
+  name: string;
+}
+
+export interface ExplorePrompt {
+  kind: "explore";
+  player: number;
+  sourceName: string;
+  creatures: ExploreCreature[];
+}
+
+export interface RevealUntilPrompt {
+  kind: "reveal";
+  player: number;
+  sourceName: string;
+  hitCardName: string;
+  /** Zone the found card goes to if kept. */
+  acceptZone: string;
+  /** Zone the found card goes to if declined. */
+  declineZone: string;
+}
+
+export type ExploreRevealPrompt = ExplorePrompt | RevealUntilPrompt;
+
+function parseExploreChoice(d: any, state?: GameState): ExplorePrompt | null {
+  const choosable = Array.isArray(d.choosable) ? d.choosable : [];
+  if (choosable.length === 0) return null;
+  return {
+    kind: "explore",
+    player: typeof d.player === "number" ? d.player : 0,
+    sourceName: state?.objects?.[d.source_id]?.name ?? "",
+    creatures: choosable.map((id: number) => ({
+      id,
+      name: state?.objects?.[id]?.name ?? "",
+    })),
+  };
+}
+
+function parseRevealUntilKeptChoice(
+  d: any,
+  state?: GameState,
+): RevealUntilPrompt | null {
+  const acceptZone = typeof d.accept_zone === "string" ? d.accept_zone : "";
+  const declineZone = typeof d.decline_zone === "string" ? d.decline_zone : "";
+  if (!acceptZone || !declineZone) return null;
+  return {
+    kind: "reveal",
+    player: typeof d.player === "number" ? d.player : 0,
+    sourceName: state?.objects?.[d.source_id]?.name ?? "",
+    hitCardName: state?.objects?.[d.hit_card]?.name ?? "",
+    acceptZone,
+    declineZone,
+  };
+}
+
+/** Read an explore or reveal-until-you-find decision aimed at the human, or null. */
+export function parseExploreRevealPrompt(
+  wf: WaitingFor | undefined,
+  state?: GameState,
+): ExploreRevealPrompt | null {
+  if (!wf) return null;
+  const d: any = wf.data ?? {};
+  switch (wf.type) {
+    case "ExploreChoice":
+      return parseExploreChoice(d, state);
+    case "RevealUntilKeptChoice":
+      return parseRevealUntilKeptChoice(d, state);
+    default:
+      return null;
+  }
+}
+
+/** Submit the chosen creature id for an explore decision. */
+export function exploreCreatureAction(id: number): {
+  type: string;
+  data: { target: { Object: number } };
+} {
+  return { type: "ChooseTarget", data: { target: { Object: id } } };
+}
+
+/** Submit the keep/decline answer for a reveal-until-you-find decision. */
+export function revealUntilAction(accept: boolean): {
+  type: string;
+  data: { accept: boolean };
+} {
+  return { type: "DecideOptionalEffect", data: { accept } };
+}

--- a/src/sim/driver.ts
+++ b/src/sim/driver.ts
@@ -49,6 +49,10 @@ import {
   type SearchDecisionPrompt,
 } from "./decisions/search";
 import { parseDigPrompt, type DigPrompt } from "./decisions/dig";
+import {
+  parseExploreRevealPrompt,
+  type ExploreRevealPrompt,
+} from "./decisions/exploreReveal";
 
 export interface MatchResult {
   matchIndex: number;
@@ -290,6 +294,11 @@ export interface DriverCallbacks {
   requestHumanDig?: (
     env: GameStateEnvelope,
     prompt: DigPrompt,
+  ) => Promise<HumanChoice>;
+  /** Called when the human explores with a creature or decides whether to keep a reveal-until hit. */
+  requestHumanExploreReveal?: (
+    env: GameStateEnvelope,
+    prompt: ExploreRevealPrompt,
   ) => Promise<HumanChoice>;
 }
 
@@ -621,6 +630,12 @@ export class MatchRunner {
         ),
       () => humanRequest(env, cb.requestHumanSearch, parseSearchPrompt(wf, state)),
       () => humanRequest(env, cb.requestHumanDig, parseDigPrompt(wf, state)),
+      () =>
+        humanRequest(
+          env,
+          cb.requestHumanExploreReveal,
+          parseExploreRevealPrompt(wf, state),
+        ),
     ];
     for (const resolve of resolvers) {
       const req = resolve();


### PR DESCRIPTION
Surfaces the engine's `ExploreChoice` and `RevealUntilKeptChoice` to the human seat instead of the AI deciding:

- Explore: the panel lists the `choosable` creatures by name; clicking one submits it directly (single pick, no confirm step needed).
- Reveal-until-you-find: the panel names the source and the found card, with a primary "Keep (zone)" button and a secondary "Put in zone" button naming the engine's `accept_zone` / `decline_zone`.
- Both fall back to "let the AI decide".

Confirmed the `ChooseTarget { target: { Object } }` / `DecideOptionalEffect { accept }` submissions against phase-rs v0.71.0's reference client (TargetingOverlay, RevealUntilKeptChoiceModal).

## Files
- `src/sim/decisions/exploreReveal.ts` + `.test.ts` — parser (discriminated `explore` | `reveal` prompt) + action builders
- `src/sim/driver.ts` — `requestHumanExploreReveal` callback + resolver
- `src/match/RunView.tsx` — `ExploreRevealTurn`, `ExploreRevealPanel`, wiring
- `src/i18n/messages.ts` — `exploreReveal.*` keys (pt/en)
- `domainbook/domains/simulation/features/choose-explore-and-reveal-outcomes.md`, changelog 0.12.0, package.json bump

## Gates
`npm run lint && npm run typecheck && npm run duplication && npm test && npm run build` — all green.
`npx domainbook check --range main..HEAD` — nothing stale.
`npx domainbook validate` — valid.

Closes #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)