### PR TITLE
feat(sim): let the human assign combat damage among blockers/attackers

### DIFF
--- a/domainbook/changelog.md
+++ b/domainbook/changelog.md
@@ -12,6 +12,15 @@ depth live there. A purely-internal PR that touches no product or architecture m
 skip its version with a `Skip-Docs: <reason>` trailer instead. There are no
 per-domain changelogs; this file is the single timeline (`ADR-0007`).
 
+## [0.19.0] - 2026-09-05
+
+### Added
+
+- You now choose how an attacker splits combat damage among multiple
+  blockers (with trample spillover), and how a blocker splits its damage
+  among multiple attackers, instead of the AI deciding
+  (`domains/simulation/features/assign-combat-damage.md`).
+
 ## [0.18.0] - 2026-09-05
 
 ### Added

--- a/domainbook/domains/simulation/features/assign-combat-damage.md
+++ b/domainbook/domains/simulation/features/assign-combat-damage.md
@@ -1,0 +1,97 @@
+---
+id: assign-combat-damage
+name: Assign combat damage order/split among multiple blockers or attackers
+status: implemented
+---
+
+## Story
+
+As a player piloting my seat
+I want to choose how my attacker splits damage across multiple blockers
+(and any trample spillover), and how my blocker splits its damage across
+multiple attackers
+So that these damage assignments are mine to choose, not the AI's
+
+## Rule: An attacker must give each blocker at least its lethal minimum before anything spills over
+
+When the engine asks the human to resolve an `AssignCombatDamage` `decision
+request` for an attacker facing multiple blockers, the control panel starts
+each blocker at its `lethal_minimum` and shows a per-blocker stepper (its
+lower bound is that blocker's lethal minimum, so it can never drop below
+what is needed to kill it). Without trample, every point of damage must
+land on a blocker; with trample, any amount left over past every blocker's
+minimum is shown as a read-only spillover line and is submitted as
+trample damage automatically.
+
+```gherkin
+Example: A trampling attacker splits lethal damage and tramples the rest
+  Given an AssignCombatDamage prompt for 6 damage from a trampling attacker across two blockers needing 2 and 3
+  When I leave both blockers at their minimum
+  Then the tramples-over line reads 1
+  And confirming sends AssignCombatDamage with assignments [[blocker1, 2], [blocker2, 3]] and trample_damage 1
+```
+
+## Rule: Trample spills to the defending player, or to a planeswalker's controller when that is the attack target
+
+The engine tells the client whether the attack target is a planeswalker
+(`pw_loyalty`/`pw_controller` present on the prompt) or the defending
+player directly. Spillover damage is routed accordingly: `controller_damage`
+when the target is a planeswalker, `trample_damage` otherwise.
+
+```gherkin
+Example: Trampling over a planeswalker
+  Given an AssignCombatDamage prompt whose attack target is a planeswalker
+  When damage spills over past the blocker's lethal minimum
+  Then confirming sends that spillover as controller_damage, not trample_damage
+```
+
+## Rule: Without trample, all of an attacker's damage must land on its blockers
+
+When the attacker has no trample, the panel shows a running "assigned"
+count against the total and Confirm stays disabled until every point of
+damage is accounted for across the blockers.
+
+```gherkin
+Example: A non-trampling attacker must assign all its damage
+  Given an AssignCombatDamage prompt for 5 damage from a non-trampling attacker across one blocker needing 2
+  When I raise that blocker's assignment to 5
+  Then the assigned count reads 5 of 5 and Confirm is enabled
+```
+
+## Rule: A blocker facing multiple attackers freely splits its damage among them
+
+An `AssignBlockerDamage` decision offers a stepper per attacker, starting
+every attacker at 0; Confirm stays disabled until the assigned amounts sum
+to the blocker's total damage.
+
+```gherkin
+Example: A blocked-by-two creature splits its damage
+  Given an AssignBlockerDamage prompt for 4 damage across two attackers
+  When I assign 1 to the first attacker and 3 to the second
+  Then confirming sends AssignBlockerDamage with assignments [[attacker1, 1], [attacker2, 3]]
+```
+
+## Rule: The choice can be handed to the AI
+
+Choosing let the AI decide hands the whole combat-damage assignment back
+to the engine's own AI, so the decision is never stuck
+(`simulation/ADR-0001`).
+
+```gherkin
+Example: Letting the AI decide
+  Given an attacker or blocker damage-assignment prompt is shown
+  When I choose let the AI decide
+  Then the engine's AI makes that assignment
+```
+
+## Open Questions
+
+- The `AssignCombatDamage` and `AssignBlockerDamage` shapes, and their
+  matching submissions, were confirmed against the phase-rs v0.71.0
+  client's type surface but not yet round-tripped against a live combat
+  with multiple blockers or attackers.
+- When an attacker's blockers' combined lethal minimums exceed its total
+  damage (a lethal-minimum figure that can no longer be fully met — for
+  example after some of the assigned damage is prevented), the panel seeds
+  a best-effort initial split rather than rejecting the prompt; Confirm
+  simply stays disabled until the human (or the AI fallback) resolves it.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander-playtester",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "private": true,
   "type": "module",
   "description": "Web playtester for Magic: The Gathering Commander decks — import, goldfish, and score.",

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -578,6 +578,26 @@ export const messages = {
   "counters.confirm": { pt: "Confirmar", en: "Confirm" },
   "counters.letAi": { pt: "IA decide", en: "Let the AI decide" },
 
+  "combatDamage.attackerTitle": {
+    pt: "Atribuir os {n} de dano de combate de {name}",
+    en: "Assign {name}'s {n} combat damage",
+  },
+  "combatDamage.blockerTitle": {
+    pt: "Atribuir os {n} de dano de {name} entre os atacantes",
+    en: "Assign {name}'s {n} damage among attackers",
+  },
+  "combatDamage.needs": { pt: "(precisa de {n})", en: "(needs {n})" },
+  "combatDamage.tramplesOver": {
+    pt: "Atropela: {n}",
+    en: "Tramples over: {n}",
+  },
+  "combatDamage.assigned": {
+    pt: "Atribuído: {sum} / {n}",
+    en: "Assigned {sum} / {n}",
+  },
+  "combatDamage.confirm": { pt: "Confirmar", en: "Confirm" },
+  "combatDamage.letAi": { pt: "IA decide", en: "Let the AI decide" },
+
   "modes.title": { pt: "Escolher modo", en: "Choose a mode" },
   "modes.source": {
     pt: "{name} pede uma escolha de modo.",

--- a/src/match/RunView.tsx
+++ b/src/match/RunView.tsx
@@ -107,6 +107,11 @@ import {
   type CountersPrompt,
   type CounterTargetRef,
 } from "../sim/decisions/counters";
+import {
+  assignCombatDamageAction,
+  assignBlockerDamageAction,
+  type CombatDamagePrompt,
+} from "../sim/decisions/combatDamage";
 import { XpWindow } from "../components/XpWindow";
 import {
   declareAttackersAction,
@@ -1391,6 +1396,228 @@ function CountersPanel({
   return <PopulatePanel prompt={prompt} resolve={resolve} />;
 }
 
+interface CombatDamageTurn {
+  prompt: CombatDamagePrompt;
+  resolve: (choice: HumanChoice) => void;
+}
+
+/** The per-blocker (or per-attacker) minimum-lethal baseline, clamped to fit total_damage. */
+function combatDamageInitialPick(prompt: CombatDamagePrompt): number[] {
+  if (prompt.kind === "blocker") return prompt.attackers.map(() => 0);
+  let remaining = prompt.totalDamage;
+  return prompt.blockers.map((blocker) => {
+    const given = Math.min(blocker.lethalMinimum, remaining);
+    remaining -= given;
+    return given;
+  });
+}
+
+function AttackerDamagePanel({
+  prompt,
+  resolve,
+  pick,
+  onStep,
+}: {
+  prompt: Extract<CombatDamagePrompt, { kind: "attacker" }>;
+  resolve: (choice: HumanChoice) => void;
+  pick: number[];
+  onStep: (index: number, delta: number) => void;
+}) {
+  const { t } = useI18n();
+  const sum = pick.reduce((total, n) => total + n, 0);
+  const everyMinMet = prompt.blockers.every(
+    (blocker, i) => (pick[i] ?? 0) >= blocker.lethalMinimum,
+  );
+  const canConfirm = prompt.hasTrample
+    ? everyMinMet && sum <= prompt.totalDamage
+    : sum === prompt.totalDamage;
+  const spillover = Math.max(0, prompt.totalDamage - sum);
+  return (
+    <>
+      <div className="control-title">
+        <strong>
+          {t("combatDamage.attackerTitle", {
+            name: prompt.attackerName,
+            n: prompt.totalDamage,
+          })}
+        </strong>
+      </div>
+      {!prompt.hasTrample && (
+        <p className="hint">
+          {t("combatDamage.assigned", { sum, n: prompt.totalDamage })}
+        </p>
+      )}
+      <div className="search-list">
+        {prompt.blockers.map((blocker, i) => (
+          <div key={blocker.id} className="import__row">
+            <button
+              className="btn btn--ghost"
+              disabled={(pick[i] ?? 0) <= blocker.lethalMinimum}
+              onClick={() => onStep(i, -1)}
+            >
+              −
+            </button>
+            <span>
+              {blocker.name}{" "}
+              {t("combatDamage.needs", { n: blocker.lethalMinimum })}:{" "}
+              {pick[i] ?? 0}
+            </span>
+            <button
+              className="btn btn--ghost"
+              disabled={sum >= prompt.totalDamage}
+              onClick={() => onStep(i, 1)}
+            >
+              +
+            </button>
+          </div>
+        ))}
+      </div>
+      {prompt.hasTrample && (
+        <p className="hint">
+          {t("combatDamage.tramplesOver", { n: spillover })}
+        </p>
+      )}
+      <div className="import__row">
+        <button
+          className="btn"
+          disabled={!canConfirm}
+          onClick={() => {
+            const trampleDamage = prompt.tramplesToController ? 0 : spillover;
+            const controllerDamage = prompt.tramplesToController
+              ? spillover
+              : 0;
+            resolve({
+              action: assignCombatDamageAction(
+                prompt.blockers.map((blocker, i) => [
+                  blocker.id,
+                  pick[i] ?? 0,
+                ]),
+                trampleDamage,
+                controllerDamage,
+              ),
+            });
+          }}
+        >
+          {t("combatDamage.confirm")}
+        </button>
+        <button
+          className="btn btn--ghost"
+          onClick={() => resolve({ ai: true })}
+        >
+          {t("combatDamage.letAi")}
+        </button>
+      </div>
+    </>
+  );
+}
+
+function BlockerDamagePanel({
+  prompt,
+  resolve,
+  pick,
+  onStep,
+}: {
+  prompt: Extract<CombatDamagePrompt, { kind: "blocker" }>;
+  resolve: (choice: HumanChoice) => void;
+  pick: number[];
+  onStep: (index: number, delta: number) => void;
+}) {
+  const { t } = useI18n();
+  const sum = pick.reduce((total, n) => total + n, 0);
+  return (
+    <>
+      <div className="control-title">
+        <strong>
+          {t("combatDamage.blockerTitle", {
+            name: prompt.blockerName,
+            n: prompt.totalDamage,
+          })}
+        </strong>
+      </div>
+      <p className="hint">
+        {t("combatDamage.assigned", { sum, n: prompt.totalDamage })}
+      </p>
+      <div className="search-list">
+        {prompt.attackers.map((attacker, i) => (
+          <div key={attacker.id} className="import__row">
+            <button
+              className="btn btn--ghost"
+              disabled={(pick[i] ?? 0) <= 0}
+              onClick={() => onStep(i, -1)}
+            >
+              −
+            </button>
+            <span>
+              {attacker.name}: {pick[i] ?? 0}
+            </span>
+            <button
+              className="btn btn--ghost"
+              disabled={sum >= prompt.totalDamage}
+              onClick={() => onStep(i, 1)}
+            >
+              +
+            </button>
+          </div>
+        ))}
+      </div>
+      <div className="import__row">
+        <button
+          className="btn"
+          disabled={sum !== prompt.totalDamage}
+          onClick={() =>
+            resolve({
+              action: assignBlockerDamageAction(
+                prompt.attackers.map((attacker, i) => [
+                  attacker.id,
+                  pick[i] ?? 0,
+                ]),
+              ),
+            })
+          }
+        >
+          {t("combatDamage.confirm")}
+        </button>
+        <button
+          className="btn btn--ghost"
+          onClick={() => resolve({ ai: true })}
+        >
+          {t("combatDamage.letAi")}
+        </button>
+      </div>
+    </>
+  );
+}
+
+function CombatDamagePanel({
+  turn,
+  pick,
+  onStep,
+}: {
+  turn: CombatDamageTurn;
+  pick: number[];
+  onStep: (index: number, delta: number) => void;
+}) {
+  const { prompt, resolve } = turn;
+  if (prompt.kind === "attacker") {
+    return (
+      <AttackerDamagePanel
+        prompt={prompt}
+        resolve={resolve}
+        pick={pick}
+        onStep={onStep}
+      />
+    );
+  }
+  return (
+    <BlockerDamagePanel
+      prompt={prompt}
+      resolve={resolve}
+      pick={pick}
+      onStep={onStep}
+    />
+  );
+}
+
 function isTargetOptional(
   targeting: TargetTurn | null,
   chosen: TargetRef[],
@@ -1546,6 +1773,8 @@ interface RunnerCallbackDeps {
   setDistributePick: Dispatch<SetStateAction<number[]>>;
   setProliferatePick: Dispatch<SetStateAction<Set<number>>>;
   setCountersTurn: Dispatch<SetStateAction<CountersTurn | null>>;
+  setCombatDamagePick: Dispatch<SetStateAction<number[]>>;
+  setCombatDamageTurn: Dispatch<SetStateAction<CombatDamageTurn | null>>;
 }
 
 function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
@@ -1601,6 +1830,8 @@ function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
     setDistributePick,
     setProliferatePick,
     setCountersTurn,
+    setCombatDamagePick,
+    setCombatDamageTurn,
   } = deps;
   return {
     onFrame: (env) => {
@@ -2012,6 +2243,22 @@ function buildRunnerCallbacks(deps: RunnerCallbackDeps): DriverCallbacks {
           },
         });
       }),
+    requestHumanCombatDamage: (_env, prompt) =>
+      new Promise<HumanChoice>((resolve) => {
+        if (isCancelled()) {
+          resolve({ ai: true });
+          return;
+        }
+        setCombatDamagePick(combatDamageInitialPick(prompt));
+        setCombatDamageTurn({
+          prompt,
+          resolve: (choice) => {
+            setCombatDamageTurn(null);
+            setCombatDamagePick([]);
+            resolve(choice);
+          },
+        });
+      }),
   };
 }
 
@@ -2148,6 +2395,9 @@ export function RunView({
   const [proliferatePick, setProliferatePick] = useState<Set<number>>(
     new Set(),
   );
+  const [combatDamageTurn, setCombatDamageTurn] =
+    useState<CombatDamageTurn | null>(null);
+  const [combatDamagePick, setCombatDamagePick] = useState<number[]>([]);
   const [passingTurn, setPassingTurn] = useState(false);
   const [logEntries, setLogEntries] = useState<LoggedEntry[]>([]);
   // On mobile the log is a full-screen drawer, so it always starts closed and
@@ -2267,6 +2517,8 @@ export function RunView({
             setDistributePick,
             setProliferatePick,
             setCountersTurn,
+            setCombatDamagePick,
+            setCombatDamageTurn,
           }),
         );
         runnerRef.current = runner;
@@ -2407,7 +2659,8 @@ export function RunView({
         equipCrewTurn ||
         wardUnlessTurn ||
         copyChoiceTurn ||
-        countersTurn)
+        countersTurn ||
+        combatDamageTurn)
     ) {
       setPassingTurn(false);
     }
@@ -2433,6 +2686,7 @@ export function RunView({
     wardUnlessTurn,
     copyChoiceTurn,
     countersTurn,
+    combatDamageTurn,
   ]);
 
   // Map draggable hand cards to their play actions for the current window.
@@ -3577,6 +3831,26 @@ export function RunView({
                   else next.add(i);
                   return next;
                 })
+              }
+            />
+          )}
+
+          {combatDamageTurn && (
+            <CombatDamagePanel
+              turn={combatDamageTurn}
+              pick={combatDamagePick}
+              onStep={(i, delta) =>
+                setCombatDamagePick((prev) =>
+                  prev.map((v, idx) => {
+                    if (idx !== i) return v;
+                    const min =
+                      combatDamageTurn.prompt.kind === "attacker"
+                        ? (combatDamageTurn.prompt.blockers[i]?.lethalMinimum ??
+                          0)
+                        : 0;
+                    return Math.max(min, v + delta);
+                  }),
+                )
               }
             />
           )}

--- a/src/sim/decisions/combatDamage.test.ts
+++ b/src/sim/decisions/combatDamage.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseCombatDamagePrompt,
+  assignCombatDamageAction,
+  assignBlockerDamageAction,
+} from "./combatDamage";
+import type { GameState, WaitingFor } from "../../engine/types";
+
+// Shape confirmed against phase-rs v0.71.0 (issue #47): AssignCombatDamage
+// { player, attacker_id, total_damage, blockers: [{blocker_id,
+// lethal_minimum}], trample: TrampleKind|null, defending_player,
+// attack_target, pw_loyalty?, pw_controller? }.
+const REAL_ASSIGN_COMBAT_DAMAGE: WaitingFor = {
+  type: "AssignCombatDamage",
+  data: {
+    player: 0,
+    attacker_id: 12,
+    total_damage: 6,
+    blockers: [
+      { blocker_id: 34, lethal_minimum: 2 },
+      { blocker_id: 56, lethal_minimum: 3 },
+    ],
+    trample: { type: "Regular" },
+    defending_player: 1,
+    attack_target: { Player: 1 },
+  },
+};
+
+// Shape confirmed against phase-rs v0.71.0 (issue #47): AssignBlockerDamage
+// { player, blocker_id, total_damage, attackers: number[] }.
+const REAL_ASSIGN_BLOCKER_DAMAGE: WaitingFor = {
+  type: "AssignBlockerDamage",
+  data: {
+    player: 0,
+    blocker_id: 34,
+    total_damage: 4,
+    attackers: [12, 78],
+  },
+};
+
+const STATE: GameState = {
+  turn_number: 1,
+  phase: "Combat",
+  active_player: 0,
+  waiting_for: { type: "Priority" },
+  players: [],
+  objects: {
+    12: { id: 12, name: "Ghalta, Primal Hunger", zone: "Battlefield" },
+    34: { id: 34, name: "Elvish Mystic", zone: "Battlefield" },
+    56: { id: 56, name: "Runeclaw Bear", zone: "Battlefield" },
+    78: { id: 78, name: "Llanowar Elves", zone: "Battlefield" },
+  },
+  battlefield: [],
+  command_zone: [],
+  stack: [],
+  eliminated_players: [],
+};
+
+describe("parseCombatDamagePrompt", () => {
+  describe("AssignCombatDamage", () => {
+    it("parses the attacker, blockers, and trample fields for a player-defender attack", () => {
+      const p = parseCombatDamagePrompt(REAL_ASSIGN_COMBAT_DAMAGE, STATE)!;
+      expect(p).not.toBeNull();
+      if (p.kind !== "attacker") throw new Error("expected attacker");
+      expect(p.player).toBe(0);
+      expect(p.attackerName).toBe("Ghalta, Primal Hunger");
+      expect(p.totalDamage).toBe(6);
+      expect(p.blockers).toEqual([
+        { id: 34, name: "Elvish Mystic", lethalMinimum: 2 },
+        { id: 56, name: "Runeclaw Bear", lethalMinimum: 3 },
+      ]);
+      expect(p.hasTrample).toBe(true);
+      expect(p.tramplesToController).toBe(false);
+    });
+
+    it("routes trample to the controller when the attack target is a planeswalker", () => {
+      const wf: WaitingFor = {
+        type: "AssignCombatDamage",
+        data: {
+          player: 0,
+          attacker_id: 12,
+          total_damage: 6,
+          blockers: [{ blocker_id: 34, lethal_minimum: 2 }],
+          trample: { type: "Regular" },
+          defending_player: 1,
+          attack_target: { Object: 99 },
+          pw_loyalty: 5,
+          pw_controller: 1,
+        },
+      };
+      const p = parseCombatDamagePrompt(wf, STATE)!;
+      if (p.kind !== "attacker") throw new Error("expected attacker");
+      expect(p.tramplesToController).toBe(true);
+    });
+
+    it("has hasTrample false when trample is null", () => {
+      const wf: WaitingFor = {
+        type: "AssignCombatDamage",
+        data: {
+          player: 0,
+          attacker_id: 12,
+          total_damage: 5,
+          blockers: [{ blocker_id: 34, lethal_minimum: 2 }],
+          trample: null,
+          defending_player: 1,
+          attack_target: { Player: 1 },
+        },
+      };
+      const p = parseCombatDamagePrompt(wf, STATE)!;
+      if (p.kind !== "attacker") throw new Error("expected attacker");
+      expect(p.hasTrample).toBe(false);
+    });
+
+    it("falls back to empty names when state is omitted", () => {
+      const p = parseCombatDamagePrompt(REAL_ASSIGN_COMBAT_DAMAGE);
+      if (p?.kind !== "attacker") throw new Error("expected attacker");
+      expect(p.attackerName).toBe("");
+      expect(p.blockers.map((b) => b.name)).toEqual(["", ""]);
+    });
+
+    it("returns null when blockers is empty", () => {
+      const wf: WaitingFor = {
+        type: "AssignCombatDamage",
+        data: {
+          player: 0,
+          attacker_id: 12,
+          total_damage: 6,
+          blockers: [],
+          trample: null,
+          defending_player: 1,
+          attack_target: { Player: 1 },
+        },
+      };
+      expect(parseCombatDamagePrompt(wf)).toBeNull();
+    });
+  });
+
+  describe("AssignBlockerDamage", () => {
+    it("parses the blocker and attackers with labels", () => {
+      const p = parseCombatDamagePrompt(REAL_ASSIGN_BLOCKER_DAMAGE, STATE)!;
+      expect(p).not.toBeNull();
+      if (p.kind !== "blocker") throw new Error("expected blocker");
+      expect(p.player).toBe(0);
+      expect(p.blockerName).toBe("Elvish Mystic");
+      expect(p.totalDamage).toBe(4);
+      expect(p.attackers).toEqual([
+        { id: 12, name: "Ghalta, Primal Hunger" },
+        { id: 78, name: "Llanowar Elves" },
+      ]);
+    });
+
+    it("falls back to empty names when state is omitted", () => {
+      const p = parseCombatDamagePrompt(REAL_ASSIGN_BLOCKER_DAMAGE);
+      if (p?.kind !== "blocker") throw new Error("expected blocker");
+      expect(p.blockerName).toBe("");
+      expect(p.attackers.map((a) => a.name)).toEqual(["", ""]);
+    });
+
+    it("returns null when attackers is empty", () => {
+      const wf: WaitingFor = {
+        type: "AssignBlockerDamage",
+        data: { player: 0, blocker_id: 34, total_damage: 4, attackers: [] },
+      };
+      expect(parseCombatDamagePrompt(wf)).toBeNull();
+    });
+  });
+
+  it("returns null for a non-matching waiting_for", () => {
+    expect(parseCombatDamagePrompt(undefined)).toBeNull();
+    expect(parseCombatDamagePrompt({ type: "Priority", data: {} })).toBeNull();
+  });
+});
+
+describe("assignCombatDamageAction", () => {
+  it("echoes each blocker_id verbatim with its assigned amount plus spillover", () => {
+    expect(
+      assignCombatDamageAction(
+        [
+          [34, 2],
+          [56, 3],
+        ],
+        1,
+        0,
+      ),
+    ).toEqual({
+      type: "AssignCombatDamage",
+      data: {
+        assignments: [
+          [34, 2],
+          [56, 3],
+        ],
+        trample_damage: 1,
+        controller_damage: 0,
+      },
+    });
+  });
+});
+
+describe("assignBlockerDamageAction", () => {
+  it("echoes each attacker_id verbatim with its assigned amount", () => {
+    expect(
+      assignBlockerDamageAction([
+        [12, 1],
+        [78, 3],
+      ]),
+    ).toEqual({
+      type: "AssignBlockerDamage",
+      data: {
+        assignments: [
+          [12, 1],
+          [78, 3],
+        ],
+      },
+    });
+  });
+});

--- a/src/sim/decisions/combatDamage.ts
+++ b/src/sim/decisions/combatDamage.ts
@@ -1,0 +1,149 @@
+// Assigning combat damage: an attacker splitting its damage among its
+// blockers (with optional trample spillover), or a blocker splitting its
+// damage among the attackers it blocks. The engine surfaces two
+// waiting_for shapes:
+// - `AssignCombatDamage` { player, attacker_id, total_damage,
+//   blockers: [{blocker_id, lethal_minimum}], trample: TrampleKind|null,
+//   defending_player, attack_target, pw_loyalty?, pw_controller? } — the
+//   attacker deals `total_damage`; each blocker needs `lethal_minimum` to
+//   die, and any leftover may spill over when `trample` is not null. The
+//   spillover goes to the attack target's controller when it is a
+//   planeswalker (`pw_loyalty`/`pw_controller` present), otherwise to the
+//   defending player. Answered with `AssignCombatDamage { assignments:
+//   [blocker_id, number][], trample_damage, controller_damage }` —
+//   `assignments` index-aligned to `blockers`, and
+//   sum(assignments) + trample_damage + controller_damage === total_damage.
+// - `AssignBlockerDamage` { player, blocker_id, total_damage,
+//   attackers: number[] } — a blocker splits its `total_damage` among the
+//   attackers it blocks. Answered with `AssignBlockerDamage { assignments:
+//   [attacker_id, number][] }` index-aligned to `attackers`, summing to
+//   `total_damage`.
+// Shapes confirmed against phase-rs v0.71.0 (issue #47).
+
+import type { GameState, WaitingFor } from "../../engine/types";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/** One blocker an attacker must assign lethal (or more) damage to. */
+export interface AttackerDamageBlocker {
+  id: number;
+  name: string;
+  lethalMinimum: number;
+}
+
+export interface AttackerDamagePrompt {
+  kind: "attacker";
+  player: number;
+  attackerName: string;
+  totalDamage: number;
+  blockers: AttackerDamageBlocker[];
+  hasTrample: boolean;
+  /** True when trample spillover goes to a planeswalker's controller rather than the defending player. */
+  tramplesToController: boolean;
+}
+
+/** One attacker a blocker must split its damage among. */
+export interface BlockerDamageAttacker {
+  id: number;
+  name: string;
+}
+
+export interface BlockerDamagePrompt {
+  kind: "blocker";
+  player: number;
+  blockerName: string;
+  totalDamage: number;
+  attackers: BlockerDamageAttacker[];
+}
+
+export type CombatDamagePrompt = AttackerDamagePrompt | BlockerDamagePrompt;
+
+function parseAssignCombatDamage(
+  d: any,
+  state?: GameState,
+): AttackerDamagePrompt | null {
+  const rawBlockers = Array.isArray(d.blockers) ? d.blockers : [];
+  const blockers = rawBlockers
+    .filter((b: any) => typeof b?.blocker_id === "number")
+    .map((b: any) => ({
+      id: b.blocker_id,
+      name: state?.objects?.[b.blocker_id]?.name ?? "",
+      lethalMinimum:
+        typeof b.lethal_minimum === "number" ? b.lethal_minimum : 0,
+    }));
+  if (blockers.length === 0) return null;
+  return {
+    kind: "attacker",
+    player: typeof d.player === "number" ? d.player : 0,
+    attackerName: state?.objects?.[d.attacker_id]?.name ?? "",
+    totalDamage: typeof d.total_damage === "number" ? d.total_damage : 0,
+    blockers,
+    hasTrample: d.trample != null,
+    tramplesToController: d.pw_loyalty != null || d.pw_controller != null,
+  };
+}
+
+function parseAssignBlockerDamage(
+  d: any,
+  state?: GameState,
+): BlockerDamagePrompt | null {
+  const rawAttackers = Array.isArray(d.attackers) ? d.attackers : [];
+  const attackers = rawAttackers
+    .filter((id: any) => typeof id === "number")
+    .map((id: number) => ({ id, name: state?.objects?.[id]?.name ?? "" }));
+  if (attackers.length === 0) return null;
+  return {
+    kind: "blocker",
+    player: typeof d.player === "number" ? d.player : 0,
+    blockerName: state?.objects?.[d.blocker_id]?.name ?? "",
+    totalDamage: typeof d.total_damage === "number" ? d.total_damage : 0,
+    attackers,
+  };
+}
+
+/** Read a combat-damage-assignment decision aimed at the human, or null. */
+export function parseCombatDamagePrompt(
+  wf: WaitingFor | undefined,
+  state?: GameState,
+): CombatDamagePrompt | null {
+  if (!wf) return null;
+  const d: any = wf.data ?? {};
+  switch (wf.type) {
+    case "AssignCombatDamage":
+      return parseAssignCombatDamage(d, state);
+    case "AssignBlockerDamage":
+      return parseAssignBlockerDamage(d, state);
+    default:
+      return null;
+  }
+}
+
+/** Submit an attacker's damage split among its blockers, plus any trample spillover. */
+export function assignCombatDamageAction(
+  assignments: [number, number][],
+  trampleDamage: number,
+  controllerDamage: number,
+): {
+  type: string;
+  data: {
+    assignments: [number, number][];
+    trample_damage: number;
+    controller_damage: number;
+  };
+} {
+  return {
+    type: "AssignCombatDamage",
+    data: {
+      assignments,
+      trample_damage: trampleDamage,
+      controller_damage: controllerDamage,
+    },
+  };
+}
+
+/** Submit a blocker's damage split among the attackers it blocks. */
+export function assignBlockerDamageAction(
+  assignments: [number, number][],
+): { type: string; data: { assignments: [number, number][] } } {
+  return { type: "AssignBlockerDamage", data: { assignments } };
+}

--- a/src/sim/driver.ts
+++ b/src/sim/driver.ts
@@ -77,6 +77,10 @@ import {
   parseCountersPrompt,
   type CountersPrompt,
 } from "./decisions/counters";
+import {
+  parseCombatDamagePrompt,
+  type CombatDamagePrompt,
+} from "./decisions/combatDamage";
 
 export interface MatchResult {
   matchIndex: number;
@@ -353,6 +357,11 @@ export interface DriverCallbacks {
   requestHumanCounters?: (
     env: GameStateEnvelope,
     prompt: CountersPrompt,
+  ) => Promise<HumanChoice>;
+  /** Called when the human assigns combat damage order/split among multiple blockers or attackers. */
+  requestHumanCombatDamage?: (
+    env: GameStateEnvelope,
+    prompt: CombatDamagePrompt,
   ) => Promise<HumanChoice>;
 }
 
@@ -725,6 +734,12 @@ export class MatchRunner {
           env,
           cb.requestHumanCounters,
           parseCountersPrompt(wf, state),
+        ),
+      () =>
+        humanRequest(
+          env,
+          cb.requestHumanCombatDamage,
+          parseCombatDamagePrompt(wf, state),
         ),
     ];
     for (const resolve of resolvers) {


### PR DESCRIPTION
## Summary

Lets the human player assign combat damage order/split among multiple blockers or attackers, instead of leaving it to the AI.

- `src/sim/decisions/combatDamage.ts` (+ `.test.ts`) — parses `AssignCombatDamage` (an attacker splitting `total_damage` among its blockers, each needing `lethal_minimum`, with optional trample spillover) and `AssignBlockerDamage` (a blocker splitting its damage among the attackers it blocks); action builders `assignCombatDamageAction` / `assignBlockerDamageAction`.
- `src/sim/driver.ts` — `requestHumanCombatDamage` callback wired into the resolver chain.
- `src/match/RunView.tsx` — `CombatDamagePanel` (`AttackerDamagePanel` / `BlockerDamagePanel`): per-blocker/attacker −/value/+ steppers, a live "tramples over" line for attackers with trample, an "assigned X / Y" readout otherwise, and a ghost "let AI decide" fallback.
- `src/i18n/messages.ts` — `combatDamage.*` keys (pt + en).
- `domainbook/domains/simulation/features/assign-combat-damage.md` + `changelog.md` (0.19.0) + `package.json` version bump.

## Judgment calls

- **Pathological init guard** (blockers' combined `lethal_minimum` exceeds `total_damage`): the panel seeds the initial split by greedily filling each blocker's minimum in order until `total_damage` runs out, leaving the rest at 0. Confirm's own gating (every pick ≥ that blocker's minimum) then naturally stays disabled in this case — the human can still adjust manually, or hand it to the AI.
- **Trample routing**: spillover is computed once as `total_damage − Σ(picks)` and always routed by `tramplesToController` (`controller_damage` for a planeswalker attack target, `trample_damage` for a defending player) — this is safe for the non-trample case too since Confirm there requires the sum to equal `total_damage`, making spillover 0 regardless of routing.

## Gates

```
npm run lint && npm run typecheck && npm run duplication && npm test && npm run build
```
All green (358 tests passed, duplication 1.23% total, no new clones flagged for the new files).

```
npx domainbook check --range main..HEAD   # 2 domains checked, nothing stale
npx domainbook validate                   # valid — 6 domains, 32 features, 17 decisions, 58 terms, 3 debt records
```

Closes #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)