### PR TITLE
feat(sim): let the human choose what a copy effect copies and how to retarget it

### DIFF
--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,6 +12,15 @@ depth live there. A purely-internal PR that touches no product or architecture m
 skip its version with a `Skip-Docs: <reason>` trailer instead. There are no
 per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
+## [0.17.0] - 2026-09-05
+
+### Added
+
+- You now choose what a **copy effect** copies, and how to retarget a copy —
+  filling one target slot at a time or keeping every proposed target —
+  instead of the AI deciding
+  (`domains/simulation/features/choose-copy-target-and-retarget.md`).
+
 ## [0.16.0] - 2026-09-05
 
 ### Added

--- a/domainbook/domains/simulation/features/choose-copy-target-and-retarget.md
+++ b/domainbook/domains/simulation/features/choose-copy-target-and-retarget.md
@@ -1,0 +1,76 @@
+---
+id: choose-copy-target-and-retarget
+name: Choose what a copy effect copies, and how to retarget it
+status: implemented
+---
+
+## Story
+
+As a player piloting my seat
+I want to choose what a copy effect turns something into, and which targets
+a copy of a spell or ability points at
+So that those choices are mine to make, not the AI's
+
+## Rule: Copying picks the object to become
+
+When the engine asks the human to resolve a `CopyTargetChoice` decision
+request — a Clone-style effect deciding what it enters as a copy of, or any
+other effect offering a set of valid copy targets — the control panel lists
+every object in `valid_targets` and submits the choice as soon as one is
+clicked. Other seats still resolve this by AI action proposal, and any
+non-matching state is untouched.
+
+```gherkin
+Example: Choosing what to copy
+  Given a copy-target prompt offers Elvish Mystic and Nyxbloom Ancient
+  When I click Nyxbloom Ancient
+  Then the engine receives ChooseTarget with Nyxbloom Ancient's object id
+```
+
+## Rule: Retargeting a copy fills one slot at a time
+
+A `CopyRetarget` decision (a copy of a targeted spell or ability deciding
+where it points) fills its `target_slots` one at a time, tracked by
+`current_slot`. The panel shows the legal alternatives for that slot only —
+an object's name, or "You" / "Seat N" for a player — and submits the chosen
+target as soon as it is clicked, then the engine advances to the next slot.
+
+```gherkin
+Example: Retargeting the copy of a targeted spell
+  Given a copy-retarget prompt is filling target 1 of 2, offering two creatures
+  When I click one of the offered creatures
+  Then the engine receives ChooseTarget with that creature's object id
+  And the panel then shows the alternatives for target 2 of 2
+```
+
+## Rule: All proposed targets can be kept at once
+
+Once every slot in a `CopyRetarget` already carries a `current` target, the
+panel additionally offers to keep every proposed target as-is instead of
+re-picking each slot.
+
+```gherkin
+Example: Keeping every proposed target
+  Given a copy-retarget prompt shows a current target for every slot
+  When I click "Keep proposed targets"
+  Then the engine receives KeepAllCopyTargets
+```
+
+## Rule: The choice can be handed to the AI
+
+Choosing let the AI decide hands the whole copy or retarget choice back to
+the engine's own AI, so the decision is never stuck (`simulation/ADR-0001`).
+
+```gherkin
+Example: Letting the AI decide
+  Given a copy-target or copy-retarget prompt is shown
+  When I choose let the AI decide
+  Then the engine's AI makes that choice
+```
+
+## Open Questions
+
+- The `CopyTargetChoice` and `CopyRetarget` shapes, and the `ChooseTarget` /
+  `KeepAllCopyTargets` submissions, were confirmed against phase-rs's
+  vendored WASM and reference client `TargetingOverlay` at v0.71.0, but not
+  yet round-tripped against a live copy effect.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -527,6 +527,31 @@ export const messages = {
   "wardUnless.decline": { pt: "Não pagar", en: "Don't pay" },
   "wardUnless.letAi": { pt: "IA decide", en: "Let the AI decide" },
 
+  "copyChoice.sourceFallback": { pt: "A cópia", en: "The copy" },
+  "copyChoice.copyTargetTitle": {
+    pt: "Escolha o que copiar",
+    en: "Choose what to copy",
+  },
+  "copyChoice.copyTargetHint": {
+    pt: "{name} pode copiar um destes.",
+    en: "{name} may copy one of these.",
+  },
+  "copyChoice.retargetTitle": {
+    pt: "Redirecionar a cópia",
+    en: "Retarget the copy",
+  },
+  "copyChoice.retargetHint": {
+    pt: "Alvo {index} de {count}",
+    en: "Target {index} of {count}",
+  },
+  "copyChoice.keepAll": {
+    pt: "Manter os alvos propostos",
+    en: "Keep proposed targets",
+  },
+  "copyChoice.you": { pt: "Você", en: "You" },
+  "copyChoice.seat": { pt: "Assento {n}", en: "Seat {n}" },
+  "copyChoice.letAi": { pt: "IA decide", en: "Let the AI decide" },
+
   "modes.title": { pt: "Escolher modo", en: "Choose a mode" },
   "modes.source": {
     pt: "{name} pede uma escolha de modo.",

--- a/src/match/RunView.tsx
+++ b/src/match/RunView.tsx
@@ -94,6 +94,12 @@ import {
   type WardUnlessPrompt,
   type UnlessCostHint,
 } from "../sim/decisions/wardUnless";
+import {
+  chooseCopyTargetAction,
+  keepAllCopyTargetsAction,
+  type CopyChoicePrompt,
+  type CopyRetargetOption,
+} from "../sim/decisions/copyChoice";
 import { XpWindow } from "../components/XpWindow";
 import {
   declareAttackersAction,
@@ -1057,6 +1063,110 @@ function WardUnlessPanel({
   );
 }
 
+interface CopyChoiceTurn {
+  prompt: CopyChoicePrompt;
+  resolve: (choice: HumanChoice) => void;
+}
+
+function copyChoiceOptionLabel(
+  option: CopyRetargetOption,
+  t: (key: MsgKey, vars?: Vars) => string,
+): string {
+  if ("Player" in option.ref) {
+    return option.ref.Player === 0
+      ? t("copyChoice.you")
+      : t("copyChoice.seat", { n: option.ref.Player });
+  }
+  return option.label;
+}
+
+function CopyChoicePanel({ turn }: { turn: CopyChoiceTurn }) {
+  const { t } = useI18n();
+  const { prompt, resolve } = turn;
+
+  if (prompt.kind === "copyTarget") {
+    const sourceName = prompt.sourceName || t("copyChoice.sourceFallback");
+    return (
+      <>
+        <div className="control-title">
+          <strong>{t("copyChoice.copyTargetTitle")}</strong>
+        </div>
+        <p className="hint">
+          {t("copyChoice.copyTargetHint", { name: sourceName })}
+        </p>
+        <div className="search-list">
+          {prompt.targets.map((target) => (
+            <button
+              key={target.id}
+              className="btn"
+              onClick={() =>
+                resolve({
+                  action: chooseCopyTargetAction({ Object: target.id }),
+                })
+              }
+            >
+              {target.name}
+            </button>
+          ))}
+        </div>
+        <div className="import__row">
+          <button
+            className="btn btn--ghost"
+            onClick={() => resolve({ ai: true })}
+          >
+            {t("copyChoice.letAi")}
+          </button>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div className="control-title">
+        <strong>{t("copyChoice.retargetTitle")}</strong>
+      </div>
+      <p className="hint">
+        {t("copyChoice.retargetHint", {
+          index: prompt.slotIndex + 1,
+          count: prompt.slotCount,
+        })}
+      </p>
+      <div className="search-list">
+        {prompt.options.map((option, i) => (
+          <button
+            key={i}
+            className="btn"
+            onClick={() =>
+              resolve({ action: chooseCopyTargetAction(option.ref) })
+            }
+          >
+            {copyChoiceOptionLabel(option, t)}
+          </button>
+        ))}
+      </div>
+      <div className="import__row">
+        {prompt.canKeepAll && (
+          <button
+            className="btn"
+            onClick={() =>
+              resolve({ action: keepAllCopyTargetsAction() })
+            }
+          >
+            {t("copyChoice.keepAll")}
+          </button>
+        )}
+        <button
+          className="btn btn--ghost"
+          onClick={() => resolve({ ai: true })}
+        >
+          {t("copyChoice.letAi")}
+        </button>
+      </div>
+    </>
+  );
+}
+
 function isTargetOptional(
   targeting: TargetTurn | null,
   chosen: TargetRef[],
@@ -1208,6 +1318,7 @@ interface RunnerCallbackDeps {
   setEquipCrewTurn: Dispatch<SetStateAction<EquipCrewTurn | null>>;
   setWardUnlessPick: Dispatch<SetStateAction<Set<number>>>;
   setWardUnlessTurn: Dispatch<SetStateAction<WardUnlessTurn | null>>;
+  setCopyChoiceTurn: Dispatch<SetStateAction<CopyChoiceTurn | null>>;
 }
 
 function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
@@ -1259,6 +1370,7 @@ function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
     setEquipCrewTurn,
     setWardUnlessPick,
     setWardUnlessTurn,
+    setCopyChoiceTurn,
   } = deps;
   return {
     onFrame: (env) => {
@@ -1635,6 +1747,20 @@ function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
           },
         });
       }),
+    requestHumanCopyChoice: (_env, prompt) =>
+      new Promise<HumanChoice>((resolve) => {
+        if (isCancelled()) {
+          resolve({ ai: true });
+          return;
+        }
+        setCopyChoiceTurn({
+          prompt,
+          resolve: (choice) => {
+            setCopyChoiceTurn(null);
+            resolve(choice);
+          },
+        });
+      }),
   };
 }
 
@@ -1763,6 +1889,9 @@ export function RunView({
   const [wardUnlessPick, setWardUnlessPick] = useState<Set<number>>(
     new Set(),
   );
+  const [copyChoiceTurn, setCopyChoiceTurn] = useState<CopyChoiceTurn | null>(
+    null,
+  );
   const [passingTurn, setPassingTurn] = useState(false);
   const [logEntries, setLogEntries] = useState<LoggedEntry[]>([]);
   // On mobile the log is a full-screen drawer, so it always starts closed and
@@ -1878,6 +2007,7 @@ export function RunView({
             setEquipCrewTurn,
             setWardUnlessPick,
             setWardUnlessTurn,
+            setCopyChoiceTurn,
           }),
         );
         runnerRef.current = runner;
@@ -2016,7 +2146,8 @@ export function RunView({
         phyrexianTurn ||
         coinFlipLifeTurn ||
         equipCrewTurn ||
-        wardUnlessTurn)
+        wardUnlessTurn ||
+        copyChoiceTurn)
     ) {
       setPassingTurn(false);
     }
@@ -2040,6 +2171,7 @@ export function RunView({
     coinFlipLifeTurn,
     equipCrewTurn,
     wardUnlessTurn,
+    copyChoiceTurn,
   ]);
 
   // Map draggable hand cards to their play actions for the current window.
@@ -3164,6 +3296,8 @@ export function RunView({
               onLetAi={() => wardUnlessTurn.resolve({ ai: true })}
             />
           )}
+
+          {copyChoiceTurn && <CopyChoicePanel turn={copyChoiceTurn} />}
         </section>
       )}
 

--- a/src/sim/decisions/copyChoice.test.ts
+++ b/src/sim/decisions/copyChoice.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseCopyChoicePrompt,
+  chooseCopyTargetAction,
+  keepAllCopyTargetsAction,
+} from "./copyChoice";
+import type { GameState, WaitingFor } from "../../engine/types";
+
+// Shape confirmed against phase-rs client/src/adapter/types.ts
+// (TargetingOverlay) at v0.71.0: CopyTargetChoice { player, source_id,
+// valid_targets, max_mana_value?, purpose? }.
+const REAL_COPY_TARGET: WaitingFor = {
+  type: "CopyTargetChoice",
+  data: {
+    player: 0,
+    source_id: 90,
+    valid_targets: [12, 34],
+    max_mana_value: 5,
+    purpose: { type: "BecomeCopy" },
+  },
+};
+
+// Shape confirmed against phase-rs client/src/adapter/types.ts
+// (TargetingOverlay) at v0.71.0: CopyRetarget { player, copy_id,
+// target_slots: CopyTargetSlot[], current_slot? }, where CopyTargetSlot is
+// { current?: TargetRef | null, legal_alternatives: TargetRef[] }.
+const REAL_RETARGET: WaitingFor = {
+  type: "CopyRetarget",
+  data: {
+    player: 0,
+    copy_id: 56,
+    current_slot: 1,
+    target_slots: [
+      { current: { Object: 12 }, legal_alternatives: [{ Object: 12 }] },
+      {
+        current: null,
+        legal_alternatives: [{ Object: 34 }, { Player: 1 }],
+      },
+    ],
+  },
+};
+
+const REAL_RETARGET_KEEP_ALL: WaitingFor = {
+  type: "CopyRetarget",
+  data: {
+    player: 0,
+    copy_id: 56,
+    current_slot: 0,
+    target_slots: [
+      { current: { Object: 12 }, legal_alternatives: [{ Object: 12 }] },
+      { current: { Player: 0 }, legal_alternatives: [{ Player: 0 }] },
+    ],
+  },
+};
+
+const STATE: GameState = {
+  turn_number: 1,
+  phase: "Main1",
+  active_player: 0,
+  waiting_for: { type: "Priority" },
+  players: [],
+  objects: {
+    12: { id: 12, name: "Clone", zone: "Battlefield" },
+    34: { id: 34, name: "Nyxbloom Ancient", zone: "Battlefield" },
+    56: { id: 56, name: "Lightning Bolt Copy", zone: "Stack" },
+    90: { id: 90, name: "Vesuvan Doppelganger", zone: "Battlefield" },
+  },
+  battlefield: [],
+  command_zone: [],
+  stack: [],
+  eliminated_players: [],
+};
+
+describe("parseCopyChoicePrompt", () => {
+  describe("CopyTargetChoice", () => {
+    it("parses the player, source name and target options", () => {
+      const p = parseCopyChoicePrompt(REAL_COPY_TARGET, STATE)!;
+      expect(p).not.toBeNull();
+      if (p.kind !== "copyTarget") throw new Error("expected copyTarget");
+      expect(p.player).toBe(0);
+      expect(p.sourceName).toBe("Vesuvan Doppelganger");
+      expect(p.targets).toEqual([
+        { id: 12, name: "Clone" },
+        { id: 34, name: "Nyxbloom Ancient" },
+      ]);
+    });
+
+    it("falls back to empty names when state is omitted", () => {
+      const p = parseCopyChoicePrompt(REAL_COPY_TARGET);
+      if (p?.kind !== "copyTarget") throw new Error("expected copyTarget");
+      expect(p.sourceName).toBe("");
+      expect(p.targets.map((t) => t.name)).toEqual(["", ""]);
+    });
+
+    it("returns null when valid_targets is empty", () => {
+      const wf: WaitingFor = {
+        type: "CopyTargetChoice",
+        data: { player: 0, source_id: 90, valid_targets: [] },
+      };
+      expect(parseCopyChoicePrompt(wf)).toBeNull();
+    });
+  });
+
+  describe("CopyRetarget", () => {
+    it("parses the current slot's options, labeling objects and players", () => {
+      const p = parseCopyChoicePrompt(REAL_RETARGET, STATE)!;
+      expect(p).not.toBeNull();
+      if (p.kind !== "retarget") throw new Error("expected retarget");
+      expect(p.player).toBe(0);
+      expect(p.slotIndex).toBe(1);
+      expect(p.slotCount).toBe(2);
+      expect(p.canKeepAll).toBe(false);
+      expect(p.options).toEqual([
+        { ref: { Object: 34 }, label: "Nyxbloom Ancient" },
+        { ref: { Player: 1 }, label: "Seat 1" },
+      ]);
+    });
+
+    it("labels seat 0 as You", () => {
+      const wf: WaitingFor = {
+        type: "CopyRetarget",
+        data: {
+          player: 0,
+          copy_id: 56,
+          current_slot: 0,
+          target_slots: [
+            { current: null, legal_alternatives: [{ Player: 0 }] },
+          ],
+        },
+      };
+      const p = parseCopyChoicePrompt(wf)!;
+      if (p.kind !== "retarget") throw new Error("expected retarget");
+      expect(p.options).toEqual([{ ref: { Player: 0 }, label: "You" }]);
+    });
+
+    it("defaults the current slot to 0 when current_slot is absent", () => {
+      const wf: WaitingFor = {
+        type: "CopyRetarget",
+        data: {
+          player: 0,
+          copy_id: 56,
+          target_slots: [
+            { current: null, legal_alternatives: [{ Object: 12 }] },
+          ],
+        },
+      };
+      const p = parseCopyChoicePrompt(wf, STATE)!;
+      if (p.kind !== "retarget") throw new Error("expected retarget");
+      expect(p.slotIndex).toBe(0);
+    });
+
+    it("allows keeping all proposed targets once every slot has a current", () => {
+      const p = parseCopyChoicePrompt(REAL_RETARGET_KEEP_ALL, STATE)!;
+      if (p.kind !== "retarget") throw new Error("expected retarget");
+      expect(p.canKeepAll).toBe(true);
+      expect(p.options).toEqual([{ ref: { Object: 12 }, label: "Clone" }]);
+    });
+
+    it("returns null when the current slot has no alternatives and not every slot has a current", () => {
+      const wf: WaitingFor = {
+        type: "CopyRetarget",
+        data: {
+          player: 0,
+          copy_id: 56,
+          current_slot: 0,
+          target_slots: [
+            { current: null, legal_alternatives: [] },
+            { current: null, legal_alternatives: [{ Object: 34 }] },
+          ],
+        },
+      };
+      expect(parseCopyChoicePrompt(wf)).toBeNull();
+    });
+  });
+
+  it("returns null for a non-matching waiting_for", () => {
+    expect(parseCopyChoicePrompt(undefined)).toBeNull();
+    expect(parseCopyChoicePrompt({ type: "Priority", data: {} })).toBeNull();
+  });
+});
+
+describe("chooseCopyTargetAction", () => {
+  it("wraps an object id as a ChooseTarget action", () => {
+    expect(chooseCopyTargetAction({ Object: 12 })).toEqual({
+      type: "ChooseTarget",
+      data: { target: { Object: 12 } },
+    });
+  });
+
+  it("echoes a player TargetRef verbatim", () => {
+    expect(chooseCopyTargetAction({ Player: 1 })).toEqual({
+      type: "ChooseTarget",
+      data: { target: { Player: 1 } },
+    });
+  });
+});
+
+describe("keepAllCopyTargetsAction", () => {
+  it("builds the KeepAllCopyTargets action", () => {
+    expect(keepAllCopyTargetsAction()).toEqual({ type: "KeepAllCopyTargets" });
+  });
+});

--- a/src/sim/decisions/copyChoice.ts
+++ b/src/sim/decisions/copyChoice.ts
@@ -1,0 +1,135 @@
+// Choosing what a copy effect copies, and how a copy is retargeted. The
+// engine surfaces two waiting_for shapes:
+// - `CopyTargetChoice` { player, source_id, valid_targets: ObjId[],
+//   max_mana_value?, purpose? } — pick one object among `valid_targets` for
+//   the copy to become. Answered with `ChooseTarget { target: { Object: id } }`.
+// - `CopyRetarget` { player, copy_id, target_slots: CopyTargetSlot[],
+//   current_slot? } — `CopyTargetSlot` is `{ current?: TargetRef | null,
+//   legal_alternatives: TargetRef[] }`. The engine fills one slot at a time
+//   (`current_slot`, default 0); pick a target for that slot from its
+//   `legal_alternatives`, answered with `ChooseTarget { target }` (the chosen
+//   `TargetRef` echoed verbatim). Once every slot already has a `current`,
+//   the player may instead accept every proposed target with
+//   `KeepAllCopyTargets`.
+// Shapes confirmed against phase-rs client/src/adapter/types.ts
+// (TargetingOverlay) at v0.71.0.
+
+import type { GameState, WaitingFor } from "../../engine/types";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/** A single legal target: an object on the board, or a player seat. */
+export type CopyTargetRef = { Object: number } | { Player: number };
+
+/** One object offered up to become the copy. */
+export interface CopyTargetOption {
+  id: number;
+  name: string;
+}
+
+export interface CopyTargetPrompt {
+  kind: "copyTarget";
+  player: number;
+  sourceName: string;
+  targets: CopyTargetOption[];
+}
+
+/** One legal alternative for the current retarget slot. */
+export interface CopyRetargetOption {
+  ref: CopyTargetRef;
+  label: string;
+}
+
+export interface CopyRetargetPrompt {
+  kind: "retarget";
+  player: number;
+  /** 0-based index of the slot the engine is currently filling. */
+  slotIndex: number;
+  slotCount: number;
+  options: CopyRetargetOption[];
+  /** True when every slot already has a current target, so all may be kept at once. */
+  canKeepAll: boolean;
+}
+
+export type CopyChoicePrompt = CopyTargetPrompt | CopyRetargetPrompt;
+
+function toRef(t: any): CopyTargetRef | null {
+  if (t && typeof t === "object") {
+    if (typeof t.Object === "number") return { Object: t.Object };
+    if (typeof t.Player === "number") return { Player: t.Player };
+  }
+  return null;
+}
+
+function refLabel(ref: CopyTargetRef, state?: GameState): string {
+  if ("Object" in ref) return state?.objects?.[ref.Object]?.name ?? "";
+  return ref.Player === 0 ? "You" : `Seat ${ref.Player}`;
+}
+
+function parseCopyTarget(d: any, state?: GameState): CopyTargetPrompt | null {
+  const validTargets = Array.isArray(d.valid_targets) ? d.valid_targets : [];
+  if (validTargets.length === 0) return null;
+  return {
+    kind: "copyTarget",
+    player: typeof d.player === "number" ? d.player : 0,
+    sourceName: state?.objects?.[d.source_id]?.name ?? "",
+    targets: validTargets.map((id: number) => ({
+      id,
+      name: state?.objects?.[id]?.name ?? "",
+    })),
+  };
+}
+
+function parseCopyRetarget(d: any, state?: GameState): CopyRetargetPrompt | null {
+  const slots = Array.isArray(d.target_slots) ? d.target_slots : [];
+  const canKeepAll =
+    slots.length > 0 && slots.every((s: any) => s?.current != null);
+  const slotIndex = typeof d.current_slot === "number" ? d.current_slot : 0;
+  const currentSlot = slots[slotIndex];
+  const legalAlternatives = Array.isArray(currentSlot?.legal_alternatives)
+    ? currentSlot.legal_alternatives
+    : [];
+  const options = legalAlternatives
+    .map(toRef)
+    .filter((r: CopyTargetRef | null): r is CopyTargetRef => r !== null)
+    .map((ref: CopyTargetRef) => ({ ref, label: refLabel(ref, state) }));
+  if (options.length === 0 && !canKeepAll) return null;
+  return {
+    kind: "retarget",
+    player: typeof d.player === "number" ? d.player : 0,
+    slotIndex,
+    slotCount: slots.length,
+    options,
+    canKeepAll,
+  };
+}
+
+/** Read a copy-choice or copy-retarget decision aimed at the human, or null. */
+export function parseCopyChoicePrompt(
+  wf: WaitingFor | undefined,
+  state?: GameState,
+): CopyChoicePrompt | null {
+  if (!wf) return null;
+  const d: any = wf.data ?? {};
+  switch (wf.type) {
+    case "CopyTargetChoice":
+      return parseCopyTarget(d, state);
+    case "CopyRetarget":
+      return parseCopyRetarget(d, state);
+    default:
+      return null;
+  }
+}
+
+/** Submit the chosen target for a copy choice or a single retarget slot. */
+export function chooseCopyTargetAction(target: CopyTargetRef): {
+  type: string;
+  data: { target: CopyTargetRef };
+} {
+  return { type: "ChooseTarget", data: { target } };
+}
+
+/** Accept every proposed target on a retarget where all slots already have one. */
+export function keepAllCopyTargetsAction(): { type: string } {
+  return { type: "KeepAllCopyTargets" };
+}

--- a/src/sim/driver.ts
+++ b/src/sim/driver.ts
@@ -69,6 +69,10 @@ import {
   parseWardUnlessPrompt,
   type WardUnlessPrompt,
 } from "./decisions/wardUnless";
+import {
+  parseCopyChoicePrompt,
+  type CopyChoicePrompt,
+} from "./decisions/copyChoice";
 
 export interface MatchResult {
   matchIndex: number;
@@ -335,6 +339,11 @@ export interface DriverCallbacks {
   requestHumanWardUnless?: (
     env: GameStateEnvelope,
     prompt: WardUnlessPrompt,
+  ) => Promise<HumanChoice>;
+  /** Called when the human chooses what a copy effect copies, or how to retarget a copy. */
+  requestHumanCopyChoice?: (
+    env: GameStateEnvelope,
+    prompt: CopyChoicePrompt,
   ) => Promise<HumanChoice>;
 }
 
@@ -695,6 +704,12 @@ export class MatchRunner {
           env,
           cb.requestHumanWardUnless,
           parseWardUnlessPrompt(wf, state),
+        ),
+      () =>
+        humanRequest(
+          env,
+          cb.requestHumanCopyChoice,
+          parseCopyChoicePrompt(wf, state),
         ),
     ];
     for (const resolve of resolvers) {


### PR DESCRIPTION
## Summary

Wires two new engine decisions to the human player, following the existing decision-wiring pattern (see `decide-an-optional-cost`, `pay-ward-and-unless-costs`):

- **`CopyTargetChoice`** — pick which object a copy effect (e.g. Clone) becomes. One button per valid target, submits on click.
- **`CopyRetarget`** — fill each copy target slot in turn (the engine advances `current_slot` itself), picking from that slot's `legal_alternatives`. Once every slot already has a proposed (`current`) target, an extra "keep proposed targets" option submits `KeepAllCopyTargets` for all of them at once.

Both kinds always offer "let the AI decide" as a fallback.

## Files

- `src/sim/decisions/copyChoice.ts` (+ `.test.ts`) — parser + action builders
- `src/sim/driver.ts` — `requestHumanCopyChoice` callback wiring
- `src/match/RunView.tsx` — `CopyChoiceTurn`, `CopyChoicePanel`, state/effect wiring
- `src/i18n/messages.ts` — `copyChoice.*` keys (pt + en)
- `domainbook/domains/simulation/features/choose-copy-target-and-retarget.md`, `domainbook/changelog.md` (0.17.0), `package.json` version bump

## Judgment call

The retarget prompt's per-option `label` field is produced by the parser per the confirmed shape (object name, or "You"/"Seat N" for a player). To keep player-seat labels localized like every other decision in the app (e.g. `coinFlipLife.you`/`coinFlipLife.seat`), the panel re-derives the displayed label for `Player` refs from `t("copyChoice.you"/"copyChoice.seat")` rather than rendering the parser's raw English fallback verbatim; the parser's own `label` field (and its test) stays as specified for the `Object` case and as a fallback shape.

## Gates

- `npm run lint && npm run typecheck && npm run duplication && npm test && npm run build` — all pass
- `npx domainbook check --range main..HEAD` — nothing stale
- `npx domainbook validate` — valid

Closes #51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)