### PR TITLE
ci: bump checkout/setup-node to v7 and adopt domainbook@v1 action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/domainbook.yml
+++ b/.github/workflows/domainbook.yml
@@ -8,13 +8,8 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-      - run: npm ci
       - name: Check the book keeps up with the change
-        run: npx domainbook check --range ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
+        uses: RafaelAugustScherer/domainbook@v1

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,8 +20,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 20
           cache: npm


### PR DESCRIPTION
## Why
The final #47 merge surfaced a CI annotation: `actions/checkout@v4` and `actions/setup-node@v4` target Node 20, which GitHub now force-runs on Node 24 with a deprecation warning (Node 20 actions are blocked from June 2026).

## What
- **`actions/checkout@v4 → @v7`** and **`actions/setup-node@v4 → @v7`** across `ci.yml`, `domainbook.yml`, and `pages.yml`. v7 is the current major for both and runs on Node 24 natively. (Picked v7 over the v5 first floated: v7 is the actual current major and matches the convention in the `domainbook` repo itself.)
- **`domainbook.yml`** now uses the composite **`RafaelAugustScherer/domainbook@v1`** action instead of the hand-rolled `setup-node` + `npm ci` + `npx domainbook check --range …` steps. The action derives the PR base/head range from the event and runs the CLI via `npx -y domainbook@latest`, so only `checkout` (with `fetch-depth: 0`) is needed before it.

`node-version: 20` for the build/test job is unchanged — that's the app's target runtime, separate from the actions' own runner.

Out of scope (not bumped): `configure-pages@v5`, `upload-pages-artifact@v3`, `deploy-pages@v4` in `pages.yml` — only `checkout`/`setup-node` were flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)