### PR TITLE
feat(sim): let the human choose counter distribution, proliferate targets, and populate token

### DIFF
--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,6 +12,14 @@ depth live there. A purely-internal PR that touches no product or architecture m
 skip its version with a `Skip-Docs: <reason>` trailer instead. There are no
 per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
+## [0.18.0] - 2026-09-05
+
+### Added
+
+- You now choose **counter distribution, proliferate targets, and which
+  token a populate effect copies**, instead of the AI deciding
+  (`domains/simulation/features/distribute-counters-proliferate-populate.md`).
+
 ## [0.17.0] - 2026-09-05
 
 ### Added

--- a/domainbook/domains/simulation/features/distribute-counters-proliferate-populate.md
+++ b/domainbook/domains/simulation/features/distribute-counters-proliferate-populate.md
@@ -1,0 +1,82 @@
+---
+id: distribute-counters-proliferate-populate
+name: Distribute counters/damage/life, proliferate, and populate
+status: implemented
+---
+
+## Story
+
+As a player piloting my seat
+I want to choose how to split counters, damage, or life among targets, which
+permanents and players to proliferate, and which token a populate effect
+copies
+So that these distributions are mine to choose, not the AI's
+
+## Rule: Distributing splits a total among targets, each getting at least one
+
+When the engine asks the human to resolve a `DistributeAmong` `decision
+request` — offered by an effect that splits counters, damage, or life among
+several targets — the control panel starts every target at 1 (satisfying the
+rule that each target gets at least one) and shows a running "assigned"
+count against the total. Per-target steppers raise or lower each target's
+share; Confirm stays disabled until the assigned amounts sum to the total,
+then submits the whole distribution.
+
+```gherkin
+Example: Distributing +1/+1 counters between two creatures
+  Given a DistributeAmong prompt for 3 +1/+1 counters across Elvish Mystic and Runeclaw Bear
+  When I raise Elvish Mystic to 2 and leave Runeclaw Bear at 1
+  Then the assigned count reads 3 of 3 and Confirm is enabled
+  And confirming sends DistributeAmong with [[Elvish Mystic, 2], [Runeclaw Bear, 1]]
+```
+
+## Rule: Proliferate chooses any subset of the eligible permanents and players
+
+A `ProliferateChoice` decision offers every eligible permanent and player as
+a toggle; any subset — including none — may be chosen, and Confirm is
+always enabled.
+
+```gherkin
+Example: Proliferating two permanents and skipping a player
+  Given a ProliferateChoice prompt offering a Saproling token, Elvish Mystic, and my own player
+  When I toggle on the Saproling token and Elvish Mystic only
+  Then confirming sends SelectTargets with just those two targets
+```
+
+## Rule: Populate copies one token among the valid choices
+
+A `PopulateChoice` decision lists every valid token; clicking one submits it
+immediately as the token to copy.
+
+```gherkin
+Example: Populating a Saproling token
+  Given a PopulateChoice prompt offering a Saproling token and an Elvish Mystic token
+  When I click the Saproling token
+  Then the engine receives ChooseTarget with the Saproling token's id
+```
+
+## Rule: The choice can be handed to the AI
+
+Choosing let the AI decide hands the whole distribute, proliferate, or
+populate choice back to the engine's own AI, so the decision is never stuck
+(`simulation/ADR-0001`).
+
+```gherkin
+Example: Letting the AI decide
+  Given a distribute, proliferate, or populate prompt is shown
+  When I choose let the AI decide
+  Then the engine's AI makes that choice
+```
+
+## Open Questions
+
+- The `DistributeAmong`, `ProliferateChoice`, and `PopulateChoice` shapes,
+  and the `DistributeAmong` / `SelectTargets` / `ChooseTarget` submissions,
+  were confirmed against phase-rs's vendored WASM and reference client
+  `DistributeAmongModal` / `ProliferateModal` / `TargetingOverlay` at
+  v0.71.0, but not yet round-tripped against a live distribute, proliferate,
+  or populate effect.
+- Two rarer counter-move shapes surfaced by the same engine area —
+  `MoveCountersDistribution` (moving existing counters between permanents)
+  and `RemoveCountersChoice` (choosing which counters to remove) — are left
+  to the AI as a deliberate second pass; the parser returns null for both.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -552,6 +552,32 @@ export const messages = {
   "copyChoice.seat": { pt: "Assento {n}", en: "Seat {n}" },
   "copyChoice.letAi": { pt: "IA decide", en: "Let the AI decide" },
 
+  "counters.distributeDamageTitle": {
+    pt: "Distribuir {n} de dano",
+    en: "Distribute {n} damage",
+  },
+  "counters.distributeLifeTitle": {
+    pt: "Distribuir {n} de vida",
+    en: "Distribute {n} life",
+  },
+  "counters.distributeCountersTitle": {
+    pt: "Distribuir {n} marcadores de {label}",
+    en: "Distribute {n} {label} counters",
+  },
+  "counters.assigned": {
+    pt: "Atribuído: {sum} / {n}",
+    en: "Assigned {sum} / {n}",
+  },
+  "counters.proliferateTitle": { pt: "Proliferar", en: "Proliferate" },
+  "counters.populateTitle": {
+    pt: "Povoar — escolha um marcador para copiar",
+    en: "Populate — choose a token to copy",
+  },
+  "counters.you": { pt: "Você", en: "You" },
+  "counters.seat": { pt: "Assento {n}", en: "Seat {n}" },
+  "counters.confirm": { pt: "Confirmar", en: "Confirm" },
+  "counters.letAi": { pt: "IA decide", en: "Let the AI decide" },
+
   "modes.title": { pt: "Escolher modo", en: "Choose a mode" },
   "modes.source": {
     pt: "{name} pede uma escolha de modo.",

--- a/src/match/RunView.tsx
+++ b/src/match/RunView.tsx
@@ -100,6 +100,13 @@ import {
   type CopyChoicePrompt,
   type CopyRetargetOption,
 } from "../sim/decisions/copyChoice";
+import {
+  distributeAmongAction,
+  proliferateAction,
+  populateAction,
+  type CountersPrompt,
+  type CounterTargetRef,
+} from "../sim/decisions/counters";
 import { XpWindow } from "../components/XpWindow";
 import {
   declareAttackersAction,
@@ -1167,6 +1174,223 @@ function CopyChoicePanel({ turn }: { turn: CopyChoiceTurn }) {
   );
 }
 
+interface CountersTurn {
+  prompt: CountersPrompt;
+  resolve: (choice: HumanChoice) => void;
+}
+
+function countersRefLabel(
+  ref: CounterTargetRef,
+  fallback: string,
+  t: (key: MsgKey, vars?: Vars) => string,
+): string {
+  if ("Player" in ref) {
+    return ref.Player === 0
+      ? t("counters.you")
+      : t("counters.seat", { n: ref.Player });
+  }
+  return fallback;
+}
+
+function distributeTitle(
+  prompt: Extract<CountersPrompt, { kind: "distribute" }>,
+  t: (key: MsgKey, vars?: Vars) => string,
+): string {
+  switch (prompt.unitKind) {
+    case "Life":
+      return t("counters.distributeLifeTitle", { n: prompt.total });
+    case "Counters":
+      return t("counters.distributeCountersTitle", {
+        n: prompt.total,
+        label: prompt.counterLabel ?? "",
+      });
+    case "Damage":
+    case "EvenSplitDamage":
+    default:
+      return t("counters.distributeDamageTitle", { n: prompt.total });
+  }
+}
+
+function DistributePanel({
+  prompt,
+  resolve,
+  pick,
+  onStep,
+}: {
+  prompt: Extract<CountersPrompt, { kind: "distribute" }>;
+  resolve: (choice: HumanChoice) => void;
+  pick: number[];
+  onStep: (index: number, delta: number) => void;
+}) {
+  const { t } = useI18n();
+  const sum = pick.reduce((total, n) => total + n, 0);
+  return (
+    <>
+      <div className="control-title">
+        <strong>{distributeTitle(prompt, t)}</strong>
+      </div>
+      <p className="hint">{t("counters.assigned", { sum, n: prompt.total })}</p>
+      <div className="search-list">
+        {prompt.targets.map((target, i) => (
+          <div key={i} className="import__row">
+            <button
+              className="btn btn--ghost"
+              disabled={(pick[i] ?? 1) <= 1}
+              onClick={() => onStep(i, -1)}
+            >
+              −
+            </button>
+            <span>
+              {countersRefLabel(target.ref, target.label, t)}: {pick[i] ?? 1}
+            </span>
+            <button
+              className="btn btn--ghost"
+              disabled={sum >= prompt.total}
+              onClick={() => onStep(i, 1)}
+            >
+              +
+            </button>
+          </div>
+        ))}
+      </div>
+      <div className="import__row">
+        <button
+          className="btn"
+          disabled={sum !== prompt.total}
+          onClick={() =>
+            resolve({
+              action: distributeAmongAction(
+                prompt.targets.map((target, i) => [target.ref, pick[i] ?? 1]),
+              ),
+            })
+          }
+        >
+          {t("counters.confirm")}
+        </button>
+        <button className="btn btn--ghost" onClick={() => resolve({ ai: true })}>
+          {t("counters.letAi")}
+        </button>
+      </div>
+    </>
+  );
+}
+
+function ProliferatePanel({
+  prompt,
+  resolve,
+  pick,
+  onTogglePick,
+}: {
+  prompt: Extract<CountersPrompt, { kind: "proliferate" }>;
+  resolve: (choice: HumanChoice) => void;
+  pick: Set<number>;
+  onTogglePick: (index: number) => void;
+}) {
+  const { t } = useI18n();
+  return (
+    <>
+      <div className="control-title">
+        <strong>{t("counters.proliferateTitle")}</strong>
+      </div>
+      <div className="search-list">
+        {prompt.options.map((option, i) => (
+          <button
+            key={i}
+            className={pick.has(i) ? "btn" : "btn--ghost"}
+            onClick={() => onTogglePick(i)}
+          >
+            {countersRefLabel(option.ref, option.label, t)}
+          </button>
+        ))}
+      </div>
+      <div className="import__row">
+        <button
+          className="btn"
+          onClick={() =>
+            resolve({
+              action: proliferateAction(
+                prompt.options
+                  .filter((_, i) => pick.has(i))
+                  .map((option) => option.ref),
+              ),
+            })
+          }
+        >
+          {t("counters.confirm")}
+        </button>
+        <button className="btn btn--ghost" onClick={() => resolve({ ai: true })}>
+          {t("counters.letAi")}
+        </button>
+      </div>
+    </>
+  );
+}
+
+function PopulatePanel({
+  prompt,
+  resolve,
+}: {
+  prompt: Extract<CountersPrompt, { kind: "populate" }>;
+  resolve: (choice: HumanChoice) => void;
+}) {
+  const { t } = useI18n();
+  return (
+    <>
+      <div className="control-title">
+        <strong>{t("counters.populateTitle")}</strong>
+      </div>
+      <div className="search-list">
+        {prompt.tokens.map((token) => (
+          <button
+            key={token.id}
+            className="btn"
+            onClick={() => resolve({ action: populateAction(token.id) })}
+          >
+            {token.name}
+          </button>
+        ))}
+      </div>
+      <div className="import__row">
+        <button className="btn btn--ghost" onClick={() => resolve({ ai: true })}>
+          {t("counters.letAi")}
+        </button>
+      </div>
+    </>
+  );
+}
+
+function CountersPanel({
+  turn,
+  distributePick,
+  onStepDistribute,
+  proliferatePick,
+  onToggleProliferate,
+}: {
+  turn: CountersTurn;
+  distributePick: number[];
+  onStepDistribute: (index: number, delta: number) => void;
+  proliferatePick: Set<number>;
+  onToggleProliferate: (index: number) => void;
+}) {
+  const { prompt, resolve } = turn;
+  if (prompt.kind === "distribute") {
+    return (
+      <DistributePanel prompt={prompt} resolve={resolve} pick={distributePick} onStep={onStepDistribute} />
+    );
+  }
+  if (prompt.kind === "proliferate") {
+    return (
+      <ProliferatePanel
+        prompt={prompt}
+        resolve={resolve}
+        pick={proliferatePick}
+        onTogglePick={onToggleProliferate}
+      />
+    );
+  }
+  return <PopulatePanel prompt={prompt} resolve={resolve} />;
+}
+
 function isTargetOptional(
   targeting: TargetTurn | null,
   chosen: TargetRef[],
@@ -1319,6 +1543,9 @@ interface RunnerCallbackDeps {
   setWardUnlessPick: Dispatch<SetStateAction<Set<number>>>;
   setWardUnlessTurn: Dispatch<SetStateAction<WardUnlessTurn | null>>;
   setCopyChoiceTurn: Dispatch<SetStateAction<CopyChoiceTurn | null>>;
+  setDistributePick: Dispatch<SetStateAction<number[]>>;
+  setProliferatePick: Dispatch<SetStateAction<Set<number>>>;
+  setCountersTurn: Dispatch<SetStateAction<CountersTurn | null>>;
 }
 
 function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
@@ -1371,6 +1598,9 @@ function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
     setWardUnlessPick,
     setWardUnlessTurn,
     setCopyChoiceTurn,
+    setDistributePick,
+    setProliferatePick,
+    setCountersTurn,
   } = deps;
   return {
     onFrame: (env) => {
@@ -1761,6 +1991,27 @@ function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
           },
         });
       }),
+    requestHumanCounters: (_env, prompt) =>
+      new Promise<HumanChoice>((resolve) => {
+        if (isCancelled()) {
+          resolve({ ai: true });
+          return;
+        }
+        if (prompt.kind === "distribute") {
+          setDistributePick(prompt.targets.map(() => 1));
+        } else if (prompt.kind === "proliferate") {
+          setProliferatePick(new Set());
+        }
+        setCountersTurn({
+          prompt,
+          resolve: (choice) => {
+            setCountersTurn(null);
+            setDistributePick([]);
+            setProliferatePick(new Set());
+            resolve(choice);
+          },
+        });
+      }),
   };
 }
 
@@ -1892,6 +2143,11 @@ export function RunView({
   const [copyChoiceTurn, setCopyChoiceTurn] = useState<CopyChoiceTurn | null>(
     null,
   );
+  const [countersTurn, setCountersTurn] = useState<CountersTurn | null>(null);
+  const [distributePick, setDistributePick] = useState<number[]>([]);
+  const [proliferatePick, setProliferatePick] = useState<Set<number>>(
+    new Set(),
+  );
   const [passingTurn, setPassingTurn] = useState(false);
   const [logEntries, setLogEntries] = useState<LoggedEntry[]>([]);
   // On mobile the log is a full-screen drawer, so it always starts closed and
@@ -2008,6 +2264,9 @@ export function RunView({
             setWardUnlessPick,
             setWardUnlessTurn,
             setCopyChoiceTurn,
+            setDistributePick,
+            setProliferatePick,
+            setCountersTurn,
           }),
         );
         runnerRef.current = runner;
@@ -2147,7 +2406,8 @@ export function RunView({
         coinFlipLifeTurn ||
         equipCrewTurn ||
         wardUnlessTurn ||
-        copyChoiceTurn)
+        copyChoiceTurn ||
+        countersTurn)
     ) {
       setPassingTurn(false);
     }
@@ -2172,6 +2432,7 @@ export function RunView({
     equipCrewTurn,
     wardUnlessTurn,
     copyChoiceTurn,
+    countersTurn,
   ]);
 
   // Map draggable hand cards to their play actions for the current window.
@@ -3298,6 +3559,27 @@ export function RunView({
           )}
 
           {copyChoiceTurn && <CopyChoicePanel turn={copyChoiceTurn} />}
+
+          {countersTurn && (
+            <CountersPanel
+              turn={countersTurn}
+              distributePick={distributePick}
+              onStepDistribute={(i, delta) =>
+                setDistributePick((prev) =>
+                  prev.map((v, idx) => (idx === i ? Math.max(1, v + delta) : v)),
+                )
+              }
+              proliferatePick={proliferatePick}
+              onToggleProliferate={(i) =>
+                setProliferatePick((prev) => {
+                  const next = new Set(prev);
+                  if (next.has(i)) next.delete(i);
+                  else next.add(i);
+                  return next;
+                })
+              }
+            />
+          )}
         </section>
       )}
 

--- a/src/sim/decisions/counters.test.ts
+++ b/src/sim/decisions/counters.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseCountersPrompt,
+  distributeAmongAction,
+  proliferateAction,
+  populateAction,
+} from "./counters";
+import type { GameState, WaitingFor } from "../../engine/types";
+
+// Shape confirmed against phase-rs client/src/adapter/types.ts
+// (DistributeAmongModal) at v0.71.0: DistributeAmong { player, total,
+// targets: TargetRef[], unit: DistributionUnit }, where DistributionUnit is
+// {type:"Damage"} | {type:"EvenSplitDamage"} | {type:"Counters", data:
+// string} | {type:"Life"}.
+const REAL_DISTRIBUTE: WaitingFor = {
+  type: "DistributeAmong",
+  data: {
+    player: 0,
+    total: 3,
+    targets: [{ Object: 12 }, { Player: 1 }],
+    unit: { type: "Counters", data: "+1/+1" },
+  },
+};
+
+// Shape confirmed against phase-rs client/src/adapter/types.ts
+// (ProliferateModal) at v0.71.0: ProliferateChoice { player, eligible: TargetRef[] }.
+const REAL_PROLIFERATE: WaitingFor = {
+  type: "ProliferateChoice",
+  data: {
+    player: 0,
+    eligible: [{ Object: 12 }, { Object: 34 }, { Player: 0 }],
+  },
+};
+
+// Shape confirmed against phase-rs client/src/adapter/types.ts
+// (TargetingOverlay) at v0.71.0: PopulateChoice { player, source_id, valid_tokens: ObjId[] }.
+const REAL_POPULATE: WaitingFor = {
+  type: "PopulateChoice",
+  data: {
+    player: 0,
+    source_id: 90,
+    valid_tokens: [12, 34],
+  },
+};
+
+const STATE: GameState = {
+  turn_number: 1,
+  phase: "Main1",
+  active_player: 0,
+  waiting_for: { type: "Priority" },
+  players: [],
+  objects: {
+    12: { id: 12, name: "Saproling Token", zone: "Battlefield" },
+    34: { id: 34, name: "Elvish Mystic", zone: "Battlefield" },
+    90: { id: 90, name: "Rite of Replication", zone: "Stack" },
+  },
+  battlefield: [],
+  command_zone: [],
+  stack: [],
+  eliminated_players: [],
+};
+
+describe("parseCountersPrompt", () => {
+  describe("DistributeAmong", () => {
+    it("parses the player, total, unit and targets with labels", () => {
+      const p = parseCountersPrompt(REAL_DISTRIBUTE, STATE)!;
+      expect(p).not.toBeNull();
+      if (p.kind !== "distribute") throw new Error("expected distribute");
+      expect(p.player).toBe(0);
+      expect(p.total).toBe(3);
+      expect(p.unitKind).toBe("Counters");
+      expect(p.counterLabel).toBe("+1/+1");
+      expect(p.targets).toEqual([
+        { ref: { Object: 12 }, label: "Saproling Token" },
+        { ref: { Player: 1 }, label: "Seat 1" },
+      ]);
+    });
+
+    it("labels seat 0 as You and omits counterLabel for Damage", () => {
+      const wf: WaitingFor = {
+        type: "DistributeAmong",
+        data: {
+          player: 0,
+          total: 5,
+          targets: [{ Player: 0 }],
+          unit: { type: "Damage" },
+        },
+      };
+      const p = parseCountersPrompt(wf)!;
+      if (p.kind !== "distribute") throw new Error("expected distribute");
+      expect(p.unitKind).toBe("Damage");
+      expect(p.counterLabel).toBeUndefined();
+      expect(p.targets).toEqual([{ ref: { Player: 0 }, label: "You" }]);
+    });
+
+    it("parses EvenSplitDamage and Life units", () => {
+      const evenSplit = parseCountersPrompt({
+        type: "DistributeAmong",
+        data: { player: 0, total: 4, targets: [{ Object: 12 }], unit: { type: "EvenSplitDamage" } },
+      })!;
+      if (evenSplit.kind !== "distribute") throw new Error("expected distribute");
+      expect(evenSplit.unitKind).toBe("EvenSplitDamage");
+
+      const life = parseCountersPrompt({
+        type: "DistributeAmong",
+        data: { player: 0, total: 2, targets: [{ Object: 12 }], unit: { type: "Life" } },
+      })!;
+      if (life.kind !== "distribute") throw new Error("expected distribute");
+      expect(life.unitKind).toBe("Life");
+    });
+
+    it("returns null when targets is empty", () => {
+      const wf: WaitingFor = {
+        type: "DistributeAmong",
+        data: { player: 0, total: 3, targets: [], unit: { type: "Damage" } },
+      };
+      expect(parseCountersPrompt(wf)).toBeNull();
+    });
+  });
+
+  describe("ProliferateChoice", () => {
+    it("parses the eligible targets with labels", () => {
+      const p = parseCountersPrompt(REAL_PROLIFERATE, STATE)!;
+      expect(p).not.toBeNull();
+      if (p.kind !== "proliferate") throw new Error("expected proliferate");
+      expect(p.player).toBe(0);
+      expect(p.options).toEqual([
+        { ref: { Object: 12 }, label: "Saproling Token" },
+        { ref: { Object: 34 }, label: "Elvish Mystic" },
+        { ref: { Player: 0 }, label: "You" },
+      ]);
+    });
+
+    it("returns null when eligible is empty", () => {
+      const wf: WaitingFor = {
+        type: "ProliferateChoice",
+        data: { player: 0, eligible: [] },
+      };
+      expect(parseCountersPrompt(wf)).toBeNull();
+    });
+  });
+
+  describe("PopulateChoice", () => {
+    it("parses the source name and valid tokens", () => {
+      const p = parseCountersPrompt(REAL_POPULATE, STATE)!;
+      expect(p).not.toBeNull();
+      if (p.kind !== "populate") throw new Error("expected populate");
+      expect(p.player).toBe(0);
+      expect(p.sourceName).toBe("Rite of Replication");
+      expect(p.tokens).toEqual([
+        { id: 12, name: "Saproling Token" },
+        { id: 34, name: "Elvish Mystic" },
+      ]);
+    });
+
+    it("falls back to empty names when state is omitted", () => {
+      const p = parseCountersPrompt(REAL_POPULATE);
+      if (p?.kind !== "populate") throw new Error("expected populate");
+      expect(p.sourceName).toBe("");
+      expect(p.tokens.map((tk) => tk.name)).toEqual(["", ""]);
+    });
+
+    it("returns null when valid_tokens is empty", () => {
+      const wf: WaitingFor = {
+        type: "PopulateChoice",
+        data: { player: 0, source_id: 90, valid_tokens: [] },
+      };
+      expect(parseCountersPrompt(wf)).toBeNull();
+    });
+  });
+
+  it("returns null for MoveCountersDistribution and RemoveCountersChoice (second pass, AI-driven)", () => {
+    const moveCounters: WaitingFor = {
+      type: "MoveCountersDistribution",
+      data: {
+        player: 0,
+        source_id: 12,
+        available: [["+1/+1", 3]],
+        destinations: [34],
+        pending_effect: {},
+      },
+    };
+    const removeCounters: WaitingFor = {
+      type: "RemoveCountersChoice",
+      data: {
+        player: 0,
+        source_id: 12,
+        available: [["+1/+1", 3]],
+        pending_effect: {},
+      },
+    };
+    expect(parseCountersPrompt(moveCounters)).toBeNull();
+    expect(parseCountersPrompt(removeCounters)).toBeNull();
+  });
+
+  it("returns null for a non-matching waiting_for", () => {
+    expect(parseCountersPrompt(undefined)).toBeNull();
+    expect(parseCountersPrompt({ type: "Priority", data: {} })).toBeNull();
+  });
+});
+
+describe("distributeAmongAction", () => {
+  it("echoes each TargetRef verbatim with its assigned amount", () => {
+    expect(
+      distributeAmongAction([
+        [{ Object: 12 }, 2],
+        [{ Player: 1 }, 1],
+      ]),
+    ).toEqual({
+      type: "DistributeAmong",
+      data: {
+        distribution: [
+          [{ Object: 12 }, 2],
+          [{ Player: 1 }, 1],
+        ],
+      },
+    });
+  });
+});
+
+describe("proliferateAction", () => {
+  it("wraps the chosen refs as a SelectTargets action", () => {
+    expect(proliferateAction([{ Object: 12 }, { Player: 0 }])).toEqual({
+      type: "SelectTargets",
+      data: { targets: [{ Object: 12 }, { Player: 0 }] },
+    });
+  });
+
+  it("allows an empty subset", () => {
+    expect(proliferateAction([])).toEqual({
+      type: "SelectTargets",
+      data: { targets: [] },
+    });
+  });
+});
+
+describe("populateAction", () => {
+  it("wraps the chosen token id as a ChooseTarget action", () => {
+    expect(populateAction(34)).toEqual({
+      type: "ChooseTarget",
+      data: { target: { Object: 34 } },
+    });
+  });
+});

--- a/src/sim/decisions/counters.ts
+++ b/src/sim/decisions/counters.ts
@@ -1,0 +1,207 @@
+// Distributing counters/damage/life among targets, proliferating, and
+// populating a token. The engine surfaces three waiting_for shapes:
+// - `DistributeAmong` { player, total, targets: TargetRef[], unit } — split
+//   `total` among `targets`, each receiving at least 1, summing to `total`.
+//   `unit` is `{type:"Damage"}` | `{type:"EvenSplitDamage"}` |
+//   `{type:"Counters", data: string}` (the counter type name) | `{type:"Life"}`.
+//   Answered with `DistributeAmong { distribution: [TargetRef, number][] }`
+//   (index-aligned to `targets`, each `TargetRef` echoed verbatim).
+// - `ProliferateChoice` { player, eligible: TargetRef[] } — choose any
+//   subset (including none) of `eligible` to proliferate. Answered with
+//   `SelectTargets { targets }` (the chosen `TargetRef`s, echoed verbatim).
+// - `PopulateChoice` { player, source_id, valid_tokens: ObjId[] } — pick one
+//   token among `valid_tokens` to copy. Answered with
+//   `ChooseTarget { target: { Object: id } }`.
+// Shapes confirmed against phase-rs client/src/adapter/types.ts
+// (DistributeAmongModal, ProliferateModal, TargetingOverlay) at v0.71.0.
+//
+// Two rarer counter-move shapes — `MoveCountersDistribution` and
+// `RemoveCountersChoice` — are a deliberate second pass (see the feature
+// doc's Open Questions) and are left to the AI: this parser returns null
+// for them.
+
+import type { GameState, WaitingFor } from "../../engine/types";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/** A single legal target: an object on the board, or a player seat. */
+export type CounterTargetRef = { Object: number } | { Player: number };
+
+/** One target offered up, with a display label. */
+export interface CounterTargetOption {
+  ref: CounterTargetRef;
+  label: string;
+}
+
+/** What is being distributed among the targets. */
+export type DistributionUnitKind =
+  | "Damage"
+  | "EvenSplitDamage"
+  | "Counters"
+  | "Life";
+
+export interface DistributePrompt {
+  kind: "distribute";
+  player: number;
+  total: number;
+  unitKind: DistributionUnitKind;
+  /** The counter type name (e.g. "+1/+1"), present only when unitKind is "Counters". */
+  counterLabel?: string;
+  targets: CounterTargetOption[];
+}
+
+export interface ProliferatePrompt {
+  kind: "proliferate";
+  player: number;
+  options: CounterTargetOption[];
+}
+
+/** One token offered up to populate (copy). */
+export interface PopulateToken {
+  id: number;
+  name: string;
+}
+
+export interface PopulatePrompt {
+  kind: "populate";
+  player: number;
+  sourceName: string;
+  tokens: PopulateToken[];
+}
+
+export type CountersPrompt =
+  | DistributePrompt
+  | ProliferatePrompt
+  | PopulatePrompt;
+
+function toRef(t: any): CounterTargetRef | null {
+  if (t && typeof t === "object") {
+    if (typeof t.Object === "number") return { Object: t.Object };
+    if (typeof t.Player === "number") return { Player: t.Player };
+  }
+  return null;
+}
+
+function refLabel(ref: CounterTargetRef, state?: GameState): string {
+  if ("Object" in ref) return state?.objects?.[ref.Object]?.name ?? "";
+  return ref.Player === 0 ? "You" : `Seat ${ref.Player}`;
+}
+
+function toRefOption(t: any, state?: GameState): CounterTargetOption | null {
+  const ref = toRef(t);
+  if (!ref) return null;
+  return { ref, label: refLabel(ref, state) };
+}
+
+const DISTRIBUTION_UNIT_KINDS = new Set<DistributionUnitKind>([
+  "Damage",
+  "EvenSplitDamage",
+  "Counters",
+  "Life",
+]);
+
+function parseDistributeAmong(
+  d: any,
+  state?: GameState,
+): DistributePrompt | null {
+  const rawTargets = Array.isArray(d.targets) ? d.targets : [];
+  const targets = rawTargets
+    .map((t: any) => toRefOption(t, state))
+    .filter(
+      (o: CounterTargetOption | null): o is CounterTargetOption => o !== null,
+    );
+  if (targets.length === 0) return null;
+  const unit = d.unit ?? {};
+  const unitKind: DistributionUnitKind = DISTRIBUTION_UNIT_KINDS.has(
+    unit.type,
+  )
+    ? unit.type
+    : "Damage";
+  return {
+    kind: "distribute",
+    player: typeof d.player === "number" ? d.player : 0,
+    total: typeof d.total === "number" ? d.total : 0,
+    unitKind,
+    counterLabel:
+      unitKind === "Counters" && typeof unit.data === "string"
+        ? unit.data
+        : undefined,
+    targets,
+  };
+}
+
+function parseProliferateChoice(
+  d: any,
+  state?: GameState,
+): ProliferatePrompt | null {
+  const eligible = Array.isArray(d.eligible) ? d.eligible : [];
+  const options = eligible
+    .map((t: any) => toRefOption(t, state))
+    .filter(
+      (o: CounterTargetOption | null): o is CounterTargetOption => o !== null,
+    );
+  if (options.length === 0) return null;
+  return {
+    kind: "proliferate",
+    player: typeof d.player === "number" ? d.player : 0,
+    options,
+  };
+}
+
+function parsePopulateChoice(
+  d: any,
+  state?: GameState,
+): PopulatePrompt | null {
+  const validTokens = Array.isArray(d.valid_tokens) ? d.valid_tokens : [];
+  if (validTokens.length === 0) return null;
+  return {
+    kind: "populate",
+    player: typeof d.player === "number" ? d.player : 0,
+    sourceName: state?.objects?.[d.source_id]?.name ?? "",
+    tokens: validTokens.map((id: number) => ({
+      id,
+      name: state?.objects?.[id]?.name ?? "",
+    })),
+  };
+}
+
+/** Read a distribute/proliferate/populate decision aimed at the human, or null. */
+export function parseCountersPrompt(
+  wf: WaitingFor | undefined,
+  state?: GameState,
+): CountersPrompt | null {
+  if (!wf) return null;
+  const d: any = wf.data ?? {};
+  switch (wf.type) {
+    case "DistributeAmong":
+      return parseDistributeAmong(d, state);
+    case "ProliferateChoice":
+      return parseProliferateChoice(d, state);
+    case "PopulateChoice":
+      return parsePopulateChoice(d, state);
+    default:
+      return null;
+  }
+}
+
+/** Submit the amount assigned to each target (index-aligned, summing to `total`). */
+export function distributeAmongAction(
+  distribution: [CounterTargetRef, number][],
+): { type: string; data: { distribution: [CounterTargetRef, number][] } } {
+  return { type: "DistributeAmong", data: { distribution } };
+}
+
+/** Submit the chosen subset of eligible permanents/players to proliferate. */
+export function proliferateAction(refs: CounterTargetRef[]): {
+  type: string;
+  data: { targets: CounterTargetRef[] };
+} {
+  return { type: "SelectTargets", data: { targets: refs } };
+}
+
+/** Submit the chosen token id to copy for populate. */
+export function populateAction(
+  id: number,
+): { type: string; data: { target: { Object: number } } } {
+  return { type: "ChooseTarget", data: { target: { Object: id } } };
+}

--- a/src/sim/driver.ts
+++ b/src/sim/driver.ts
@@ -73,6 +73,10 @@ import {
   parseCopyChoicePrompt,
   type CopyChoicePrompt,
 } from "./decisions/copyChoice";
+import {
+  parseCountersPrompt,
+  type CountersPrompt,
+} from "./decisions/counters";
 
 export interface MatchResult {
   matchIndex: number;
@@ -344,6 +348,11 @@ export interface DriverCallbacks {
   requestHumanCopyChoice?: (
     env: GameStateEnvelope,
     prompt: CopyChoicePrompt,
+  ) => Promise<HumanChoice>;
+  /** Called when the human distributes counters/damage/life, proliferates, or populates a token. */
+  requestHumanCounters?: (
+    env: GameStateEnvelope,
+    prompt: CountersPrompt,
   ) => Promise<HumanChoice>;
 }
 
@@ -710,6 +719,12 @@ export class MatchRunner {
           env,
           cb.requestHumanCopyChoice,
           parseCopyChoicePrompt(wf, state),
+        ),
+      () =>
+        humanRequest(
+          env,
+          cb.requestHumanCounters,
+          parseCountersPrompt(wf, state),
         ),
     ];
     for (const resolve of resolvers) {


### PR DESCRIPTION
## Summary

Surfaces three engine decisions to the human seat instead of always letting the AI decide:

- **`DistributeAmong`** — split a total (counters/damage/life) among targets, each getting at least one. A per-target stepper starts every target at 1, tracks "assigned / total", and Confirm is disabled until the sum matches the total.
- **`ProliferateChoice`** — toggle any subset (including none) of the eligible permanents/players to proliferate.
- **`PopulateChoice`** — pick one token to copy; submits immediately.

Shapes and submissions (`DistributeAmong { distribution }`, `SelectTargets { targets }`, `ChooseTarget { target }`) were confirmed against phase-rs v0.71.0's reference client (`DistributeAmongModal`, `ProliferateModal`, `TargetingOverlay`).

Each panel keeps a "let the AI decide" fallback, consistent with the other manual-play decisions.

## Scope note

Two rarer counter-move decisions in the same engine area — `MoveCountersDistribution` (moving existing counters between permanents) and `RemoveCountersChoice` (choosing which counters to remove) — remain AI-driven as a deliberate second pass. `parseCountersPrompt` returns `null` for both, and this is documented in the feature doc's Open Questions.

## Files

- `src/sim/decisions/counters.ts` + `.test.ts` — parser, prompt types, action builders
- `src/sim/driver.ts` — `requestHumanCounters` callback + resolver wiring
- `src/match/RunView.tsx` — `CountersTurn`, `CountersPanel` (+ distribute/proliferate/populate sub-panels), pick-state plumbing
- `src/i18n/messages.ts` — `counters.*` keys (pt/en)
- `domainbook/domains/simulation/features/distribute-counters-proliferate-populate.md`
- `domainbook/changelog.md` — 0.18.0
- `package.json` — version bump to 0.18.0

## Gates

- `npm run lint && npm run typecheck && npm run duplication && npm test && npm run build` — all pass
- `npx domainbook check --range main..HEAD` — nothing stale
- `npx domainbook validate` — valid

Closes #50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)