### PR TITLE
feat(sim): let the human pay Phyrexian mana costs with life

### DIFF
--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,6 +12,14 @@ depth live there. A purely-internal PR that touches no product or architecture m
 skip its version with a `Skip-Docs: <reason>` trailer instead. There are no
 per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
+## [0.13.0] - 2026-09-05
+
+### Added
+
+- You now choose, shard by shard, whether to **pay a Phyrexian mana cost with
+  mana or with 2 life**, instead of the AI deciding
+  (`domains/simulation/features/pay-phyrexian-with-life.md`).
+
 ## [0.12.0] - 2026-09-05
 
 ### Added

--- a/domainbook/domains/simulation/features/pay-phyrexian-with-life.md
+++ b/domainbook/domains/simulation/features/pay-phyrexian-with-life.md
@@ -1,0 +1,74 @@
+---
+id: pay-phyrexian-with-life
+name: Pay Phyrexian mana with life
+status: implemented
+---
+
+## Story
+
+As a player piloting my seat
+I want to choose, symbol by symbol, whether to pay a Phyrexian mana cost with mana or with life
+So that a choice that costs me life instead of mana is mine, not the AI's
+
+## Rule: A Phyrexian payment prompts the human on their own cast
+
+When the engine asks the human to resolve a `PhyrexianPayment` decision
+request — casting a spell whose cost has one or more Phyrexian mana symbols
+({W/P}, {U/P}, …) — the seat's control panel shows one row per symbol,
+naming the spell and each symbol's color. Other seats resolve it by AI
+action proposal as before, and any non-`PhyrexianPayment` state is untouched.
+
+```gherkin
+Example: The prompt appears on my own Phyrexian spell
+  Given a play-mode match where I control seat 0
+  When I cast a spell with a Phyrexian mana symbol in its cost
+  Then the control panel asks how to pay each symbol, naming the spell
+  And an opponent's Phyrexian spell is still decided by the AI
+```
+
+## Rule: Each shard toggles between mana and life, unless the engine locks it
+
+Each symbol (a "shard") offers a two-way toggle between paying with its
+color's mana and paying with 2 life. When the engine reports a shard as
+`ManaOnly` or `LifeOnly` — for example a color the seat cannot produce, or a
+format that disallows the life option — that shard's toggle is locked to the
+engine's answer and cannot be switched. A running total shows how much life
+the current choices would spend.
+
+```gherkin
+Example: A flexible shard can be toggled either way
+  Given a Phyrexian payment prompt with a black shard offering mana or life
+  When I switch that shard to pay with life
+  Then the running life total increases by 2
+
+Example: A locked shard cannot be switched
+  Given a Phyrexian payment prompt with a shard the engine marks mana-only
+  Then that shard's toggle is disabled and stays on mana
+```
+
+## Rule: Confirm submits the per-shard choices, and the choice can be handed to the AI
+
+Confirm submits `SubmitPhyrexianChoices` with one `PayMana`/`PayLife` choice
+per shard, in the same order the engine listed them. Choosing let the AI
+decide hands the whole payment back to the engine's own AI, so the decision
+is never stuck (`simulation/ADR-0001`).
+
+```gherkin
+Example: Confirming a mix of mana and life
+  Given a Phyrexian payment prompt with two shards, one set to life
+  When I confirm
+  Then the engine receives one PayMana or PayLife choice per shard, in order
+
+Example: Letting the AI decide
+  Given the Phyrexian payment prompt is shown
+  When I choose let the AI decide
+  Then the engine's AI decides how to pay each shard
+```
+
+## Open Questions
+
+- The `PhyrexianPayment` shape (`spell_object`, `shards: PhyrexianShard[]`
+  with `shard_index`/`color`/`options`) and the `SubmitPhyrexianChoices`
+  submission were confirmed against phase-rs `client/src/adapter/types.ts`
+  at v0.71.0, but not yet round-tripped against a live cast with a
+  Phyrexian-mana card.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -410,6 +410,26 @@ export const messages = {
   },
   "exploreReveal.letAi": { pt: "IA decide", en: "Let the AI decide" },
 
+  "phyrexian.title": { pt: "Pagar mana phyrexiana", en: "Pay Phyrexian mana" },
+  "phyrexian.prompt": {
+    pt: "{name} tem símbolos de mana phyrexiana. Escolha como pagar cada um.",
+    en: "{name} has Phyrexian mana symbols. Choose how to pay each one.",
+  },
+  "phyrexian.spellFallback": { pt: "esta mágica", en: "this spell" },
+  "phyrexian.colorWhite": { pt: "Branco", en: "White" },
+  "phyrexian.colorBlue": { pt: "Azul", en: "Blue" },
+  "phyrexian.colorBlack": { pt: "Preto", en: "Black" },
+  "phyrexian.colorRed": { pt: "Vermelho", en: "Red" },
+  "phyrexian.colorGreen": { pt: "Verde", en: "Green" },
+  "phyrexian.manaOption": { pt: "Mana {color}", en: "{color} mana" },
+  "phyrexian.lifeOption": { pt: "2 de vida", en: "2 life" },
+  "phyrexian.lifeTotal": {
+    pt: "Vida total a pagar: {n}",
+    en: "Total life to pay: {n}",
+  },
+  "phyrexian.confirm": { pt: "Confirmar", en: "Confirm" },
+  "phyrexian.letAi": { pt: "IA decide", en: "Let the AI decide" },
+
   "modes.title": { pt: "Escolher modo", en: "Choose a mode" },
   "modes.source": {
     pt: "{name} pede uma escolha de modo.",

--- a/src/match/RunView.tsx
+++ b/src/match/RunView.tsx
@@ -69,6 +69,13 @@ import {
   revealUntilAction,
   type ExploreRevealPrompt,
 } from "../sim/decisions/exploreReveal";
+import {
+  defaultPhyrexianChoices,
+  submitPhyrexianAction,
+  type ManaColor,
+  type PhyrexianPaymentPrompt,
+  type PhyrexianShardChoice,
+} from "../sim/decisions/phyrexianPayment";
 import { XpWindow } from "../components/XpWindow";
 import {
   declareAttackersAction,
@@ -537,6 +544,85 @@ function ExploreRevealPanel({ turn }: { turn: ExploreRevealTurn }) {
   );
 }
 
+interface PhyrexianTurn {
+  prompt: PhyrexianPaymentPrompt;
+  resolve: (choice: HumanChoice) => void;
+}
+
+const PHYREXIAN_COLOR_KEY: Record<ManaColor, MsgKey> = {
+  White: "phyrexian.colorWhite",
+  Blue: "phyrexian.colorBlue",
+  Black: "phyrexian.colorBlack",
+  Red: "phyrexian.colorRed",
+  Green: "phyrexian.colorGreen",
+};
+
+function PhyrexianPanel({
+  turn,
+  pick,
+  onTogglePick,
+  onConfirm,
+  onLetAi,
+}: {
+  turn: PhyrexianTurn;
+  pick: PhyrexianShardChoice[];
+  onTogglePick: (index: number) => void;
+  onConfirm: () => void;
+  onLetAi: () => void;
+}) {
+  const { t } = useI18n();
+  const { prompt } = turn;
+  const sourceName = prompt.sourceName || t("phyrexian.spellFallback");
+  const lifeTotal =
+    pick.filter((choice) => choice === "PayLife").length * 2;
+  return (
+    <>
+      <div className="control-title">
+        <strong>{t("phyrexian.title")}</strong>
+      </div>
+      <p className="hint">{t("phyrexian.prompt", { name: sourceName })}</p>
+      <div className="search-list">
+        {prompt.shards.map((shard, index) => {
+          const locked = shard.optionType !== "ManaOrLife";
+          const payingLife = pick[index] === "PayLife";
+          const colorLabel = t(PHYREXIAN_COLOR_KEY[shard.color]);
+          return (
+            <div className="import__row" key={index}>
+              <div className="seg">
+                <button
+                  className={`seg__btn ${!payingLife ? "seg__btn--active" : ""}`}
+                  disabled={locked}
+                  aria-pressed={!payingLife}
+                  onClick={() => onTogglePick(index)}
+                >
+                  {t("phyrexian.manaOption", { color: colorLabel })}
+                </button>
+                <button
+                  className={`seg__btn ${payingLife ? "seg__btn--active" : ""}`}
+                  disabled={locked}
+                  aria-pressed={payingLife}
+                  onClick={() => onTogglePick(index)}
+                >
+                  {t("phyrexian.lifeOption")}
+                </button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      <p className="hint">{t("phyrexian.lifeTotal", { n: lifeTotal })}</p>
+      <div className="import__row">
+        <button className="btn" onClick={onConfirm}>
+          {t("phyrexian.confirm")}
+        </button>
+        <button className="btn btn--ghost" onClick={onLetAi}>
+          {t("phyrexian.letAi")}
+        </button>
+      </div>
+    </>
+  );
+}
+
 function isTargetOptional(
   targeting: TargetTurn | null,
   chosen: TargetRef[],
@@ -680,6 +766,8 @@ interface RunnerCallbackDeps {
   setDigPick: Dispatch<SetStateAction<Set<number>>>;
   setDigTurn: Dispatch<SetStateAction<DigTurn | null>>;
   setExploreRevealTurn: Dispatch<SetStateAction<ExploreRevealTurn | null>>;
+  setPhyrexianPick: Dispatch<SetStateAction<PhyrexianShardChoice[]>>;
+  setPhyrexianTurn: Dispatch<SetStateAction<PhyrexianTurn | null>>;
 }
 
 function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
@@ -723,6 +811,8 @@ function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
     setDigPick,
     setDigTurn,
     setExploreRevealTurn,
+    setPhyrexianPick,
+    setPhyrexianTurn,
   } = deps;
   return {
     onFrame: (env) => {
@@ -1035,6 +1125,22 @@ function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
           },
         });
       }),
+    requestHumanPhyrexianPayment: (_env, prompt) =>
+      new Promise<HumanChoice>((resolve) => {
+        if (isCancelled()) {
+          resolve({ ai: true });
+          return;
+        }
+        setPhyrexianPick(defaultPhyrexianChoices(prompt.shards));
+        setPhyrexianTurn({
+          prompt,
+          resolve: (choice) => {
+            setPhyrexianTurn(null);
+            setPhyrexianPick(defaultPhyrexianChoices(prompt.shards));
+            resolve(choice);
+          },
+        });
+      }),
   };
 }
 
@@ -1142,6 +1248,12 @@ export function RunView({
   const [digPick, setDigPick] = useState<Set<number>>(new Set());
   const [exploreRevealTurn, setExploreRevealTurn] =
     useState<ExploreRevealTurn | null>(null);
+  const [phyrexianTurn, setPhyrexianTurn] = useState<PhyrexianTurn | null>(
+    null,
+  );
+  const [phyrexianPick, setPhyrexianPick] = useState<PhyrexianShardChoice[]>(
+    [],
+  );
   const [passingTurn, setPassingTurn] = useState(false);
   const [logEntries, setLogEntries] = useState<LoggedEntry[]>([]);
   // On mobile the log is a full-screen drawer, so it always starts closed and
@@ -1249,6 +1361,8 @@ export function RunView({
             setDigPick,
             setDigTurn,
             setExploreRevealTurn,
+            setPhyrexianPick,
+            setPhyrexianTurn,
           }),
         );
         runnerRef.current = runner;
@@ -1383,7 +1497,8 @@ export function RunView({
         orderTriggersTurn ||
         searchTurn ||
         digTurn ||
-        exploreRevealTurn)
+        exploreRevealTurn ||
+        phyrexianTurn)
     ) {
       setPassingTurn(false);
     }
@@ -1403,6 +1518,7 @@ export function RunView({
     searchTurn,
     digTurn,
     exploreRevealTurn,
+    phyrexianTurn,
   ]);
 
   // Map draggable hand cards to their play actions for the current window.
@@ -2430,6 +2546,27 @@ export function RunView({
           )}
 
           {exploreRevealTurn && <ExploreRevealPanel turn={exploreRevealTurn} />}
+
+          {phyrexianTurn && (
+            <PhyrexianPanel
+              turn={phyrexianTurn}
+              pick={phyrexianPick}
+              onTogglePick={(index) =>
+                setPhyrexianPick((prev) =>
+                  prev.map((choice, i) => {
+                    if (i !== index) return choice;
+                    return choice === "PayLife" ? "PayMana" : "PayLife";
+                  }),
+                )
+              }
+              onConfirm={() =>
+                phyrexianTurn.resolve({
+                  action: submitPhyrexianAction(phyrexianPick),
+                })
+              }
+              onLetAi={() => phyrexianTurn.resolve({ ai: true })}
+            />
+          )}
         </section>
       )}
 

--- a/src/sim/decisions/phyrexianPayment.test.ts
+++ b/src/sim/decisions/phyrexianPayment.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import {
+  parsePhyrexianPaymentPrompt,
+  defaultPhyrexianChoices,
+  submitPhyrexianAction,
+} from "./phyrexianPayment";
+import type { GameObject, WaitingFor } from "../../engine/types";
+
+// Shape confirmed against phase-rs client/src/adapter/types.ts (v0.71.0):
+// PhyrexianPayment { player, spell_object, shards: PhyrexianShard[]
+// { shard_index, color: ManaColor, options: ShardOptions } }, where
+// ShardOptions is one of ManaOrLife / ManaOnly / LifeOnly.
+const REAL_PHYREXIAN: WaitingFor = {
+  type: "PhyrexianPayment",
+  data: {
+    player: 0,
+    spell_object: 45,
+    shards: [
+      { shard_index: 0, color: "Black", options: { type: "ManaOrLife" } },
+      { shard_index: 1, color: "Black", options: { type: "ManaOnly" } },
+      { shard_index: 2, color: "Blue", options: { type: "LifeOnly" } },
+    ],
+  },
+};
+
+const OBJECTS: Record<string, GameObject> = {
+  45: { id: 45, name: "Gitaxian Probe", zone: "Stack" },
+};
+
+describe("parsePhyrexianPaymentPrompt", () => {
+  it("parses the player, source name and shard options in order", () => {
+    const p = parsePhyrexianPaymentPrompt(REAL_PHYREXIAN, OBJECTS)!;
+    expect(p).not.toBeNull();
+    expect(p.player).toBe(0);
+    expect(p.sourceName).toBe("Gitaxian Probe");
+    expect(p.shards).toEqual([
+      { color: "Black", optionType: "ManaOrLife" },
+      { color: "Black", optionType: "ManaOnly" },
+      { color: "Blue", optionType: "LifeOnly" },
+    ]);
+  });
+
+  it("falls back to an empty source name when the object is unknown", () => {
+    const p = parsePhyrexianPaymentPrompt(REAL_PHYREXIAN);
+    expect(p?.sourceName).toBe("");
+  });
+
+  it("returns null for a non-matching waiting_for", () => {
+    expect(parsePhyrexianPaymentPrompt(undefined)).toBeNull();
+    expect(
+      parsePhyrexianPaymentPrompt({ type: "Priority", data: {} }),
+    ).toBeNull();
+  });
+
+  it("returns null when shards is empty", () => {
+    const wf: WaitingFor = {
+      type: "PhyrexianPayment",
+      data: { player: 0, spell_object: 45, shards: [] },
+    };
+    expect(parsePhyrexianPaymentPrompt(wf)).toBeNull();
+  });
+
+  it("returns null when a shard has a malformed color or option type", () => {
+    const wf: WaitingFor = {
+      type: "PhyrexianPayment",
+      data: {
+        player: 0,
+        spell_object: 45,
+        shards: [{ shard_index: 0, color: "Colorless", options: {} }],
+      },
+    };
+    expect(parsePhyrexianPaymentPrompt(wf)).toBeNull();
+  });
+});
+
+describe("defaultPhyrexianChoices", () => {
+  it("defaults ManaOnly and ManaOrLife shards to PayMana, LifeOnly to PayLife", () => {
+    const p = parsePhyrexianPaymentPrompt(REAL_PHYREXIAN)!;
+    expect(defaultPhyrexianChoices(p.shards)).toEqual([
+      "PayMana",
+      "PayMana",
+      "PayLife",
+    ]);
+  });
+});
+
+describe("submitPhyrexianAction", () => {
+  it("builds one ShardChoice per shard, in order", () => {
+    expect(submitPhyrexianAction(["PayMana", "PayLife"])).toEqual({
+      type: "SubmitPhyrexianChoices",
+      data: { choices: [{ type: "PayMana" }, { type: "PayLife" }] },
+    });
+  });
+});

--- a/src/sim/decisions/phyrexianPayment.ts
+++ b/src/sim/decisions/phyrexianPayment.ts
@@ -1,0 +1,90 @@
+// Paying a Phyrexian mana cost — a spell with one or more Phyrexian mana
+// symbols ({W/P}, {U/P}, …) asks the controller how to pay each shard: with
+// the colored mana, or with 2 life instead. The engine surfaces a
+// `PhyrexianPayment` waiting_for whose `data` carries the acting `player`,
+// the `spell_object` (the spell on the stack), and `shards`: an ordered
+// list of `PhyrexianShard { shard_index, color, options }`, where `options`
+// is `ManaOrLife` (either), `ManaOnly`, or `LifeOnly` (the shard is locked).
+// The seat answers by submitting `SubmitPhyrexianChoices` with one
+// `ShardChoice` (`PayMana` or `PayLife`) per shard, index-aligned to the
+// `shards` order.
+// Shapes confirmed against phase-rs client/src/adapter/types.ts at v0.71.0.
+
+import type { GameObject, WaitingFor } from "../../engine/types";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export type ManaColor = "White" | "Blue" | "Black" | "Red" | "Green";
+
+export type PhyrexianShardOptionType = "ManaOrLife" | "ManaOnly" | "LifeOnly";
+
+export interface PhyrexianShardPrompt {
+  color: ManaColor;
+  optionType: PhyrexianShardOptionType;
+}
+
+export type PhyrexianShardChoice = "PayMana" | "PayLife";
+
+export interface PhyrexianPaymentPrompt {
+  player: number;
+  /** The spell whose cost is being paid, for the prompt (may be empty). */
+  sourceName: string;
+  shards: PhyrexianShardPrompt[];
+}
+
+const MANA_COLORS: ManaColor[] = ["White", "Blue", "Black", "Red", "Green"];
+
+function isManaColor(value: unknown): value is ManaColor {
+  return typeof value === "string" && MANA_COLORS.includes(value as ManaColor);
+}
+
+function isShardOptionType(value: unknown): value is PhyrexianShardOptionType {
+  return value === "ManaOrLife" || value === "ManaOnly" || value === "LifeOnly";
+}
+
+/** Read a "pay a Phyrexian mana cost" decision aimed at the human, or null. */
+export function parsePhyrexianPaymentPrompt(
+  wf: WaitingFor | undefined,
+  objects?: Record<string, GameObject>,
+): PhyrexianPaymentPrompt | null {
+  if (!wf || wf.type !== "PhyrexianPayment") return null;
+  const d: any = wf.data ?? {};
+  const rawShards = Array.isArray(d.shards) ? d.shards : [];
+
+  const shards: PhyrexianShardPrompt[] = [];
+  for (const shard of rawShards) {
+    const color = shard?.color;
+    const optionType = shard?.options?.type;
+    if (!isManaColor(color) || !isShardOptionType(optionType)) return null;
+    shards.push({ color, optionType });
+  }
+  if (shards.length === 0) return null;
+
+  const sourceName = objects?.[d.spell_object]?.name ?? "";
+
+  return {
+    player: typeof d.player === "number" ? d.player : 0,
+    sourceName,
+    shards,
+  };
+}
+
+/** Per-shard default choice, for the initial pick-state. */
+export function defaultPhyrexianChoices(
+  shards: PhyrexianShardPrompt[],
+): PhyrexianShardChoice[] {
+  return shards.map((shard) =>
+    shard.optionType === "LifeOnly" ? "PayLife" : "PayMana",
+  );
+}
+
+/** Submit the per-shard mana/life choices back to the engine. */
+export function submitPhyrexianAction(choices: PhyrexianShardChoice[]): {
+  type: string;
+  data: { choices: { type: PhyrexianShardChoice }[] };
+} {
+  return {
+    type: "SubmitPhyrexianChoices",
+    data: { choices: choices.map((c) => ({ type: c })) },
+  };
+}

--- a/src/sim/driver.ts
+++ b/src/sim/driver.ts
@@ -53,6 +53,10 @@ import {
   parseExploreRevealPrompt,
   type ExploreRevealPrompt,
 } from "./decisions/exploreReveal";
+import {
+  parsePhyrexianPaymentPrompt,
+  type PhyrexianPaymentPrompt,
+} from "./decisions/phyrexianPayment";
 
 export interface MatchResult {
   matchIndex: number;
@@ -299,6 +303,11 @@ export interface DriverCallbacks {
   requestHumanExploreReveal?: (
     env: GameStateEnvelope,
     prompt: ExploreRevealPrompt,
+  ) => Promise<HumanChoice>;
+  /** Called when a spell with Phyrexian mana symbols asks the human to pay each shard with mana or life. */
+  requestHumanPhyrexianPayment?: (
+    env: GameStateEnvelope,
+    prompt: PhyrexianPaymentPrompt,
   ) => Promise<HumanChoice>;
 }
 
@@ -635,6 +644,12 @@ export class MatchRunner {
           env,
           cb.requestHumanExploreReveal,
           parseExploreRevealPrompt(wf, state),
+        ),
+      () =>
+        humanRequest(
+          env,
+          cb.requestHumanPhyrexianPayment,
+          parsePhyrexianPaymentPrompt(wf, state.objects),
         ),
     ];
     for (const resolve of resolvers) {


### PR DESCRIPTION
Surfaces the engine's `PhyrexianPayment` decision to the human seat: casting a spell with Phyrexian mana symbols shows one row per shard, each a mana/life toggle (locked when the engine reports the shard as `ManaOnly` or `LifeOnly`), a running "total life to pay" count, and a let-the-AI-decide escape. Submits `SubmitPhyrexianChoices { choices }`, one `PayMana`/`PayLife` per shard, index-aligned.

Follows the established decision-wiring recipe: `src/sim/decisions/phyrexianPayment.ts` (+ tests), `src/sim/driver.ts` resolver, `src/match/RunView.tsx` (`PhyrexianTurn`, `PhyrexianPanel`, pick-state reset to per-shard defaults on each new turn), `src/i18n/messages.ts` (pt/en), and domainbook feature doc + changelog (0.13.0) + package.json bump.

Shapes confirmed against phase-rs v0.71.0's reference client per the vendored WASM (not yet round-tripped against a live cast with a Phyrexian-mana card — noted as an Open Question in the feature doc).

Closes #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)