### PR TITLE
feat(sim): let the human pay ward and unless costs

### DIFF
--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,6 +12,15 @@ depth live there. A purely-internal PR that touches no product or architecture m
 skip its version with a `Skip-Docs: <reason>` trailer instead. There are no
 per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
+## [0.16.0] - 2026-09-05
+
+### Added
+
+- You now choose how to pay **Ward and "unless" costs** — which card to
+  discard, which permanent to sacrifice or return to hand, and which of
+  several alternative costs to pay — instead of the AI deciding
+  (`domains/simulation/features/pay-ward-and-unless-costs.md`).
+
 ## [0.15.0] - 2026-09-05
 
 ### Added

--- a/domainbook/domains/simulation/features/pay-ward-and-unless-costs.md
+++ b/domainbook/domains/simulation/features/pay-ward-and-unless-costs.md
@@ -1,0 +1,87 @@
+---
+id: pay-ward-and-unless-costs
+name: Pay Ward and unless costs
+status: implemented
+---
+
+## Story
+
+As a player piloting my seat
+I want to choose which card, permanent, or cost to give up when a Ward
+triggers or a spell offers me a way out with "unless"
+So that those trade-offs are mine to make, not the AI's
+
+## Rule: Ward discard and unless bounce pick a single card or permanent
+
+When the engine asks the human to resolve a `WardDiscardChoice` or
+`UnlessBounceChoice` decision request — a Ward that costs a discard, or a
+spell that lets its controller keep a permanent by returning it to hand —
+the control panel lists every offered card or permanent and submits the
+choice as soon as one is clicked. Other seats still resolve these by AI
+action proposal, and any non-matching state is untouched.
+
+```gherkin
+Example: Paying a Ward by discarding
+  Given a Ward discard prompt offers Cancel and Lightning Bolt from my hand
+  When I click Lightning Bolt
+  Then the engine receives SelectCards with Lightning Bolt's id
+```
+
+## Rule: Ward sacrifice picks one permanent, or several until a power threshold is met
+
+A `WardSacrificeChoice` decision either asks for a single permanent
+(`min_total_power` is absent or null) or, when a `min_total_power` is set,
+lets the player toggle any number of the offered permanents until their
+summed power meets or exceeds that threshold. The single-pick case behaves
+like Ward discard and unless bounce — one click submits the choice; the
+threshold case shows a running power total and disables Confirm until it is
+met.
+
+```gherkin
+Example: Sacrificing to meet a power threshold
+  Given a Ward sacrifice prompt asks for 4 power, offering two 2-power creatures
+  When I select both creatures
+  Then the selected power reads 4 of 4 and Confirm is enabled
+  And confirming sends SelectCards with both permanents' ids
+```
+
+## Rule: Unless payment picks which cost to pay, or declines all of them
+
+An `UnlessPaymentChooseCost` decision offers a list of alternative costs —
+paying life, discarding a card, sacrificing permanents, returning permanents
+to hand, or paying mana — for the same "unless" effect. The panel shows one
+button per cost, labeled for its kind (and quantity, where the cost carries
+one), plus a "Don't pay" option that declines every cost and lets the
+effect resolve unpaid.
+
+```gherkin
+Example: Choosing which unless cost to pay
+  Given an unless prompt offers "Pay 5 life" and "Discard a card"
+  When I click "Discard a card"
+  Then the engine receives ChooseUnlessCostBranch with a Pay choice at that cost's index
+
+Example: Declining every unless cost
+  Given an unless prompt is shown
+  When I click "Don't pay"
+  Then the engine receives ChooseUnlessCostBranch with a Decline choice
+```
+
+## Rule: The choice can be handed to the AI
+
+Choosing let the AI decide hands the whole Ward or unless choice back to the
+engine's own AI, so the decision is never stuck (`simulation/ADR-0001`).
+
+```gherkin
+Example: Letting the AI decide
+  Given a Ward or unless prompt is shown
+  When I choose let the AI decide
+  Then the engine's AI makes that choice
+```
+
+## Open Questions
+
+- The `WardDiscardChoice`, `WardSacrificeChoice`, `UnlessBounceChoice`, and
+  `UnlessPaymentChooseCost` shapes, and the `SelectCards` /
+  `ChooseUnlessCostBranch` submissions, were confirmed against phase-rs's
+  vendored WASM and reference client `gameStateView` at v0.71.0, but not yet
+  round-tripped against a live Ward or "unless" effect.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -478,6 +478,55 @@ export const messages = {
   "equipCrew.confirm": { pt: "Confirmar", en: "Confirm" },
   "equipCrew.letAi": { pt: "IA decide", en: "Let the AI decide" },
 
+  "wardUnless.discardTitle": {
+    pt: "Escolha uma carta para descartar",
+    en: "Choose a card to discard",
+  },
+  "wardUnless.bounceTitle": {
+    pt: "Escolha um permanente para devolver à mão",
+    en: "Choose a permanent to return to hand",
+  },
+  "wardUnless.sacrificeTitle": {
+    pt: "Escolha um permanente para sacrificar",
+    en: "Choose a permanent to sacrifice",
+  },
+  "wardUnless.powerRequired": {
+    pt: "Poder necessário: {n}",
+    en: "Power required: {n}",
+  },
+  "wardUnless.powerProgress": {
+    pt: "Poder selecionado: {sum} / {n}",
+    en: "Power selected: {sum} / {n}",
+  },
+  "wardUnless.confirm": { pt: "Confirmar", en: "Confirm" },
+  "wardUnless.costTitle": {
+    pt: "Escolha como pagar",
+    en: "Choose how to pay",
+  },
+  "wardUnless.costFixed": { pt: "Pagar custo de mana", en: "Pay mana cost" },
+  "wardUnless.costGeneric": {
+    pt: "Pagar mana genérica",
+    en: "Pay generic mana",
+  },
+  "wardUnless.costPayLife": {
+    pt: "Pagar {amount} de vida",
+    en: "Pay {amount} life",
+  },
+  "wardUnless.costDiscard": {
+    pt: "Descartar uma carta",
+    en: "Discard a card",
+  },
+  "wardUnless.costSacrifice": {
+    pt: "Sacrificar {count}",
+    en: "Sacrifice {count}",
+  },
+  "wardUnless.costReturnToHand": {
+    pt: "Devolver {count} à mão",
+    en: "Return {count} to hand",
+  },
+  "wardUnless.decline": { pt: "Não pagar", en: "Don't pay" },
+  "wardUnless.letAi": { pt: "IA decide", en: "Let the AI decide" },
+
   "modes.title": { pt: "Escolher modo", en: "Choose a mode" },
   "modes.source": {
     pt: "{name} pede uma escolha de modo.",

--- a/src/match/RunView.tsx
+++ b/src/match/RunView.tsx
@@ -88,6 +88,12 @@ import {
   saddleMountAction,
   type EquipCrewPrompt,
 } from "../sim/decisions/equipCrew";
+import {
+  selectWardUnlessCardsAction,
+  chooseUnlessCostBranchAction,
+  type WardUnlessPrompt,
+  type UnlessCostHint,
+} from "../sim/decisions/wardUnless";
 import { XpWindow } from "../components/XpWindow";
 import {
   declareAttackersAction,
@@ -865,6 +871,192 @@ function EquipCrewPanel({
   );
 }
 
+interface WardUnlessTurn {
+  prompt: WardUnlessPrompt;
+  resolve: (choice: HumanChoice) => void;
+}
+
+function unlessCostLabel(
+  hint: UnlessCostHint,
+  t: (key: MsgKey, vars?: Vars) => string,
+): string {
+  switch (hint.type) {
+    case "payLife":
+      return t("wardUnless.costPayLife", { amount: hint.amount });
+    case "discardCard":
+      return t("wardUnless.costDiscard");
+    case "sacrifice":
+      return t("wardUnless.costSacrifice", { count: hint.count });
+    case "returnToHand":
+      return t("wardUnless.costReturnToHand", { count: hint.count });
+    case "dynamicGeneric":
+      return t("wardUnless.costGeneric");
+    case "fixed":
+    default:
+      return t("wardUnless.costFixed");
+  }
+}
+
+function WardUnlessPanel({
+  turn,
+  pick,
+  onTogglePick,
+  onConfirm,
+  onLetAi,
+}: {
+  turn: WardUnlessTurn;
+  pick: Set<number>;
+  onTogglePick: (id: number) => void;
+  onConfirm: () => void;
+  onLetAi: () => void;
+}) {
+  const { t } = useI18n();
+  const { prompt, resolve } = turn;
+
+  if (prompt.kind === "wardDiscard") {
+    return (
+      <>
+        <div className="control-title">
+          <strong>{t("wardUnless.discardTitle")}</strong>
+        </div>
+        <div className="search-list">
+          {prompt.cards.map((card) => (
+            <button
+              key={card.id}
+              className="btn"
+              onClick={() =>
+                resolve({ action: selectWardUnlessCardsAction([card.id]) })
+              }
+            >
+              {card.name}
+            </button>
+          ))}
+        </div>
+        <div className="import__row">
+          <button className="btn btn--ghost" onClick={onLetAi}>
+            {t("wardUnless.letAi")}
+          </button>
+        </div>
+      </>
+    );
+  }
+
+  if (
+    prompt.kind === "unlessBounce" ||
+    (prompt.kind === "wardSacrifice" && prompt.minTotalPower == null)
+  ) {
+    const titleKey =
+      prompt.kind === "unlessBounce"
+        ? "wardUnless.bounceTitle"
+        : "wardUnless.sacrificeTitle";
+    return (
+      <>
+        <div className="control-title">
+          <strong>{t(titleKey)}</strong>
+        </div>
+        <div className="search-list">
+          {prompt.permanents.map((permanent) => (
+            <button
+              key={permanent.id}
+              className="btn"
+              onClick={() =>
+                resolve({
+                  action: selectWardUnlessCardsAction([permanent.id]),
+                })
+              }
+            >
+              {equipCrewCreatureLabel(permanent, t)}
+            </button>
+          ))}
+        </div>
+        <div className="import__row">
+          <button className="btn btn--ghost" onClick={onLetAi}>
+            {t("wardUnless.letAi")}
+          </button>
+        </div>
+      </>
+    );
+  }
+
+  if (prompt.kind === "wardSacrifice") {
+    const threshold = prompt.minTotalPower ?? 0;
+    const power = prompt.permanents
+      .filter((p) => pick.has(p.id))
+      .reduce((sum, p) => sum + (p.power ?? 0), 0);
+    const met = power >= threshold;
+    return (
+      <>
+        <div className="control-title">
+          <strong>{t("wardUnless.sacrificeTitle")}</strong>
+        </div>
+        <p className="hint">
+          {t("wardUnless.powerRequired", { n: threshold })}
+        </p>
+        <p className="hint">
+          {t("wardUnless.powerProgress", { sum: power, n: threshold })}
+        </p>
+        <div className="search-list">
+          {prompt.permanents.map((permanent) => {
+            const picked = pick.has(permanent.id);
+            return (
+              <button
+                key={permanent.id}
+                className={picked ? "btn" : "btn--ghost"}
+                onClick={() => onTogglePick(permanent.id)}
+              >
+                {equipCrewCreatureLabel(permanent, t)}
+              </button>
+            );
+          })}
+        </div>
+        <div className="import__row">
+          <button className="btn" disabled={!met} onClick={onConfirm}>
+            {t("wardUnless.confirm")}
+          </button>
+          <button className="btn btn--ghost" onClick={onLetAi}>
+            {t("wardUnless.letAi")}
+          </button>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div className="control-title">
+        <strong>{t("wardUnless.costTitle")}</strong>
+      </div>
+      {prompt.description && <p className="hint">{prompt.description}</p>}
+      <div className="search-list">
+        {prompt.costs.map((cost) => (
+          <button
+            key={cost.index}
+            className="btn"
+            onClick={() =>
+              resolve({ action: chooseUnlessCostBranchAction(cost.index) })
+            }
+          >
+            {unlessCostLabel(cost.hint, t)}
+          </button>
+        ))}
+      </div>
+      <div className="import__row">
+        <button
+          className="btn btn--ghost"
+          onClick={() =>
+            resolve({ action: chooseUnlessCostBranchAction(null) })
+          }
+        >
+          {t("wardUnless.decline")}
+        </button>
+        <button className="btn btn--ghost" onClick={onLetAi}>
+          {t("wardUnless.letAi")}
+        </button>
+      </div>
+    </>
+  );
+}
+
 function isTargetOptional(
   targeting: TargetTurn | null,
   chosen: TargetRef[],
@@ -1014,6 +1206,8 @@ interface RunnerCallbackDeps {
   setCoinFlipLifeTurn: Dispatch<SetStateAction<CoinFlipLifeTurn | null>>;
   setEquipCrewPick: Dispatch<SetStateAction<Set<number>>>;
   setEquipCrewTurn: Dispatch<SetStateAction<EquipCrewTurn | null>>;
+  setWardUnlessPick: Dispatch<SetStateAction<Set<number>>>;
+  setWardUnlessTurn: Dispatch<SetStateAction<WardUnlessTurn | null>>;
 }
 
 function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
@@ -1063,6 +1257,8 @@ function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
     setCoinFlipLifeTurn,
     setEquipCrewPick,
     setEquipCrewTurn,
+    setWardUnlessPick,
+    setWardUnlessTurn,
   } = deps;
   return {
     onFrame: (env) => {
@@ -1423,6 +1619,22 @@ function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
           },
         });
       }),
+    requestHumanWardUnless: (_env, prompt) =>
+      new Promise<HumanChoice>((resolve) => {
+        if (isCancelled()) {
+          resolve({ ai: true });
+          return;
+        }
+        setWardUnlessPick(new Set());
+        setWardUnlessTurn({
+          prompt,
+          resolve: (choice) => {
+            setWardUnlessTurn(null);
+            setWardUnlessPick(new Set());
+            resolve(choice);
+          },
+        });
+      }),
   };
 }
 
@@ -1545,6 +1757,12 @@ export function RunView({
     null,
   );
   const [equipCrewPick, setEquipCrewPick] = useState<Set<number>>(new Set());
+  const [wardUnlessTurn, setWardUnlessTurn] = useState<WardUnlessTurn | null>(
+    null,
+  );
+  const [wardUnlessPick, setWardUnlessPick] = useState<Set<number>>(
+    new Set(),
+  );
   const [passingTurn, setPassingTurn] = useState(false);
   const [logEntries, setLogEntries] = useState<LoggedEntry[]>([]);
   // On mobile the log is a full-screen drawer, so it always starts closed and
@@ -1658,6 +1876,8 @@ export function RunView({
             setCoinFlipLifeTurn,
             setEquipCrewPick,
             setEquipCrewTurn,
+            setWardUnlessPick,
+            setWardUnlessTurn,
           }),
         );
         runnerRef.current = runner;
@@ -1795,7 +2015,8 @@ export function RunView({
         exploreRevealTurn ||
         phyrexianTurn ||
         coinFlipLifeTurn ||
-        equipCrewTurn)
+        equipCrewTurn ||
+        wardUnlessTurn)
     ) {
       setPassingTurn(false);
     }
@@ -1818,6 +2039,7 @@ export function RunView({
     phyrexianTurn,
     coinFlipLifeTurn,
     equipCrewTurn,
+    wardUnlessTurn,
   ]);
 
   // Map draggable hand cards to their play actions for the current window.
@@ -2919,6 +3141,27 @@ export function RunView({
                 })
               }
               onLetAi={() => equipCrewTurn.resolve({ ai: true })}
+            />
+          )}
+
+          {wardUnlessTurn && (
+            <WardUnlessPanel
+              turn={wardUnlessTurn}
+              pick={wardUnlessPick}
+              onTogglePick={(id) =>
+                setWardUnlessPick((prev) => {
+                  const next = new Set(prev);
+                  if (next.has(id)) next.delete(id);
+                  else next.add(id);
+                  return next;
+                })
+              }
+              onConfirm={() =>
+                wardUnlessTurn.resolve({
+                  action: selectWardUnlessCardsAction([...wardUnlessPick]),
+                })
+              }
+              onLetAi={() => wardUnlessTurn.resolve({ ai: true })}
             />
           )}
         </section>

--- a/src/sim/decisions/wardUnless.test.ts
+++ b/src/sim/decisions/wardUnless.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseWardUnlessPrompt,
+  selectWardUnlessCardsAction,
+  chooseUnlessCostBranchAction,
+} from "./wardUnless";
+import type { GameState, WaitingFor } from "../../engine/types";
+
+const STATE: GameState = {
+  turn_number: 1,
+  phase: "Main1",
+  active_player: 0,
+  waiting_for: { type: "Priority" },
+  players: [],
+  objects: {
+    10: { id: 10, name: "Cancel", zone: "Hand" },
+    11: { id: 11, name: "Lightning Bolt", zone: "Hand" },
+    20: {
+      id: 20,
+      name: "Grizzly Bears",
+      zone: "Battlefield",
+      power: 2,
+      toughness: 2,
+    },
+    21: {
+      id: 21,
+      name: "Runeclaw Bear",
+      zone: "Battlefield",
+      power: 2,
+      toughness: 2,
+    },
+    22: { id: 22, name: "Winged Temple of Orazca", zone: "Battlefield" },
+  },
+  battlefield: [],
+  command_zone: [],
+  stack: [],
+  eliminated_players: [],
+};
+
+// Shape confirmed against phase-rs client/src/adapter/types.ts at v0.71.0:
+// WardDiscardChoice { player, cards, remaining, filter? }.
+const REAL_WARD_DISCARD: WaitingFor = {
+  type: "WardDiscardChoice",
+  data: { player: 0, cards: [10, 11], remaining: 1 },
+};
+
+// WardSacrificeChoice { player, permanents, remaining, min_total_power?: number|null }
+// with no threshold: pick a single permanent immediately.
+const REAL_WARD_SACRIFICE_SINGLE: WaitingFor = {
+  type: "WardSacrificeChoice",
+  data: {
+    player: 0,
+    permanents: [20, 21],
+    remaining: 1,
+    min_total_power: null,
+  },
+};
+
+// Same shape, this time with a power threshold: pick any number of
+// permanents whose summed power meets min_total_power.
+const REAL_WARD_SACRIFICE_THRESHOLD: WaitingFor = {
+  type: "WardSacrificeChoice",
+  data: {
+    player: 0,
+    permanents: [20, 21],
+    remaining: 1,
+    min_total_power: 4,
+  },
+};
+
+// UnlessBounceChoice { player, permanents, remaining }.
+const REAL_UNLESS_BOUNCE: WaitingFor = {
+  type: "UnlessBounceChoice",
+  data: { player: 0, permanents: [20, 22], remaining: 1 },
+};
+
+// UnlessPaymentChooseCost { player, costs: UnlessCost[], pending_effect,
+// effect_description? }. UnlessCost variants confirmed against
+// phase-rs client/src/adapter/types.ts at v0.71.0.
+const REAL_UNLESS_COST: WaitingFor = {
+  type: "UnlessPaymentChooseCost",
+  data: {
+    player: 0,
+    effect_description: "Counter unless its controller pays {3} or sacrifices a creature",
+    costs: [
+      { type: "DynamicGeneric", quantity: 3 },
+      { type: "Sacrifice", count: 1, filter: "Creature" },
+      { type: "PayLife", amount: 5 },
+      { type: "DiscardCard" },
+      { type: "ReturnToHand", count: 1, filter: "Permanent" },
+      { type: "Fixed", cost: { generic: 2 } },
+    ],
+  },
+};
+
+describe("parseWardUnlessPrompt", () => {
+  describe("WardDiscardChoice", () => {
+    it("parses the offered cards", () => {
+      const p = parseWardUnlessPrompt(REAL_WARD_DISCARD, STATE);
+      expect(p).not.toBeNull();
+      if (p?.kind !== "wardDiscard") throw new Error("expected wardDiscard");
+      expect(p.player).toBe(0);
+      expect(p.cards).toEqual([
+        { id: 10, name: "Cancel" },
+        { id: 11, name: "Lightning Bolt" },
+      ]);
+    });
+
+    it("returns null when cards is empty", () => {
+      const wf: WaitingFor = {
+        type: "WardDiscardChoice",
+        data: { player: 0, cards: [], remaining: 1 },
+      };
+      expect(parseWardUnlessPrompt(wf, STATE)).toBeNull();
+    });
+  });
+
+  describe("WardSacrificeChoice", () => {
+    it("parses a single-pick prompt when min_total_power is null", () => {
+      const p = parseWardUnlessPrompt(REAL_WARD_SACRIFICE_SINGLE, STATE);
+      expect(p).not.toBeNull();
+      if (p?.kind !== "wardSacrifice") throw new Error("expected wardSacrifice");
+      expect(p.minTotalPower).toBeNull();
+      expect(p.permanents).toEqual([
+        { id: 20, name: "Grizzly Bears", power: 2, toughness: 2 },
+        { id: 21, name: "Runeclaw Bear", power: 2, toughness: 2 },
+      ]);
+    });
+
+    it("parses a threshold prompt when min_total_power is set", () => {
+      const p = parseWardUnlessPrompt(REAL_WARD_SACRIFICE_THRESHOLD, STATE);
+      expect(p).not.toBeNull();
+      if (p?.kind !== "wardSacrifice") throw new Error("expected wardSacrifice");
+      expect(p.minTotalPower).toBe(4);
+      expect(p.permanents).toEqual([
+        { id: 20, name: "Grizzly Bears", power: 2, toughness: 2 },
+        { id: 21, name: "Runeclaw Bear", power: 2, toughness: 2 },
+      ]);
+    });
+
+    it("returns null when permanents is empty", () => {
+      const wf: WaitingFor = {
+        type: "WardSacrificeChoice",
+        data: { player: 0, permanents: [], remaining: 1, min_total_power: null },
+      };
+      expect(parseWardUnlessPrompt(wf, STATE)).toBeNull();
+    });
+  });
+
+  describe("UnlessBounceChoice", () => {
+    it("parses the offered permanents", () => {
+      const p = parseWardUnlessPrompt(REAL_UNLESS_BOUNCE, STATE);
+      expect(p).not.toBeNull();
+      if (p?.kind !== "unlessBounce") throw new Error("expected unlessBounce");
+      expect(p.player).toBe(0);
+      expect(p.permanents).toEqual([
+        { id: 20, name: "Grizzly Bears", power: 2, toughness: 2 },
+        { id: 22, name: "Winged Temple of Orazca", power: undefined, toughness: undefined },
+      ]);
+    });
+
+    it("returns null when permanents is empty", () => {
+      const wf: WaitingFor = {
+        type: "UnlessBounceChoice",
+        data: { player: 0, permanents: [], remaining: 1 },
+      };
+      expect(parseWardUnlessPrompt(wf, STATE)).toBeNull();
+    });
+  });
+
+  describe("UnlessPaymentChooseCost", () => {
+    it("labels each cost variant and preserves its index", () => {
+      const p = parseWardUnlessPrompt(REAL_UNLESS_COST, STATE);
+      expect(p).not.toBeNull();
+      if (p?.kind !== "unlessCost") throw new Error("expected unlessCost");
+      expect(p.player).toBe(0);
+      expect(p.description).toBe(
+        "Counter unless its controller pays {3} or sacrifices a creature",
+      );
+      expect(p.costs).toEqual([
+        { hint: { type: "dynamicGeneric" }, index: 0 },
+        { hint: { type: "sacrifice", count: 1 }, index: 1 },
+        { hint: { type: "payLife", amount: 5 }, index: 2 },
+        { hint: { type: "discardCard" }, index: 3 },
+        { hint: { type: "returnToHand", count: 1 }, index: 4 },
+        { hint: { type: "fixed" }, index: 5 },
+      ]);
+    });
+
+    it("returns null when costs is empty", () => {
+      const wf: WaitingFor = {
+        type: "UnlessPaymentChooseCost",
+        data: { player: 0, costs: [], pending_effect: {} },
+      };
+      expect(parseWardUnlessPrompt(wf, STATE)).toBeNull();
+    });
+  });
+
+  it("returns null for a non-matching waiting_for", () => {
+    expect(parseWardUnlessPrompt(undefined)).toBeNull();
+    expect(parseWardUnlessPrompt({ type: "Priority", data: {} })).toBeNull();
+  });
+});
+
+describe("selectWardUnlessCardsAction", () => {
+  it("builds the SelectCards action", () => {
+    expect(selectWardUnlessCardsAction([10])).toEqual({
+      type: "SelectCards",
+      data: { cards: [10] },
+    });
+  });
+
+  it("supports multiple ids for a threshold sacrifice", () => {
+    expect(selectWardUnlessCardsAction([20, 21])).toEqual({
+      type: "SelectCards",
+      data: { cards: [20, 21] },
+    });
+  });
+});
+
+describe("chooseUnlessCostBranchAction", () => {
+  it("builds a Pay branch for a chosen index", () => {
+    expect(chooseUnlessCostBranchAction(2)).toEqual({
+      type: "ChooseUnlessCostBranch",
+      data: { choice: { type: "Pay", data: { index: 2 } } },
+    });
+  });
+
+  it("builds a Decline branch for a null index", () => {
+    expect(chooseUnlessCostBranchAction(null)).toEqual({
+      type: "ChooseUnlessCostBranch",
+      data: { choice: { type: "Decline" } },
+    });
+  });
+});

--- a/src/sim/decisions/wardUnless.ts
+++ b/src/sim/decisions/wardUnless.ts
@@ -1,0 +1,237 @@
+// Paying a Ward or an "unless" cost — discarding a card, sacrificing a
+// permanent, bouncing a permanent to hand, or choosing which of several
+// costs to pay. The engine surfaces four waiting_for shapes:
+// - `WardDiscardChoice` { player, cards: ObjId[], remaining, filter? } —
+//   pick one card from `cards` to discard. Answered with
+//   `SelectCards { cards: [chosenId] }`.
+// - `WardSacrificeChoice` { player, permanents: ObjId[], remaining,
+//   min_total_power?: number | null } — when `min_total_power` is absent
+//   or null, pick one permanent to sacrifice immediately; otherwise pick
+//   any number of `permanents` whose summed power meets or exceeds
+//   `min_total_power`. Answered with `SelectCards { cards }`.
+// - `UnlessBounceChoice` { player, permanents: ObjId[], remaining } —
+//   pick one permanent from `permanents` to return to hand. Answered with
+//   `SelectCards { cards: [chosenId] }`.
+// - `UnlessPaymentChooseCost` { player, costs: UnlessCost[], pending_effect,
+//   effect_description? } — pick which of several costs to pay, or decline
+//   to pay any of them. `UnlessCost` is one of: `Fixed { cost }`,
+//   `DynamicGeneric { quantity }`, `PayLife { amount }`, `DiscardCard`,
+//   `Sacrifice { count, filter }`, `ReturnToHand { count, filter }`.
+//   Answered with `ChooseUnlessCostBranch { choice }`, where `choice` is
+//   `{ type: "Decline" }` or `{ type: "Pay", data: { index } }` (the
+//   position of the chosen cost in `costs`).
+// Shapes confirmed against phase-rs client/src/adapter/types.ts at v0.71.0.
+
+import type { GameState, WaitingFor } from "../../engine/types";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/** A hand card offered up for a Ward discard. */
+export interface WardUnlessCard {
+  id: number;
+  name: string;
+}
+
+/** A permanent offered for a Ward sacrifice or an "unless" bounce, with display-only P/T. */
+export interface WardUnlessPermanent {
+  id: number;
+  name: string;
+  power?: number | null;
+  toughness?: number | null;
+}
+
+export interface WardDiscardPrompt {
+  kind: "wardDiscard";
+  player: number;
+  cards: WardUnlessCard[];
+}
+
+export interface WardSacrificePrompt {
+  kind: "wardSacrifice";
+  player: number;
+  permanents: WardUnlessPermanent[];
+  /** Null means pick a single permanent; otherwise pick until this much power is met. */
+  minTotalPower: number | null;
+}
+
+export interface UnlessBouncePrompt {
+  kind: "unlessBounce";
+  player: number;
+  permanents: WardUnlessPermanent[];
+}
+
+/**
+ * A localization-agnostic description of one `UnlessCost` variant, for the
+ * panel to map onto a fixed, statically-keyed message.
+ */
+export type UnlessCostHint =
+  | { type: "fixed" }
+  | { type: "dynamicGeneric" }
+  | { type: "payLife"; amount: number }
+  | { type: "discardCard" }
+  | { type: "sacrifice"; count: number }
+  | { type: "returnToHand"; count: number };
+
+export interface UnlessCostOption {
+  hint: UnlessCostHint;
+  /** Position of this cost in the engine's `costs` array — echoed back on Pay. */
+  index: number;
+}
+
+export interface UnlessCostPrompt {
+  kind: "unlessCost";
+  player: number;
+  description: string;
+  costs: UnlessCostOption[];
+}
+
+export type WardUnlessPrompt =
+  | WardDiscardPrompt
+  | WardSacrificePrompt
+  | UnlessBouncePrompt
+  | UnlessCostPrompt;
+
+function toCard(id: number, state?: GameState): WardUnlessCard {
+  return { id, name: state?.objects?.[id]?.name ?? "" };
+}
+
+function toPermanent(id: number, state?: GameState): WardUnlessPermanent {
+  const obj = state?.objects?.[id];
+  return {
+    id,
+    name: obj?.name ?? "",
+    power: obj?.power,
+    toughness: obj?.toughness,
+  };
+}
+
+function costHint(cost: any): UnlessCostHint {
+  switch (cost?.type) {
+    case "PayLife":
+      return {
+        type: "payLife",
+        amount: typeof cost.amount === "number" ? cost.amount : 0,
+      };
+    case "DiscardCard":
+      return { type: "discardCard" };
+    case "Sacrifice":
+      return {
+        type: "sacrifice",
+        count: typeof cost.count === "number" ? cost.count : 1,
+      };
+    case "ReturnToHand":
+      return {
+        type: "returnToHand",
+        count: typeof cost.count === "number" ? cost.count : 1,
+      };
+    case "DynamicGeneric":
+      return { type: "dynamicGeneric" };
+    case "Fixed":
+    default:
+      return { type: "fixed" };
+  }
+}
+
+function parseWardDiscard(
+  d: any,
+  state?: GameState,
+): WardDiscardPrompt | null {
+  const cards = Array.isArray(d.cards) ? d.cards : [];
+  if (cards.length === 0) return null;
+  return {
+    kind: "wardDiscard",
+    player: typeof d.player === "number" ? d.player : 0,
+    cards: cards.map((id: number) => toCard(id, state)),
+  };
+}
+
+function parseWardSacrifice(
+  d: any,
+  state?: GameState,
+): WardSacrificePrompt | null {
+  const permanents = Array.isArray(d.permanents) ? d.permanents : [];
+  if (permanents.length === 0) return null;
+  return {
+    kind: "wardSacrifice",
+    player: typeof d.player === "number" ? d.player : 0,
+    permanents: permanents.map((id: number) => toPermanent(id, state)),
+    minTotalPower:
+      typeof d.min_total_power === "number" ? d.min_total_power : null,
+  };
+}
+
+function parseUnlessBounce(
+  d: any,
+  state?: GameState,
+): UnlessBouncePrompt | null {
+  const permanents = Array.isArray(d.permanents) ? d.permanents : [];
+  if (permanents.length === 0) return null;
+  return {
+    kind: "unlessBounce",
+    player: typeof d.player === "number" ? d.player : 0,
+    permanents: permanents.map((id: number) => toPermanent(id, state)),
+  };
+}
+
+function parseUnlessCost(d: any): UnlessCostPrompt | null {
+  const costs = Array.isArray(d.costs) ? d.costs : [];
+  if (costs.length === 0) return null;
+  return {
+    kind: "unlessCost",
+    player: typeof d.player === "number" ? d.player : 0,
+    description:
+      typeof d.effect_description === "string" ? d.effect_description : "",
+    costs: costs.map((cost: any, index: number) => ({
+      hint: costHint(cost),
+      index,
+    })),
+  };
+}
+
+/** Read a Ward/unless payment decision aimed at the human, or null. */
+export function parseWardUnlessPrompt(
+  wf: WaitingFor | undefined,
+  state?: GameState,
+): WardUnlessPrompt | null {
+  if (!wf) return null;
+  const d: any = wf.data ?? {};
+  switch (wf.type) {
+    case "WardDiscardChoice":
+      return parseWardDiscard(d, state);
+    case "WardSacrificeChoice":
+      return parseWardSacrifice(d, state);
+    case "UnlessBounceChoice":
+      return parseUnlessBounce(d, state);
+    case "UnlessPaymentChooseCost":
+      return parseUnlessCost(d);
+    default:
+      return null;
+  }
+}
+
+/** Submit the chosen card/permanent ids for a Ward discard, sacrifice, or unless bounce. */
+export function selectWardUnlessCardsAction(ids: number[]): {
+  type: string;
+  data: { cards: number[] };
+} {
+  return { type: "SelectCards", data: { cards: ids } };
+}
+
+/** Submit which unless cost to pay (by its index in `costs`), or decline all of them. */
+export function chooseUnlessCostBranchAction(index: number | null): {
+  type: string;
+  data: {
+    choice: { type: "Decline" } | { type: "Pay"; data: { index: number } };
+  };
+} {
+  if (index === null) {
+    return {
+      type: "ChooseUnlessCostBranch",
+      data: { choice: { type: "Decline" } },
+    };
+  }
+  return {
+    type: "ChooseUnlessCostBranch",
+    data: { choice: { type: "Pay", data: { index } } },
+  };
+}

--- a/src/sim/driver.ts
+++ b/src/sim/driver.ts
@@ -65,6 +65,10 @@ import {
   parseEquipCrewPrompt,
   type EquipCrewPrompt,
 } from "./decisions/equipCrew";
+import {
+  parseWardUnlessPrompt,
+  type WardUnlessPrompt,
+} from "./decisions/wardUnless";
 
 export interface MatchResult {
   matchIndex: number;
@@ -326,6 +330,11 @@ export interface DriverCallbacks {
   requestHumanEquipCrew?: (
     env: GameStateEnvelope,
     prompt: EquipCrewPrompt,
+  ) => Promise<HumanChoice>;
+  /** Called when the human pays a Ward cost or chooses which "unless" cost to pay. */
+  requestHumanWardUnless?: (
+    env: GameStateEnvelope,
+    prompt: WardUnlessPrompt,
   ) => Promise<HumanChoice>;
 }
 
@@ -680,6 +689,12 @@ export class MatchRunner {
           env,
           cb.requestHumanEquipCrew,
           parseEquipCrewPrompt(wf, state.objects),
+        ),
+      () =>
+        humanRequest(
+          env,
+          cb.requestHumanWardUnless,
+          parseWardUnlessPrompt(wf, state),
         ),
     ];
     for (const resolve of resolvers) {


### PR DESCRIPTION
## Summary
Wires the fourth manual-play decision kind: paying Ward and "unless" costs. The human now chooses:
- **Ward discard** — which hand card to discard.
- **Ward sacrifice** — a single permanent, or (when a power threshold applies) any number of permanents whose summed power meets it.
- **Unless bounce** — which permanent to return to hand.
- **Unless payment** — which of several alternative costs to pay (life, discard, sacrifice, return to hand, mana), or decline all of them.

Every prompt keeps a "let the AI decide" fallback, matching the existing decision-wiring pattern (`optionalCost`, `equipCrew`, etc.).

## Judgment calls
- The `UnlessCost` label logic returns a structured, i18n-agnostic `UnlessCostHint` from the parser (`{type, amount?, count?}`) rather than a pre-formatted string, so the panel can localize it through fixed `MsgKey`s with no dynamic keys — consistent with how the rest of the app's i18n works.
- Ward-sacrifice and unless-bounce permanents carry optional `power`/`toughness` pulled from `state.objects` (same convention as `equipCrew`'s `EquipCrewCreature`), so both list buttons can show P/T when available, even though the engine's own payload doesn't carry it.

## Gates
- `npm run lint` — pass
- `npm run typecheck` — pass
- `npm run duplication` — pass (0.95% total, no new duplication)
- `npm test` — pass (320 passed, 3 skipped; +14 new tests in `wardUnless.test.ts`)
- `npm run build` — pass
- `npx domainbook check --range main..HEAD` — nothing stale
- `npx domainbook validate` — valid

Closes #52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)