### PR TITLE
feat(sim): let the human choose coin-flip results and life redistribution

### DIFF
--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,6 +12,14 @@ depth live there. A purely-internal PR that touches no product or architecture m
 skip its version with a `Skip-Docs: <reason>` trailer instead. There are no
 per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
+## [0.14.0] - 2026-09-05
+
+### Added
+
+- You now choose which **coin-flip results to keep** and which
+  **life-redistribution option to apply**, instead of the AI deciding
+  (`domains/simulation/features/choose-coin-flips-and-life-redistribution.md`).
+
 ## [0.13.0] - 2026-09-05
 
 ### Added

--- a/domainbook/domains/simulation/features/choose-coin-flips-and-life-redistribution.md
+++ b/domainbook/domains/simulation/features/choose-coin-flips-and-life-redistribution.md
@@ -1,0 +1,79 @@
+---
+id: choose-coin-flips-and-life-redistribution
+name: Choose coin-flip results and life redistribution
+status: implemented
+---
+
+## Story
+
+As a player piloting my seat
+I want to pick which coin-flip results to keep and which life-redistribution
+option to apply
+So that those outcomes are mine to choose, not the AI's
+
+## Rule: A coin-flip prompt shows every result and how many to keep
+
+When the engine asks the human to resolve a `CoinFlipKeepChoice`
+`decision request` — offered whenever an effect flips several coins and the
+seat keeps a subset of the results — the control panel lists each flip as
+heads or tails and lets the seat toggle which ones to keep, up to
+`keep_count`. Other seats resolve it by `AI action proposal` as before, and
+any non-`CoinFlipKeepChoice` state is untouched.
+
+```gherkin
+Example: The prompt appears on my own coin flips
+  Given a play-mode match where I control seat 0
+  When an effect flips three coins and I keep two of them
+  Then the control panel lists all three results as heads or tails
+  And an opponent's coin flip is still decided by the AI
+```
+
+## Rule: Confirm is disabled until exactly keep_count results are picked
+
+The seat toggles individual results on and off; the confirm button stays
+disabled until exactly `keep_count` are selected, then submits
+`SelectCoinFlips { keep_indices }` with the indices (into `results`) that
+were kept.
+
+```gherkin
+Example: Keeping the right number of results
+  Given a coin-flip prompt asking to keep 2 of 3 results
+  When I toggle exactly two results and confirm
+  Then the engine receives those two indices as the kept flips
+```
+
+## Rule: A life-redistribution prompt lists each option's outcome
+
+A `RedistributeLifeTotals` decision (an effect like Repercussion or Sword of
+the Meek's Metalcraft trigger that redistributes life among seats) offers a
+fixed set of `options`, each a complete new assignment of life totals across
+seats. The panel lists every option as a button naming the resulting life
+total per seat (the human's own seat labeled "You", others "Seat N").
+
+```gherkin
+Example: Picking a life-redistribution option
+  Given a life-redistribution prompt with two options
+  When I click one of the listed options
+  Then the engine receives that option's index as the chosen redistribution
+```
+
+## Rule: The choice can be handed to the AI
+
+Choosing let the AI decide hands the whole coin-flip-keep or
+life-redistribution choice back to the engine's own AI, so the decision is
+never stuck (`simulation/ADR-0001`).
+
+```gherkin
+Example: Letting the AI decide
+  Given a coin-flip or life-redistribution prompt is shown
+  When I choose let the AI decide
+  Then the engine's AI makes that choice
+```
+
+## Open Questions
+
+- The `CoinFlipKeepChoice` and `RedistributeLifeTotals` shapes, and the
+  `SelectCoinFlips` / `SubmitLifeRedistribution` submissions, were confirmed
+  against phase-rs `client/src/adapter/types.ts`
+  (CoinFlipKeepModal, LifeRedistributionModal) at v0.71.0, but not yet
+  round-tripped against a live coin-flip or life-redistribution effect.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -430,6 +430,30 @@ export const messages = {
   "phyrexian.confirm": { pt: "Confirmar", en: "Confirm" },
   "phyrexian.letAi": { pt: "IA decide", en: "Let the AI decide" },
 
+  "coinFlipLife.coinFlipTitle": {
+    pt: "Manter resultados de moeda",
+    en: "Keep coin-flip results",
+  },
+  "coinFlipLife.coinFlipHint": {
+    pt: "Mantenha {n} resultado(s).",
+    en: "Keep {n} result(s).",
+  },
+  "coinFlipLife.kept": {
+    pt: "Mantidos: {picked} / {n}",
+    en: "Kept {picked} of {n}",
+  },
+  "coinFlipLife.heads": { pt: "Cara", en: "Heads" },
+  "coinFlipLife.tails": { pt: "Coroa", en: "Tails" },
+  "coinFlipLife.confirm": { pt: "Confirmar", en: "Confirm" },
+  "coinFlipLife.lifeTitle": {
+    pt: "Redistribuir totais de vida",
+    en: "Redistribute life totals",
+  },
+  "coinFlipLife.lifeEntry": { pt: "{seat}: {life}", en: "{seat}: {life}" },
+  "coinFlipLife.you": { pt: "Você", en: "You" },
+  "coinFlipLife.seat": { pt: "Assento {n}", en: "Seat {n}" },
+  "coinFlipLife.letAi": { pt: "IA decide", en: "Let the AI decide" },
+
   "modes.title": { pt: "Escolher modo", en: "Choose a mode" },
   "modes.source": {
     pt: "{name} pede uma escolha de modo.",

--- a/src/match/RunView.tsx
+++ b/src/match/RunView.tsx
@@ -76,6 +76,11 @@ import {
   type PhyrexianPaymentPrompt,
   type PhyrexianShardChoice,
 } from "../sim/decisions/phyrexianPayment";
+import {
+  selectCoinFlipsAction,
+  submitLifeRedistributionAction,
+  type CoinFlipLifePrompt,
+} from "../sim/decisions/coinFlipAndLife";
 import { XpWindow } from "../components/XpWindow";
 import {
   declareAttackersAction,
@@ -623,6 +628,117 @@ function PhyrexianPanel({
   );
 }
 
+interface CoinFlipLifeTurn {
+  prompt: CoinFlipLifePrompt;
+  resolve: (choice: HumanChoice) => void;
+}
+
+function coinFlipLifeSeatLabel(
+  seat: number,
+  t: (key: MsgKey, vars?: Vars) => string,
+): string {
+  return seat === 0
+    ? t("coinFlipLife.you")
+    : t("coinFlipLife.seat", { n: seat });
+}
+
+function CoinFlipLifePanel({
+  turn,
+  pick,
+  onTogglePick,
+  onConfirm,
+  onLetAi,
+}: {
+  turn: CoinFlipLifeTurn;
+  pick: Set<number>;
+  onTogglePick: (index: number) => void;
+  onConfirm: () => void;
+  onLetAi: () => void;
+}) {
+  const { t } = useI18n();
+  const { prompt, resolve } = turn;
+
+  if (prompt.kind === "coinFlip") {
+    const atCap = pick.size >= prompt.keepCount;
+    return (
+      <>
+        <div className="control-title">
+          <strong>{t("coinFlipLife.coinFlipTitle")}</strong>
+        </div>
+        <p className="hint">
+          {t("coinFlipLife.coinFlipHint", { n: prompt.keepCount })}
+        </p>
+        <p className="hint">
+          {t("coinFlipLife.kept", {
+            picked: pick.size,
+            n: prompt.keepCount,
+          })}
+        </p>
+        <div className="search-list">
+          {prompt.results.map((heads, index) => {
+            const picked = pick.has(index);
+            return (
+              <button
+                key={index}
+                className={picked ? "btn" : "btn--ghost"}
+                disabled={!picked && atCap}
+                onClick={() => onTogglePick(index)}
+              >
+                {heads ? t("coinFlipLife.heads") : t("coinFlipLife.tails")}
+              </button>
+            );
+          })}
+        </div>
+        <div className="import__row">
+          <button
+            className="btn"
+            disabled={pick.size !== prompt.keepCount}
+            onClick={onConfirm}
+          >
+            {t("coinFlipLife.confirm")}
+          </button>
+          <button className="btn btn--ghost" onClick={onLetAi}>
+            {t("coinFlipLife.letAi")}
+          </button>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div className="control-title">
+        <strong>{t("coinFlipLife.lifeTitle")}</strong>
+      </div>
+      <div className="search-list">
+        {prompt.options.map((option, index) => (
+          <button
+            key={index}
+            className="btn"
+            onClick={() =>
+              resolve({ action: submitLifeRedistributionAction(index) })
+            }
+          >
+            {option
+              .map((a) =>
+                t("coinFlipLife.lifeEntry", {
+                  seat: coinFlipLifeSeatLabel(a.seat, t),
+                  life: a.life,
+                }),
+              )
+              .join(" / ")}
+          </button>
+        ))}
+      </div>
+      <div className="import__row">
+        <button className="btn btn--ghost" onClick={onLetAi}>
+          {t("coinFlipLife.letAi")}
+        </button>
+      </div>
+    </>
+  );
+}
+
 function isTargetOptional(
   targeting: TargetTurn | null,
   chosen: TargetRef[],
@@ -768,6 +884,8 @@ interface RunnerCallbackDeps {
   setExploreRevealTurn: Dispatch<SetStateAction<ExploreRevealTurn | null>>;
   setPhyrexianPick: Dispatch<SetStateAction<PhyrexianShardChoice[]>>;
   setPhyrexianTurn: Dispatch<SetStateAction<PhyrexianTurn | null>>;
+  setCoinFlipLifePick: Dispatch<SetStateAction<Set<number>>>;
+  setCoinFlipLifeTurn: Dispatch<SetStateAction<CoinFlipLifeTurn | null>>;
 }
 
 function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
@@ -813,6 +931,8 @@ function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
     setExploreRevealTurn,
     setPhyrexianPick,
     setPhyrexianTurn,
+    setCoinFlipLifePick,
+    setCoinFlipLifeTurn,
   } = deps;
   return {
     onFrame: (env) => {
@@ -1141,6 +1261,22 @@ function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
           },
         });
       }),
+    requestHumanCoinFlipLife: (_env, prompt) =>
+      new Promise<HumanChoice>((resolve) => {
+        if (isCancelled()) {
+          resolve({ ai: true });
+          return;
+        }
+        setCoinFlipLifePick(new Set());
+        setCoinFlipLifeTurn({
+          prompt,
+          resolve: (choice) => {
+            setCoinFlipLifeTurn(null);
+            setCoinFlipLifePick(new Set());
+            resolve(choice);
+          },
+        });
+      }),
   };
 }
 
@@ -1254,6 +1390,11 @@ export function RunView({
   const [phyrexianPick, setPhyrexianPick] = useState<PhyrexianShardChoice[]>(
     [],
   );
+  const [coinFlipLifeTurn, setCoinFlipLifeTurn] =
+    useState<CoinFlipLifeTurn | null>(null);
+  const [coinFlipLifePick, setCoinFlipLifePick] = useState<Set<number>>(
+    new Set(),
+  );
   const [passingTurn, setPassingTurn] = useState(false);
   const [logEntries, setLogEntries] = useState<LoggedEntry[]>([]);
   // On mobile the log is a full-screen drawer, so it always starts closed and
@@ -1363,6 +1504,8 @@ export function RunView({
             setExploreRevealTurn,
             setPhyrexianPick,
             setPhyrexianTurn,
+            setCoinFlipLifePick,
+            setCoinFlipLifeTurn,
           }),
         );
         runnerRef.current = runner;
@@ -1498,7 +1641,8 @@ export function RunView({
         searchTurn ||
         digTurn ||
         exploreRevealTurn ||
-        phyrexianTurn)
+        phyrexianTurn ||
+        coinFlipLifeTurn)
     ) {
       setPassingTurn(false);
     }
@@ -1519,6 +1663,7 @@ export function RunView({
     digTurn,
     exploreRevealTurn,
     phyrexianTurn,
+    coinFlipLifeTurn,
   ]);
 
   // Map draggable hand cards to their play actions for the current window.
@@ -2565,6 +2710,33 @@ export function RunView({
                 })
               }
               onLetAi={() => phyrexianTurn.resolve({ ai: true })}
+            />
+          )}
+
+          {coinFlipLifeTurn && (
+            <CoinFlipLifePanel
+              turn={coinFlipLifeTurn}
+              pick={coinFlipLifePick}
+              onTogglePick={(index) =>
+                setCoinFlipLifePick((prev) => {
+                  const next = new Set(prev);
+                  if (next.has(index)) {
+                    next.delete(index);
+                  } else if (
+                    coinFlipLifeTurn.prompt.kind === "coinFlip" &&
+                    next.size < coinFlipLifeTurn.prompt.keepCount
+                  ) {
+                    next.add(index);
+                  }
+                  return next;
+                })
+              }
+              onConfirm={() =>
+                coinFlipLifeTurn.resolve({
+                  action: selectCoinFlipsAction([...coinFlipLifePick]),
+                })
+              }
+              onLetAi={() => coinFlipLifeTurn.resolve({ ai: true })}
             />
           )}
         </section>

--- a/src/sim/decisions/coinFlipAndLife.test.ts
+++ b/src/sim/decisions/coinFlipAndLife.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseCoinFlipLifePrompt,
+  selectCoinFlipsAction,
+  submitLifeRedistributionAction,
+} from "./coinFlipAndLife";
+import type { WaitingFor } from "../../engine/types";
+
+// Shape confirmed against phase-rs client/src/adapter/types.ts
+// (CoinFlipKeepModal) at v0.71.0: CoinFlipKeepChoice { player, results, keep_count }.
+const REAL_COIN_FLIP: WaitingFor = {
+  type: "CoinFlipKeepChoice",
+  data: {
+    player: 0,
+    results: [true, false, true],
+    keep_count: 2,
+  },
+};
+
+// Shape confirmed against phase-rs client/src/adapter/types.ts
+// (LifeRedistributionModal) at v0.71.0: RedistributeLifeTotals
+// { player, options: { assignment: [PlayerId, number][] }[] }.
+const REAL_LIFE_REDISTRIBUTION: WaitingFor = {
+  type: "RedistributeLifeTotals",
+  data: {
+    player: 0,
+    options: [
+      {
+        assignment: [
+          [0, 20],
+          [1, 30],
+        ],
+      },
+      {
+        assignment: [
+          [0, 30],
+          [1, 20],
+        ],
+      },
+    ],
+  },
+};
+
+describe("parseCoinFlipLifePrompt", () => {
+  describe("CoinFlipKeepChoice", () => {
+    it("parses the player, results and keep count", () => {
+      const p = parseCoinFlipLifePrompt(REAL_COIN_FLIP)!;
+      expect(p).not.toBeNull();
+      if (p.kind !== "coinFlip") throw new Error("expected a coinFlip prompt");
+      expect(p.player).toBe(0);
+      expect(p.results).toEqual([true, false, true]);
+      expect(p.keepCount).toBe(2);
+    });
+
+    it("returns null when results is empty", () => {
+      const wf: WaitingFor = {
+        type: "CoinFlipKeepChoice",
+        data: { player: 0, results: [], keep_count: 0 },
+      };
+      expect(parseCoinFlipLifePrompt(wf)).toBeNull();
+    });
+  });
+
+  describe("RedistributeLifeTotals", () => {
+    it("parses each option's per-seat life assignment", () => {
+      const p = parseCoinFlipLifePrompt(REAL_LIFE_REDISTRIBUTION)!;
+      expect(p).not.toBeNull();
+      if (p.kind !== "life") throw new Error("expected a life prompt");
+      expect(p.player).toBe(0);
+      expect(p.options).toEqual([
+        [
+          { seat: 0, life: 20 },
+          { seat: 1, life: 30 },
+        ],
+        [
+          { seat: 0, life: 30 },
+          { seat: 1, life: 20 },
+        ],
+      ]);
+    });
+
+    it("returns null when options is empty", () => {
+      const wf: WaitingFor = {
+        type: "RedistributeLifeTotals",
+        data: { player: 0, options: [] },
+      };
+      expect(parseCoinFlipLifePrompt(wf)).toBeNull();
+    });
+  });
+
+  it("returns null for a non-matching waiting_for", () => {
+    expect(parseCoinFlipLifePrompt(undefined)).toBeNull();
+    expect(parseCoinFlipLifePrompt({ type: "Priority", data: {} })).toBeNull();
+  });
+});
+
+describe("selectCoinFlipsAction", () => {
+  it("builds the SelectCoinFlips action", () => {
+    expect(selectCoinFlipsAction([0, 2])).toEqual({
+      type: "SelectCoinFlips",
+      data: { keep_indices: [0, 2] },
+    });
+  });
+});
+
+describe("submitLifeRedistributionAction", () => {
+  it("builds the SubmitLifeRedistribution action", () => {
+    expect(submitLifeRedistributionAction(1)).toEqual({
+      type: "SubmitLifeRedistribution",
+      data: { option_index: 1 },
+    });
+  });
+});

--- a/src/sim/decisions/coinFlipAndLife.ts
+++ b/src/sim/decisions/coinFlipAndLife.ts
@@ -1,0 +1,101 @@
+// Keeping coin-flip results, and redistributing life totals. The engine
+// surfaces two waiting_for shapes:
+// - `CoinFlipKeepChoice` { player, results: boolean[], keep_count } — a set
+//   of coin flips already made (`results[i]` true = heads, false = tails);
+//   keep exactly `keep_count` of them. Answered with `SelectCoinFlips
+//   { keep_indices }`, the indices (into `results`) to keep.
+// - `RedistributeLifeTotals` { player, options: { assignment: [PlayerId,
+//   number][] }[] } — each option is one full permutation of life totals
+//   across seats; pick one. Answered with `SubmitLifeRedistribution
+//   { option_index }`.
+// Shapes confirmed against phase-rs client/src/adapter/types.ts
+// (CoinFlipKeepModal, LifeRedistributionModal) at v0.71.0.
+
+import type { WaitingFor } from "../../engine/types";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export interface CoinFlipPrompt {
+  kind: "coinFlip";
+  player: number;
+  results: boolean[];
+  keepCount: number;
+}
+
+/** One seat's life total under a life-redistribution option. */
+export interface LifeAssignment {
+  seat: number;
+  life: number;
+}
+
+export interface LifeRedistributionPrompt {
+  kind: "life";
+  player: number;
+  options: LifeAssignment[][];
+}
+
+export type CoinFlipLifePrompt = CoinFlipPrompt | LifeRedistributionPrompt;
+
+function parseCoinFlipKeepChoice(d: any): CoinFlipPrompt | null {
+  const results = Array.isArray(d.results) ? d.results : [];
+  if (results.length === 0) return null;
+  return {
+    kind: "coinFlip",
+    player: typeof d.player === "number" ? d.player : 0,
+    results: results.map((r: unknown) => !!r),
+    keepCount: typeof d.keep_count === "number" ? d.keep_count : 0,
+  };
+}
+
+function parseRedistributeLifeTotals(d: any): LifeRedistributionPrompt | null {
+  const options = Array.isArray(d.options) ? d.options : [];
+  if (options.length === 0) return null;
+  return {
+    kind: "life",
+    player: typeof d.player === "number" ? d.player : 0,
+    options: options.map((option: any) => {
+      const assignment = Array.isArray(option?.assignment)
+        ? option.assignment
+        : [];
+      return assignment.map(([seat, life]: [number, number]) => ({
+        seat,
+        life,
+      }));
+    }),
+  };
+}
+
+/** Read a coin-flip-keep or life-redistribution decision aimed at the human, or null. */
+export function parseCoinFlipLifePrompt(
+  wf: WaitingFor | undefined,
+): CoinFlipLifePrompt | null {
+  if (!wf) return null;
+  const d: any = wf.data ?? {};
+  switch (wf.type) {
+    case "CoinFlipKeepChoice":
+      return parseCoinFlipKeepChoice(d);
+    case "RedistributeLifeTotals":
+      return parseRedistributeLifeTotals(d);
+    default:
+      return null;
+  }
+}
+
+/** Submit the indices (into `results`) of the coin flips to keep. */
+export function selectCoinFlipsAction(keepIndices: number[]): {
+  type: string;
+  data: { keep_indices: number[] };
+} {
+  return { type: "SelectCoinFlips", data: { keep_indices: keepIndices } };
+}
+
+/** Submit the chosen life-redistribution option by its index. */
+export function submitLifeRedistributionAction(optionIndex: number): {
+  type: string;
+  data: { option_index: number };
+} {
+  return {
+    type: "SubmitLifeRedistribution",
+    data: { option_index: optionIndex },
+  };
+}

--- a/src/sim/driver.ts
+++ b/src/sim/driver.ts
@@ -57,6 +57,10 @@ import {
   parsePhyrexianPaymentPrompt,
   type PhyrexianPaymentPrompt,
 } from "./decisions/phyrexianPayment";
+import {
+  parseCoinFlipLifePrompt,
+  type CoinFlipLifePrompt,
+} from "./decisions/coinFlipAndLife";
 
 export interface MatchResult {
   matchIndex: number;
@@ -308,6 +312,11 @@ export interface DriverCallbacks {
   requestHumanPhyrexianPayment?: (
     env: GameStateEnvelope,
     prompt: PhyrexianPaymentPrompt,
+  ) => Promise<HumanChoice>;
+  /** Called when the human keeps coin-flip results, or picks a life-redistribution option. */
+  requestHumanCoinFlipLife?: (
+    env: GameStateEnvelope,
+    prompt: CoinFlipLifePrompt,
   ) => Promise<HumanChoice>;
 }
 
@@ -650,6 +659,12 @@ export class MatchRunner {
           env,
           cb.requestHumanPhyrexianPayment,
           parsePhyrexianPaymentPrompt(wf, state.objects),
+        ),
+      () =>
+        humanRequest(
+          env,
+          cb.requestHumanCoinFlipLife,
+          parseCoinFlipLifePrompt(wf),
         ),
     ];
     for (const resolve of resolvers) {


### PR DESCRIPTION
Wires two more manual-play decisions per the recipe in #44/#55's PRs, following the same pattern.

- `CoinFlipKeepChoice` — the seat toggles which coin-flip results to keep, capped at `keep_count`, then submits `SelectCoinFlips { keep_indices }`.
- `RedistributeLifeTotals` — the seat picks one of the offered life-redistribution options, submitting `SubmitLifeRedistribution { option_index }`.

Both fall back to "let the AI decide" like every other manual decision.

Shapes confirmed against the phase-rs v0.71.0 reference client (CoinFlipKeepModal, LifeRedistributionModal) but not yet round-tripped against a live effect (noted as an Open Question in the feature doc).

Closes #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)