### PR TITLE
feat(sim): let the human choose equip/crew/saddle/station targets

### DIFF
--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,6 +12,14 @@ depth live there. A purely-internal PR that touches no product or architecture m
 skip its version with a `Skip-Docs: <reason>` trailer instead. There are no
 per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
+## [0.15.0] - 2026-09-05
+
+### Added
+
+- You now choose the target creature when **equipping, stationing, crewing,
+  or saddling**, instead of the AI deciding
+  (`domains/simulation/features/choose-equip-crew-saddle-station-target.md`).
+
 ## [0.14.0] - 2026-09-05
 
 ### Added

--- a/domainbook/domains/simulation/features/choose-equip-crew-saddle-station-target.md
+++ b/domainbook/domains/simulation/features/choose-equip-crew-saddle-station-target.md
@@ -1,0 +1,73 @@
+---
+id: choose-equip-crew-saddle-station-target
+name: Choose the equip, crew, saddle, and station target
+status: implemented
+---
+
+## Story
+
+As a player piloting my seat
+I want to pick which creature gets equipped, stations a Spacecraft, or
+crews/saddles a Vehicle/Mount
+So that those attachments and activations are mine to choose, not the AI's
+
+## Rule: Equipping and stationing pick a single creature
+
+When the engine asks the human to resolve an `EquipTarget` or `StationTarget`
+`decision request` — offered when an Equipment or Fortification attaches, or
+a Spacecraft's station ability needs a creature — the control panel lists
+every legal creature and submits the choice as soon as one is clicked. Other
+seats still resolve these by `AI action proposal`, and any non-matching state
+is untouched.
+
+```gherkin
+Example: Equipping my own creature
+  Given a play-mode match where I control seat 0
+  And Bonesplitter offers Grizzly Bears and Runeclaw Bear as valid targets
+  When I click Grizzly Bears
+  Then the engine receives Equip with Bonesplitter's id and Grizzly Bears' id
+```
+
+## Rule: Crewing and saddling pick creatures until the power threshold is met
+
+A `CrewVehicle` or `SaddleMount` decision offers a pool of eligible
+creatures and a power threshold (`crew_power` / `saddle_power`). The panel
+shows a running total of the selected creatures' power against that
+threshold and toggles creatures on and off; Confirm stays disabled until the
+selected total meets or exceeds the threshold, then submits the chosen
+creature ids.
+
+A creature's power toward the threshold is its `contributions[i]` value
+(index-aligned to `eligible_creatures`) when the engine provides one —
+letting an effect that only counts toward crewing/saddling, such as a
+temporary boost, differ from the creature's board power — and otherwise its
+own power.
+
+```gherkin
+Example: Crewing a Vehicle with two creatures
+  Given a crew prompt asking for 3 power, where Elite Vanguard and Loyal Pegasus each contribute 2 power to this crew
+  When I select both creatures
+  Then the selected power reads 4 of 3 and Confirm is enabled
+  And confirming sends CrewVehicle with both creature ids
+```
+
+## Rule: The choice can be handed to the AI
+
+Choosing let the AI decide hands the whole equip, station, crew, or saddle
+choice back to the engine's own AI, so the decision is never stuck
+(`simulation/ADR-0001`).
+
+```gherkin
+Example: Letting the AI decide
+  Given an equip, station, crew, or saddle prompt is shown
+  When I choose let the AI decide
+  Then the engine's AI makes that choice
+```
+
+## Open Questions
+
+- The `EquipTarget`, `StationTarget`, `CrewVehicle` and `SaddleMount` shapes,
+  and the `Equip` / `ActivateStation` / `CrewVehicle` / `SaddleMount`
+  submissions, were confirmed against phase-rs's vendored WASM and reference
+  client `gameStateView` at v0.71.0, but not yet round-tripped against a live
+  equip, station, crew, or saddle effect.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -454,6 +454,30 @@ export const messages = {
   "coinFlipLife.seat": { pt: "Assento {n}", en: "Seat {n}" },
   "coinFlipLife.letAi": { pt: "IA decide", en: "Let the AI decide" },
 
+  "equipCrew.sourceFallback": { pt: "isto", en: "this" },
+  "equipCrew.equipTitle": { pt: "Equipar {name}", en: "Equip {name}" },
+  "equipCrew.stationTitle": { pt: "Guarnecer {name}", en: "Station {name}" },
+  "equipCrew.crewTitle": { pt: "Tripular {name}", en: "Crew {name}" },
+  "equipCrew.saddleTitle": { pt: "Selar {name}", en: "Saddle {name}" },
+  "equipCrew.creaturePt": {
+    pt: "{name} ({power}/{toughness})",
+    en: "{name} ({power}/{toughness})",
+  },
+  "equipCrew.powerRequired": {
+    pt: "Poder necessário: {n}",
+    en: "Power required: {n}",
+  },
+  "equipCrew.powerProgress": {
+    pt: "Poder selecionado: {sum} / {n}",
+    en: "Power selected: {sum} / {n}",
+  },
+  "equipCrew.creaturePower": {
+    pt: "{name} (poder {power})",
+    en: "{name} (power {power})",
+  },
+  "equipCrew.confirm": { pt: "Confirmar", en: "Confirm" },
+  "equipCrew.letAi": { pt: "IA decide", en: "Let the AI decide" },
+
   "modes.title": { pt: "Escolher modo", en: "Choose a mode" },
   "modes.source": {
     pt: "{name} pede uma escolha de modo.",

--- a/src/match/RunView.tsx
+++ b/src/match/RunView.tsx
@@ -81,6 +81,13 @@ import {
   submitLifeRedistributionAction,
   type CoinFlipLifePrompt,
 } from "../sim/decisions/coinFlipAndLife";
+import {
+  equipAction,
+  activateStationAction,
+  crewVehicleAction,
+  saddleMountAction,
+  type EquipCrewPrompt,
+} from "../sim/decisions/equipCrew";
 import { XpWindow } from "../components/XpWindow";
 import {
   declareAttackersAction,
@@ -739,6 +746,125 @@ function CoinFlipLifePanel({
   );
 }
 
+interface EquipCrewTurn {
+  prompt: EquipCrewPrompt;
+  resolve: (choice: HumanChoice) => void;
+}
+
+function equipCrewCreatureLabel(
+  creature: { name: string; power?: number | null; toughness?: number | null },
+  t: (key: MsgKey, vars?: Vars) => string,
+): string {
+  if (creature.power != null && creature.toughness != null) {
+    return t("equipCrew.creaturePt", {
+      name: creature.name,
+      power: creature.power,
+      toughness: creature.toughness,
+    });
+  }
+  return creature.name;
+}
+
+function EquipCrewPanel({
+  turn,
+  pick,
+  onTogglePick,
+  onConfirm,
+  onLetAi,
+}: {
+  turn: EquipCrewTurn;
+  pick: Set<number>;
+  onTogglePick: (id: number) => void;
+  onConfirm: () => void;
+  onLetAi: () => void;
+}) {
+  const { t } = useI18n();
+  const { prompt, resolve } = turn;
+  const sourceName = prompt.sourceName || t("equipCrew.sourceFallback");
+
+  if (prompt.kind === "equip" || prompt.kind === "station") {
+    const titleKey =
+      prompt.kind === "equip"
+        ? "equipCrew.equipTitle"
+        : "equipCrew.stationTitle";
+    return (
+      <>
+        <div className="control-title">
+          <strong>{t(titleKey, { name: sourceName })}</strong>
+        </div>
+        <div className="search-list">
+          {prompt.creatures.map((creature) => (
+            <button
+              key={creature.id}
+              className="btn"
+              onClick={() =>
+                resolve({
+                  action:
+                    prompt.kind === "equip"
+                      ? equipAction(prompt.sourceId, creature.id)
+                      : activateStationAction(prompt.sourceId, creature.id),
+                })
+              }
+            >
+              {equipCrewCreatureLabel(creature, t)}
+            </button>
+          ))}
+        </div>
+        <div className="import__row">
+          <button className="btn btn--ghost" onClick={onLetAi}>
+            {t("equipCrew.letAi")}
+          </button>
+        </div>
+      </>
+    );
+  }
+
+  const titleKey =
+    prompt.kind === "crew" ? "equipCrew.crewTitle" : "equipCrew.saddleTitle";
+  const power = prompt.creatures
+    .filter((c) => pick.has(c.id))
+    .reduce((sum, c) => sum + c.power, 0);
+  const met = power >= prompt.threshold;
+  return (
+    <>
+      <div className="control-title">
+        <strong>{t(titleKey, { name: sourceName })}</strong>
+      </div>
+      <p className="hint">
+        {t("equipCrew.powerRequired", { n: prompt.threshold })}
+      </p>
+      <p className="hint">
+        {t("equipCrew.powerProgress", { sum: power, n: prompt.threshold })}
+      </p>
+      <div className="search-list">
+        {prompt.creatures.map((creature) => {
+          const picked = pick.has(creature.id);
+          return (
+            <button
+              key={creature.id}
+              className={picked ? "btn" : "btn--ghost"}
+              onClick={() => onTogglePick(creature.id)}
+            >
+              {t("equipCrew.creaturePower", {
+                name: creature.name,
+                power: creature.power,
+              })}
+            </button>
+          );
+        })}
+      </div>
+      <div className="import__row">
+        <button className="btn" disabled={!met} onClick={onConfirm}>
+          {t("equipCrew.confirm")}
+        </button>
+        <button className="btn btn--ghost" onClick={onLetAi}>
+          {t("equipCrew.letAi")}
+        </button>
+      </div>
+    </>
+  );
+}
+
 function isTargetOptional(
   targeting: TargetTurn | null,
   chosen: TargetRef[],
@@ -886,6 +1012,8 @@ interface RunnerCallbackDeps {
   setPhyrexianTurn: Dispatch<SetStateAction<PhyrexianTurn | null>>;
   setCoinFlipLifePick: Dispatch<SetStateAction<Set<number>>>;
   setCoinFlipLifeTurn: Dispatch<SetStateAction<CoinFlipLifeTurn | null>>;
+  setEquipCrewPick: Dispatch<SetStateAction<Set<number>>>;
+  setEquipCrewTurn: Dispatch<SetStateAction<EquipCrewTurn | null>>;
 }
 
 function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
@@ -933,6 +1061,8 @@ function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
     setPhyrexianTurn,
     setCoinFlipLifePick,
     setCoinFlipLifeTurn,
+    setEquipCrewPick,
+    setEquipCrewTurn,
   } = deps;
   return {
     onFrame: (env) => {
@@ -1277,6 +1407,22 @@ function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
           },
         });
       }),
+    requestHumanEquipCrew: (_env, prompt) =>
+      new Promise<HumanChoice>((resolve) => {
+        if (isCancelled()) {
+          resolve({ ai: true });
+          return;
+        }
+        setEquipCrewPick(new Set());
+        setEquipCrewTurn({
+          prompt,
+          resolve: (choice) => {
+            setEquipCrewTurn(null);
+            setEquipCrewPick(new Set());
+            resolve(choice);
+          },
+        });
+      }),
   };
 }
 
@@ -1395,6 +1541,10 @@ export function RunView({
   const [coinFlipLifePick, setCoinFlipLifePick] = useState<Set<number>>(
     new Set(),
   );
+  const [equipCrewTurn, setEquipCrewTurn] = useState<EquipCrewTurn | null>(
+    null,
+  );
+  const [equipCrewPick, setEquipCrewPick] = useState<Set<number>>(new Set());
   const [passingTurn, setPassingTurn] = useState(false);
   const [logEntries, setLogEntries] = useState<LoggedEntry[]>([]);
   // On mobile the log is a full-screen drawer, so it always starts closed and
@@ -1506,6 +1656,8 @@ export function RunView({
             setPhyrexianTurn,
             setCoinFlipLifePick,
             setCoinFlipLifeTurn,
+            setEquipCrewPick,
+            setEquipCrewTurn,
           }),
         );
         runnerRef.current = runner;
@@ -1642,7 +1794,8 @@ export function RunView({
         digTurn ||
         exploreRevealTurn ||
         phyrexianTurn ||
-        coinFlipLifeTurn)
+        coinFlipLifeTurn ||
+        equipCrewTurn)
     ) {
       setPassingTurn(false);
     }
@@ -1664,6 +1817,7 @@ export function RunView({
     exploreRevealTurn,
     phyrexianTurn,
     coinFlipLifeTurn,
+    equipCrewTurn,
   ]);
 
   // Map draggable hand cards to their play actions for the current window.
@@ -2737,6 +2891,34 @@ export function RunView({
                 })
               }
               onLetAi={() => coinFlipLifeTurn.resolve({ ai: true })}
+            />
+          )}
+
+          {equipCrewTurn && (
+            <EquipCrewPanel
+              turn={equipCrewTurn}
+              pick={equipCrewPick}
+              onTogglePick={(id) =>
+                setEquipCrewPick((prev) => {
+                  const next = new Set(prev);
+                  if (next.has(id)) next.delete(id);
+                  else next.add(id);
+                  return next;
+                })
+              }
+              onConfirm={() =>
+                equipCrewTurn.resolve({
+                  action:
+                    equipCrewTurn.prompt.kind === "crew"
+                      ? crewVehicleAction(equipCrewTurn.prompt.sourceId, [
+                          ...equipCrewPick,
+                        ])
+                      : saddleMountAction(equipCrewTurn.prompt.sourceId, [
+                          ...equipCrewPick,
+                        ]),
+                })
+              }
+              onLetAi={() => equipCrewTurn.resolve({ ai: true })}
             />
           )}
         </section>

--- a/src/sim/decisions/equipCrew.test.ts
+++ b/src/sim/decisions/equipCrew.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseEquipCrewPrompt,
+  equipAction,
+  activateStationAction,
+  crewVehicleAction,
+  saddleMountAction,
+} from "./equipCrew";
+import type { GameObject, WaitingFor } from "../../engine/types";
+
+const OBJECTS: Record<string, GameObject> = {
+  1: { id: 1, name: "Bonesplitter", zone: "Battlefield" },
+  2: {
+    id: 2,
+    name: "Grizzly Bears",
+    zone: "Battlefield",
+    power: 2,
+    toughness: 2,
+  },
+  3: {
+    id: 3,
+    name: "Runeclaw Bear",
+    zone: "Battlefield",
+    power: 2,
+    toughness: 2,
+  },
+  4: { id: 4, name: "Skysovereign, Consul Flagship", zone: "Battlefield" },
+  5: { id: 5, name: "Smuggler's Copter", zone: "Battlefield" },
+  6: {
+    id: 6,
+    name: "Elite Vanguard",
+    zone: "Battlefield",
+    power: 1,
+    toughness: 1,
+  },
+  7: {
+    id: 7,
+    name: "Loyal Pegasus",
+    zone: "Battlefield",
+    power: 1,
+    toughness: 1,
+  },
+  8: { id: 8, name: "Winged Temple of Orazca", zone: "Battlefield" },
+};
+
+// Shape confirmed against phase-rs client/src/adapter/types.ts
+// (EquipTargetModal) at v0.71.0: EquipTarget { player, equipment_id, valid_targets }.
+const REAL_EQUIP: WaitingFor = {
+  type: "EquipTarget",
+  data: { player: 0, equipment_id: 1, valid_targets: [2, 3] },
+};
+
+// Shape confirmed against phase-rs client/src/adapter/types.ts
+// (StationTargetModal) at v0.71.0: StationTarget { player, spacecraft_id,
+// eligible_creatures }.
+const REAL_STATION: WaitingFor = {
+  type: "StationTarget",
+  data: { player: 0, spacecraft_id: 4, eligible_creatures: [2, 3] },
+};
+
+// Shape confirmed against phase-rs client/src/adapter/types.ts
+// (CrewVehicleModal) at v0.71.0: CrewVehicle { player, vehicle_id,
+// crew_power, eligible_creatures, contributions? }. Here `contributions`
+// differs from the creatures' raw power (e.g. an anthem or Menace-style
+// crew bonus applies only while crewing).
+const REAL_CREW_WITH_CONTRIBUTIONS: WaitingFor = {
+  type: "CrewVehicle",
+  data: {
+    player: 0,
+    vehicle_id: 5,
+    crew_power: 3,
+    eligible_creatures: [6, 7],
+    contributions: [2, 4],
+  },
+};
+
+const REAL_CREW_WITHOUT_CONTRIBUTIONS: WaitingFor = {
+  type: "CrewVehicle",
+  data: {
+    player: 0,
+    vehicle_id: 5,
+    crew_power: 2,
+    eligible_creatures: [6, 7],
+  },
+};
+
+// Shape confirmed against phase-rs client/src/adapter/types.ts
+// (SaddleMountModal) at v0.71.0: SaddleMount { player, mount_id,
+// saddle_power, eligible_creatures, contributions? }.
+const REAL_SADDLE: WaitingFor = {
+  type: "SaddleMount",
+  data: {
+    player: 0,
+    mount_id: 8,
+    saddle_power: 3,
+    eligible_creatures: [6, 7],
+  },
+};
+
+describe("parseEquipCrewPrompt", () => {
+  describe("EquipTarget", () => {
+    it("parses the equipment, source name and creature targets", () => {
+      const p = parseEquipCrewPrompt(REAL_EQUIP, OBJECTS);
+      expect(p).not.toBeNull();
+      if (p?.kind !== "equip") throw new Error("expected an equip prompt");
+      expect(p.player).toBe(0);
+      expect(p.sourceId).toBe(1);
+      expect(p.sourceName).toBe("Bonesplitter");
+      expect(p.creatures).toEqual([
+        { id: 2, name: "Grizzly Bears", power: 2, toughness: 2 },
+        { id: 3, name: "Runeclaw Bear", power: 2, toughness: 2 },
+      ]);
+    });
+
+    it("returns null when valid_targets is empty", () => {
+      const wf: WaitingFor = {
+        type: "EquipTarget",
+        data: { player: 0, equipment_id: 1, valid_targets: [] },
+      };
+      expect(parseEquipCrewPrompt(wf, OBJECTS)).toBeNull();
+    });
+  });
+
+  describe("StationTarget", () => {
+    it("parses the spacecraft, source name and eligible creatures", () => {
+      const p = parseEquipCrewPrompt(REAL_STATION, OBJECTS);
+      expect(p).not.toBeNull();
+      if (p?.kind !== "station") throw new Error("expected a station prompt");
+      expect(p.player).toBe(0);
+      expect(p.sourceId).toBe(4);
+      expect(p.sourceName).toBe("Skysovereign, Consul Flagship");
+      expect(p.creatures).toEqual([
+        { id: 2, name: "Grizzly Bears", power: 2, toughness: 2 },
+        { id: 3, name: "Runeclaw Bear", power: 2, toughness: 2 },
+      ]);
+    });
+
+    it("returns null when eligible_creatures is empty", () => {
+      const wf: WaitingFor = {
+        type: "StationTarget",
+        data: { player: 0, spacecraft_id: 4, eligible_creatures: [] },
+      };
+      expect(parseEquipCrewPrompt(wf, OBJECTS)).toBeNull();
+    });
+  });
+
+  describe("CrewVehicle", () => {
+    it("uses contributions (index-aligned) over raw power when present", () => {
+      const p = parseEquipCrewPrompt(REAL_CREW_WITH_CONTRIBUTIONS, OBJECTS);
+      expect(p).not.toBeNull();
+      if (p?.kind !== "crew") throw new Error("expected a crew prompt");
+      expect(p.player).toBe(0);
+      expect(p.sourceId).toBe(5);
+      expect(p.sourceName).toBe("Smuggler's Copter");
+      expect(p.threshold).toBe(3);
+      expect(p.creatures).toEqual([
+        { id: 6, name: "Elite Vanguard", power: 2 },
+        { id: 7, name: "Loyal Pegasus", power: 4 },
+      ]);
+    });
+
+    it("falls back to the object's power when contributions is absent", () => {
+      const p = parseEquipCrewPrompt(REAL_CREW_WITHOUT_CONTRIBUTIONS, OBJECTS);
+      expect(p).not.toBeNull();
+      if (p?.kind !== "crew") throw new Error("expected a crew prompt");
+      expect(p.creatures).toEqual([
+        { id: 6, name: "Elite Vanguard", power: 1 },
+        { id: 7, name: "Loyal Pegasus", power: 1 },
+      ]);
+    });
+
+    it("returns null when eligible_creatures is empty", () => {
+      const wf: WaitingFor = {
+        type: "CrewVehicle",
+        data: {
+          player: 0,
+          vehicle_id: 5,
+          crew_power: 3,
+          eligible_creatures: [],
+        },
+      };
+      expect(parseEquipCrewPrompt(wf, OBJECTS)).toBeNull();
+    });
+  });
+
+  describe("SaddleMount", () => {
+    it("parses the mount, source name, threshold and creature power", () => {
+      const p = parseEquipCrewPrompt(REAL_SADDLE, OBJECTS);
+      expect(p).not.toBeNull();
+      if (p?.kind !== "saddle") throw new Error("expected a saddle prompt");
+      expect(p.player).toBe(0);
+      expect(p.sourceId).toBe(8);
+      expect(p.sourceName).toBe("Winged Temple of Orazca");
+      expect(p.threshold).toBe(3);
+      expect(p.creatures).toEqual([
+        { id: 6, name: "Elite Vanguard", power: 1 },
+        { id: 7, name: "Loyal Pegasus", power: 1 },
+      ]);
+    });
+
+    it("returns null when eligible_creatures is empty", () => {
+      const wf: WaitingFor = {
+        type: "SaddleMount",
+        data: {
+          player: 0,
+          mount_id: 8,
+          saddle_power: 3,
+          eligible_creatures: [],
+        },
+      };
+      expect(parseEquipCrewPrompt(wf, OBJECTS)).toBeNull();
+    });
+  });
+
+  it("returns null for a non-matching waiting_for", () => {
+    expect(parseEquipCrewPrompt(undefined)).toBeNull();
+    expect(parseEquipCrewPrompt({ type: "Priority", data: {} })).toBeNull();
+  });
+});
+
+describe("equipAction", () => {
+  it("builds the Equip action", () => {
+    expect(equipAction(1, 2)).toEqual({
+      type: "Equip",
+      data: { equipment_id: 1, target_id: 2 },
+    });
+  });
+});
+
+describe("activateStationAction", () => {
+  it("builds the ActivateStation action", () => {
+    expect(activateStationAction(4, 2)).toEqual({
+      type: "ActivateStation",
+      data: { spacecraft_id: 4, creature_id: 2 },
+    });
+  });
+});
+
+describe("crewVehicleAction", () => {
+  it("builds the CrewVehicle action", () => {
+    expect(crewVehicleAction(5, [6, 7])).toEqual({
+      type: "CrewVehicle",
+      data: { vehicle_id: 5, creature_ids: [6, 7] },
+    });
+  });
+});
+
+describe("saddleMountAction", () => {
+  it("builds the SaddleMount action", () => {
+    expect(saddleMountAction(8, [6, 7])).toEqual({
+      type: "SaddleMount",
+      data: { mount_id: 8, creature_ids: [6, 7] },
+    });
+  });
+});

--- a/src/sim/decisions/equipCrew.ts
+++ b/src/sim/decisions/equipCrew.ts
@@ -1,0 +1,252 @@
+// Equipping, stationing, crewing and saddling — attaching Equipment/Fortifications,
+// staffing a Spacecraft ability, or crewing a Vehicle/saddling a Mount. The engine
+// surfaces four waiting_for shapes:
+// - `EquipTarget` { player, equipment_id, valid_targets } — pick one creature
+//   from `valid_targets` to equip. Answered with `Equip { equipment_id, target_id }`.
+// - `StationTarget` { player, spacecraft_id, eligible_creatures } — pick one
+//   creature to station. Answered with `ActivateStation { spacecraft_id, creature_id }`.
+// - `CrewVehicle` { player, vehicle_id, crew_power, eligible_creatures,
+//   contributions? } — pick any number of `eligible_creatures` whose summed
+//   power meets `crew_power`. A creature's contribution is `contributions[i]`
+//   (index-aligned to `eligible_creatures`) when present, else its own power.
+//   Answered with `CrewVehicle { vehicle_id, creature_ids }`.
+// - `SaddleMount` { player, mount_id, saddle_power, eligible_creatures,
+//   contributions? } — same shape as crewing, for a Mount. Answered with
+//   `SaddleMount { mount_id, creature_ids }`.
+// Shapes confirmed against phase-rs client/src/adapter/types.ts at v0.71.0.
+
+import type { GameObject, WaitingFor } from "../../engine/types";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/** A creature offered as an equip/station target, with display-only P/T. */
+export interface EquipCrewCreature {
+  id: number;
+  name: string;
+  power?: number | null;
+  toughness?: number | null;
+}
+
+/** A creature offered to crew/saddle, with its power contribution toward the threshold. */
+export interface CrewSaddleCreature {
+  id: number;
+  name: string;
+  power: number;
+}
+
+export interface EquipPrompt {
+  kind: "equip";
+  player: number;
+  sourceId: number;
+  sourceName: string;
+  creatures: EquipCrewCreature[];
+}
+
+export interface StationPrompt {
+  kind: "station";
+  player: number;
+  sourceId: number;
+  sourceName: string;
+  creatures: EquipCrewCreature[];
+}
+
+export interface CrewPrompt {
+  kind: "crew";
+  player: number;
+  sourceId: number;
+  sourceName: string;
+  threshold: number;
+  creatures: CrewSaddleCreature[];
+}
+
+export interface SaddlePrompt {
+  kind: "saddle";
+  player: number;
+  sourceId: number;
+  sourceName: string;
+  threshold: number;
+  creatures: CrewSaddleCreature[];
+}
+
+export type EquipCrewPrompt =
+  EquipPrompt | StationPrompt | CrewPrompt | SaddlePrompt;
+
+function nameOf(id: number, objects?: Record<string, GameObject>): string {
+  return objects?.[id]?.name ?? "";
+}
+
+function toEquipCrewCreature(
+  id: number,
+  objects?: Record<string, GameObject>,
+): EquipCrewCreature {
+  const obj = objects?.[id];
+  return {
+    id,
+    name: obj?.name ?? "",
+    power: obj?.power,
+    toughness: obj?.toughness,
+  };
+}
+
+function contributionOf(
+  id: number,
+  index: number,
+  contributions: unknown,
+  objects?: Record<string, GameObject>,
+): number {
+  if (
+    Array.isArray(contributions) &&
+    typeof contributions[index] === "number"
+  ) {
+    return contributions[index];
+  }
+  return objects?.[id]?.power ?? 0;
+}
+
+function parseEquipTarget(
+  d: any,
+  objects?: Record<string, GameObject>,
+): EquipPrompt | null {
+  const validTargets = Array.isArray(d.valid_targets) ? d.valid_targets : [];
+  if (validTargets.length === 0) return null;
+  const equipmentId = typeof d.equipment_id === "number" ? d.equipment_id : 0;
+  return {
+    kind: "equip",
+    player: typeof d.player === "number" ? d.player : 0,
+    sourceId: equipmentId,
+    sourceName: nameOf(equipmentId, objects),
+    creatures: validTargets.map((id: number) =>
+      toEquipCrewCreature(id, objects),
+    ),
+  };
+}
+
+function parseStationTarget(
+  d: any,
+  objects?: Record<string, GameObject>,
+): StationPrompt | null {
+  const eligible = Array.isArray(d.eligible_creatures)
+    ? d.eligible_creatures
+    : [];
+  if (eligible.length === 0) return null;
+  const spacecraftId =
+    typeof d.spacecraft_id === "number" ? d.spacecraft_id : 0;
+  return {
+    kind: "station",
+    player: typeof d.player === "number" ? d.player : 0,
+    sourceId: spacecraftId,
+    sourceName: nameOf(spacecraftId, objects),
+    creatures: eligible.map((id: number) => toEquipCrewCreature(id, objects)),
+  };
+}
+
+function parseCrewVehicle(
+  d: any,
+  objects?: Record<string, GameObject>,
+): CrewPrompt | null {
+  const eligible = Array.isArray(d.eligible_creatures)
+    ? d.eligible_creatures
+    : [];
+  if (eligible.length === 0) return null;
+  const vehicleId = typeof d.vehicle_id === "number" ? d.vehicle_id : 0;
+  return {
+    kind: "crew",
+    player: typeof d.player === "number" ? d.player : 0,
+    sourceId: vehicleId,
+    sourceName: nameOf(vehicleId, objects),
+    threshold: typeof d.crew_power === "number" ? d.crew_power : 0,
+    creatures: eligible.map((id: number, i: number) => ({
+      id,
+      name: nameOf(id, objects),
+      power: contributionOf(id, i, d.contributions, objects),
+    })),
+  };
+}
+
+function parseSaddleMount(
+  d: any,
+  objects?: Record<string, GameObject>,
+): SaddlePrompt | null {
+  const eligible = Array.isArray(d.eligible_creatures)
+    ? d.eligible_creatures
+    : [];
+  if (eligible.length === 0) return null;
+  const mountId = typeof d.mount_id === "number" ? d.mount_id : 0;
+  return {
+    kind: "saddle",
+    player: typeof d.player === "number" ? d.player : 0,
+    sourceId: mountId,
+    sourceName: nameOf(mountId, objects),
+    threshold: typeof d.saddle_power === "number" ? d.saddle_power : 0,
+    creatures: eligible.map((id: number, i: number) => ({
+      id,
+      name: nameOf(id, objects),
+      power: contributionOf(id, i, d.contributions, objects),
+    })),
+  };
+}
+
+/** Read an equip/station/crew/saddle decision aimed at the human, or null. */
+export function parseEquipCrewPrompt(
+  wf: WaitingFor | undefined,
+  objects?: Record<string, GameObject>,
+): EquipCrewPrompt | null {
+  if (!wf) return null;
+  const d: any = wf.data ?? {};
+  switch (wf.type) {
+    case "EquipTarget":
+      return parseEquipTarget(d, objects);
+    case "StationTarget":
+      return parseStationTarget(d, objects);
+    case "CrewVehicle":
+      return parseCrewVehicle(d, objects);
+    case "SaddleMount":
+      return parseSaddleMount(d, objects);
+    default:
+      return null;
+  }
+}
+
+/** Submit the creature to equip a piece of Equipment onto. */
+export function equipAction(
+  equipmentId: number,
+  targetId: number,
+): { type: string; data: { equipment_id: number; target_id: number } } {
+  return {
+    type: "Equip",
+    data: { equipment_id: equipmentId, target_id: targetId },
+  };
+}
+
+/** Submit the creature to station at a Spacecraft ability. */
+export function activateStationAction(
+  spacecraftId: number,
+  creatureId: number,
+): { type: string; data: { spacecraft_id: number; creature_id: number } } {
+  return {
+    type: "ActivateStation",
+    data: { spacecraft_id: spacecraftId, creature_id: creatureId },
+  };
+}
+
+/** Submit the creatures crewing a Vehicle. */
+export function crewVehicleAction(
+  vehicleId: number,
+  creatureIds: number[],
+): { type: string; data: { vehicle_id: number; creature_ids: number[] } } {
+  return {
+    type: "CrewVehicle",
+    data: { vehicle_id: vehicleId, creature_ids: creatureIds },
+  };
+}
+
+/** Submit the creatures saddling a Mount. */
+export function saddleMountAction(
+  mountId: number,
+  creatureIds: number[],
+): { type: string; data: { mount_id: number; creature_ids: number[] } } {
+  return {
+    type: "SaddleMount",
+    data: { mount_id: mountId, creature_ids: creatureIds },
+  };
+}

--- a/src/sim/driver.ts
+++ b/src/sim/driver.ts
@@ -61,6 +61,10 @@ import {
   parseCoinFlipLifePrompt,
   type CoinFlipLifePrompt,
 } from "./decisions/coinFlipAndLife";
+import {
+  parseEquipCrewPrompt,
+  type EquipCrewPrompt,
+} from "./decisions/equipCrew";
 
 export interface MatchResult {
   matchIndex: number;
@@ -317,6 +321,11 @@ export interface DriverCallbacks {
   requestHumanCoinFlipLife?: (
     env: GameStateEnvelope,
     prompt: CoinFlipLifePrompt,
+  ) => Promise<HumanChoice>;
+  /** Called when the human equips, stations, crews, or saddles a creature. */
+  requestHumanEquipCrew?: (
+    env: GameStateEnvelope,
+    prompt: EquipCrewPrompt,
   ) => Promise<HumanChoice>;
 }
 
@@ -665,6 +674,12 @@ export class MatchRunner {
           env,
           cb.requestHumanCoinFlipLife,
           parseCoinFlipLifePrompt(wf),
+        ),
+      () =>
+        humanRequest(
+          env,
+          cb.requestHumanEquipCrew,
+          parseEquipCrewPrompt(wf, state.objects),
         ),
     ];
     for (const resolve of resolvers) {


### PR DESCRIPTION
## Summary
- Adds the manual-play decision handler for the four attach/activate-with-power decisions: `EquipTarget`, `StationTarget`, `CrewVehicle`, `SaddleMount`.
- Equip/Station: single-pick, submits immediately on click.
- Crew/Saddle: multi-select toggle list with a running power total against the threshold; Confirm disabled until met. A creature's power contribution uses `contributions[i]` (index-aligned) when the engine provides it, else its own board power.
- Wired through `src/sim/driver.ts` (`requestHumanEquipCrew`), `src/match/RunView.tsx` (turn state + `EquipCrewPanel`), and `src/i18n/messages.ts` (pt/en).
- domainbook feature doc + changelog entry (0.15.0) + package.json bump.

## Judgment calls
- Added optional `power`/`toughness` display fields to the equip/station creature shape (not in the strict decision→action mapping) so the UI can show P/T next to each creature's name, per the UX priority in the brief; this doesn't change the submitted actions.
- Added an `equipCrew.sourceFallback` i18n key, matching the existing fallback-name pattern used by other decision panels (optionalCost, commanderZone, xValue, exploreReveal, phyrexian) for when the source object's name is empty.

## Gates (all green)
```
npm run lint && npm run typecheck && npm run duplication && npm test && npm run build
npx domainbook check --range main..HEAD   # nothing stale
npx domainbook validate                   # valid
```

Closes #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)